### PR TITLE
Fix boottime failures on non root K8s environment

### DIFF
--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -49,22 +49,15 @@ RUN npm config set prefix "${HOME}/.npm-global" && \
     yarn ${YARN_FLAGS} global add yo generator-code vsce @theia/generator-plugin@0.0.1-1562578105 file:${HOME}/eclipse-che-theia-generator && \
     rm -rf ${HOME}/eclipse-che-theia-generator && \
     # Generate .passwd.template \
-    cat /etc/passwd | \
-    sed s#root:x.*#theia-dev:x:\${USER_ID}:\${GROUP_ID}::${HOME}:/bin/bash#g \
-    > ${HOME}/.passwd.template && \
-    # Generate .group.template \
-    cat /etc/group | \
-    sed s#root:x:0:#root:x:0:0,\${USER_ID}:#g \
-    > ${HOME}/.group.template && \
+    sed -e "s#^theia-dev:x.*#theia-dev:x:\${USER_ID}:\${GROUP_ID}::${HOME}:/bin/bash#g" \
+        /etc/passwd > /.passwd.template && \
+    sed -e 's#^theia-dev:.*#theia-dev:x:${GROUP_ID}:#g' \
+        /etc/group > /.group.template && \
     mkdir /projects && \
-    # Define default prompt
-    echo "export PS1='\[\033[01;33m\](\u@container)\[\033[01;36m\] (\w) \$ \[\033[00m\]'" > ${HOME}/.bashrc  && \
-    # Disable the statistics for yeoman
-    mkdir -p ${HOME}/.config/insight-nodejs/ && \
-    echo '{"optOut": true}' > ${HOME}/.config/insight-nodejs/insight-yo.json && \
     # Change permissions to let any arbitrary user
-    for f in "${HOME}" "/etc/passwd" "/etc/group" "/projects"; do \
-        echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
+    for f in "${HOME}" /projects /etc/passwd /etc/group; do \
+        echo "Changing permissions on ${f}" && \
+        chgrp -R 0 ${f} && \
         chmod -R g+rwX ${f}; \
     done
 

--- a/dockerfiles/theia-dev/e2e/Dockerfile
+++ b/dockerfiles/theia-dev/e2e/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright (c) 2018-2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+
+# Use upstream image
+FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia-dev:${BUILD_TAG}
+
+# Export GITHUB_TOKEN into environment variable
+ARG GITHUB_TOKEN=''
+ENV GITHUB_TOKEN=$GITHUB_TOKEN
+
+# Just try to build the latest theia with current image
+RUN git clone -b 'master' --single-branch --depth 1 https://github.com/eclipse-theia/theia theia
+
+# setup extra step
+#{INCLUDE:docker/${BUILD_IMAGE_TARGET}/post-clone.dockerfile}
+
+# Unset GITHUB_TOKEN environment variable if it is empty.
+# This is needed for some tools which use this variable and will fail with 401 Unauthorized error if it is invalid.
+# For example, vscode ripgrep downloading is an example of such case.
+RUN if [ -z $GITHUB_TOKEN ]; then unset GITHUB_TOKEN; fi && \
+    cd theia && yarn
+
+ADD src/test-entrypoint.sh /test-entrypoint.sh
+
+CMD ["/test-entrypoint.sh"]

--- a/dockerfiles/theia-dev/e2e/src/test-entrypoint.sh
+++ b/dockerfiles/theia-dev/e2e/src/test-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+. /entrypoint.sh
+
+cd /projects
+
+# Just try to build the latest theia with current image
+git clone -b 'master' --single-branch --depth 1 https://github.com/theia-ide/theia theia
+cd theia && yarn

--- a/dockerfiles/theia-dev/e2e/test.sh
+++ b/dockerfiles/theia-dev/e2e/test.sh
@@ -9,7 +9,7 @@
 base_dir=$(cd "$(dirname "$0")"; pwd)
 . "${base_dir}/../../build.include"
 
