### PR TITLE
Replace WorkspaceService by DevfileService

### DIFF
--- a/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
+++ b/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
@@ -14,8 +14,8 @@ import * as path from 'path';
 import { inject, injectable } from 'inversify';
 
 import { DefaultWorkspaceServer } from '@theia/workspace/lib/node/default-workspace-server';
+import { DevfileService } from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
 import { FileUri } from '@theia/core/lib/node';
-import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
 
 interface TheiaWorkspace {
   folders: TheiaWorkspacePath[];
@@ -27,14 +27,14 @@ interface TheiaWorkspacePath {
 
 @injectable()
 export class CheWorkspaceServer extends DefaultWorkspaceServer {
-  @inject(WorkspaceService)
-  protected workspaceService: WorkspaceService;
+  @inject(DevfileService)
+  protected devfileService: DevfileService;
 
   // override any workspace that could have been defined through CLI and use entries from the devfile
   // if not possible, use default method
   protected async getRoot(): Promise<string | undefined> {
-    const workspace = await this.workspaceService.currentWorkspace();
-    if (workspace.devfile?.attributes?.multiRoot === 'off') {
+    const devfile = await this.devfileService.get();
+    if (devfile?.metadata?.attributes?.multiRoot === 'off') {
       return super.getRoot();
     }
 


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Replace `WorkspaceService` by `DevfileService` to have multi-root related logic working for `DevWorkspace` engine.
Also please see the comments
-  https://github.com/eclipse-che/che-theia/pull/1053#discussion_r602186469
- https://github.com/eclipse-che/che-theia/pull/1055#issuecomment-808462041

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Related to:
- https://github.com/eclipse/che/issues/19191 
- https://github.com/eclipse/che/issues/19389


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

devfile_V2 use case  -`DevWorkspace`: a workspace should start in `Multi-root` mode by default.

devfile_V1 use case:
1. Start a workspace and check that the workspace has started in `Multi-root` mode by default.
2. Add the following to your devfile:
```
attributes:
  multiRoot: 'off'

 ```
3. Start the workspace and check that the `Multi-root` mode is off.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