-init --name:theia-e2e "$@"
+init --name:theia-builder-e2e "$@"
 
 DOCKER_RUN_OPTIONS=""
 # run bats with terminal mode (pretty print) if supported by current shell
@@ -19,14 +19,10 @@ fi
 
 # Runs E2E tests in a docker container.
 run_test_in_docker_container() {
-  mkdir -p ${base_dir}/$1
   docker_exec run --rm ${DOCKER_RUN_OPTIONS} \
-       --user $1 \
-       -v "${base_dir}/$1/videos":/projects/cypress/videos \
-       -v "${base_dir}/$1/logs":/projects/logs \
-       -v /var/run/docker.sock:/var/run/docker.sock \
+        --user $1 --group-add 0 \
            $IMAGE_NAME
 }
 
-run_test_in_docker_container '0:0'
-run_test_in_docker_container '1234:5678'
+run_test_in_docker_container 0:0
+run_test_in_docker_container 1234:5678

--- a/dockerfiles/theia-dev/src/entrypoint.sh
+++ b/dockerfiles/theia-dev/src/entrypoint.sh
@@ -17,13 +17,31 @@ if ! grep -Fq "${USER_ID}" /etc/passwd; then
     # current user is an arbitrary
     # user (its uid is not in the
     # container /etc/passwd). Let's fix that
-    cat ${HOME}/.passwd.template | \
-    sed "s/\${USER_ID}/${USER_ID}/g" | \
-    sed "s/\${GROUP_ID}/${GROUP_ID}/g" > /etc/passwd
+    sed \
+	-e "s/\${USER_ID}/${USER_ID}/g" \
+        -e "s/\${GROUP_ID}/${GROUP_ID}/g" \
+        -e "s/\${HOME}/\/home\/theia/g" \
+        /.passwd.template > /etc/passwd
+    sed \
+        -e "s/\${GROUP_ID}/${GROUP_ID}/g" \
+        /.group.template > /etc/group
 
-    cat ${HOME}/.group.template | \
-    sed "s/\${USER_ID}/${USER_ID}/g" | \
-    sed "s/\${GROUP_ID}/${GROUP_ID}/g" > /etc/group
+    # now the user `theia-dev` (that have uid:gid == $USER_ID,$GROUPID) can use `sudo`.
 fi
+
+# Grant access to projects volume in case of non root user with sudo rights
+if [ "$USER_ID" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /dev/null 2>&1; then
+    sudo chmod 644 /etc/passwd /etc/group
+    sudo chown root:root /etc/passwd /etc/group
+
+    sudo chown ${USER_ID}:${GROUP_ID} /projects ${HOME}
+fi
+
+# Define default prompt
+echo "export PS1='\[\033[01;33m\](\u@container)\[\033[01;36m\] (\w) \$ \[\033[00m\]'" > ${HOME}/.bashrc
+
+# Disable the statistics for yeoman
+mkdir -p ${HOME}/.config/insight-nodejs/
+echo '{"optOut": true}' > ${HOME}/.config/insight-nodejs/insight-yo.json
 
 exec "$@"

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -160,8 +160,8 @@ COPY --from=build-result /che-theia-build/plugins /default-theia-plugins
            sudo chgrp -R 0 ${f} && \
            sudo chmod -R g+rwX ${f}; \
        done \
-    && cat /etc/passwd | sed s#root:x.*#root:x:\${USER_ID}:\${GROUP_ID}::\${HOME}:/bin/bash#g > ${HOME}/passwd.template \
-    && cat /etc/group | sed s#root:x:0:#root:x:0:0,\${USER_ID}:#g > ${HOME}/group.template \
+    && cat /etc/passwd | sed s#root:x.*#root:x:\${USER_ID}:\${GROUP_ID}::\${HOME}:/bin/bash#g > /.passwd.template \
+    && cat /etc/group | sed s#root:x:0:#root:x:0:0,\${USER_ID}:#g > /.group.template \
     # Add yeoman, theia plugin & VS Code generator and typescript (to have tsc/typescript working)
     && yarn global add ${YARN_FLAGS} yo @theia/generator-plugin@0.0.1-1562578105 generator-code typescript@3.5.3 \
     && mkdir -p ${HOME}/.config/insight-nodejs/ \
@@ -178,9 +178,13 @@ COPY --from=build-result /che-theia-build/plugins /default-theia-plugins
     && yarn cache clean \
     #ENDIF
     # Change permissions to allow editing of files for openshift user
-    && find ${HOME} -exec sh -c "chgrp 0 {}; chmod g+rwX {}" \;
+    && for f in "${HOME}" /etc/passwd /etc/group /node_modules /default-theia-plugins /projects; do\
+           sudo chgrp -R 0 ${f} && \
+           sudo chmod -R g+rwX ${f}; \
+       done
 
-COPY --chown=theia:root --from=build-result /che-theia-build /home/theia
+COPY --chown=theia:root --from=builder /home/theia-dev/theia-source-code/production /home/theia
+
 USER theia
 WORKDIR /projects
 COPY src/entrypoint.sh /entrypoint.sh

--- a/dockerfiles/theia/e2e/Dockerfile
+++ b/dockerfiles/theia/e2e/Dockerfile
@@ -10,7 +10,6 @@ FROM ${BUILD_ORGANIZATION}/${BUILD_PARENT_IMAGE}:${BUILD_TAG} as theia
 FROM cypress/browsers:node10.16.3-chrome80-ff73
 
 USER root
-ENV HOME=/root
 ENV NOCDN=true
 
 RUN apt-get update && \
@@ -19,12 +18,15 @@ CMD /root/docker-run.sh
 RUN yarn global add typescript@3.5.3 node-gyp && node-gyp install
 
 # Add cypress scripts and grab dependencies
-COPY src /root/
-RUN cd /root && yarn
+COPY src /projects/
+RUN cd /projects && yarn
 
 # Add tests
-ADD cypress /root/cypress/
+ADD cypress /projects/cypress/
 
 COPY --from=theia /home/theia /home/theia
 COPY --from=theia /entrypoint.sh /entrypoint.sh
 RUN find /home/theia/ -name "binding.gyp" |  xargs -i sh -c 'cd $(dirname {}) && node-gyp rebuild'
+
+USER theia
+CMD /projects/docker-run.sh

--- a/dockerfiles/theia/e2e/src/docker-run.sh
+++ b/dockerfiles/theia/e2e/src/docker-run.sh
@@ -10,12 +10,12 @@
 : "${WAIT_COUNT:=30}"
 
 echo "Starting Theia..."
-rm -rf /root/logs/*
-HOME=/home/theia /entrypoint.sh > /root/logs/theia.log 2>/root/logs/theia-error.log&
+rm -rf /projects/logs/*
+HOME=/home/theia /entrypoint.sh > /projects/logs/theia.log 2>/projects/logs/theia-error.log&
 
 echo "Cleaning videos folder..."
 # Cleanup previous videos
-rm -rf /root/cypress/videos/*
+rm -rf /projects/cypress/videos/*
 
 # Find TCP 0.0.0.0:3100 that will be opened by Theia.
 sleep 5s
@@ -35,4 +35,4 @@ fi
 
 # Run tests
 echo "Run the tests"
-cd /root && unset LD_LIBRARY_PATH && /root/node_modules/.bin/cypress run -c trashAssetsBeforeRuns=false  --browser chrome
+cd /projects && unset LD_LIBRARY_PATH && /projects/node_modules/.bin/cypress run -c trashAssetsBeforeRuns=false  --browser chrome


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

* Fixes boottime failures on non root K8s environment.
* Enables to use `sudo` on the vanilla and some K8s based environment.

### What issues does this PR fix or reference?

* related on #284 #292
