### PR TITLE
feat(docker): Provide a new vsix-installer image for devfile v2 plug-ins handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
         echo "{\"text\":\":no_entry_sign: Che Theia ${{ github.event.inputs.version }} release has failed: https://github.com/eclipse-che/che-theia/actions/workflows/release.yml\"}" > mattermost.json
     - name: Create success MM message
       run: |
-        echo "{\"text\":\":white_check_mark: Che Theia ${{ github.event.inputs.version }} has been released: https://quay.io/eclipse/che-theia-dev:${{ github.event.inputs.version }} https://quay.io/eclipse/che-theia:${{ github.event.inputs.version }} https://quay.io/eclipse/che-theia-endpoint-runtime-binary:${{ github.event.inputs.version }}\"}" > mattermost.json
+        echo "{\"text\":\":white_check_mark: Che Theia ${{ github.event.inputs.version }} has been released: https://quay.io/eclipse/che-theia-dev:${{ github.event.inputs.version }} https://quay.io/eclipse/che-theia:${{ github.event.inputs.version }} https://quay.io/eclipse/che-theia-endpoint-runtime-binary:${{ github.event.inputs.version }} https://quay.io/eclipse/che-theia-vsix-installer:${{ github.event.inputs.version }}\"}" > mattermost.json
     - name: Send MM message
       if: ${{ success() }} || ${{ failure() }}
       uses: mattermost/action-mattermost-notify@1.0.2

--- a/build.include
+++ b/build.include
@@ -61,12 +61,14 @@ DOCKER_FILES_LOCATIONS=(
   dockerfiles/theia-dev
   dockerfiles/theia
   dockerfiles/theia-endpoint-runtime-binary
+  dockerfiles/theia-vsix-installer
 )
 
 PUBLISH_IMAGES_LIST=(
   eclipse/che-theia-dev
   eclipse/che-theia
   eclipse/che-theia-endpoint-runtime-binary
+  eclipse/che-theia-vsix-installer
 )
 
 getImages() {

--- a/dockerfiles/theia-vsix-installer/Dockerfile
+++ b/dockerfiles/theia-vsix-installer/Dockerfile
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+#{INCLUDE:docker/${BUILD_IMAGE_TARGET}/from.dockerfile}
+#{INCLUDE:docker/${BUILD_IMAGE_TARGET}/setup.dockerfile}
+
+COPY src/entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dockerfiles/theia-vsix-installer/build.sh
+++ b/dockerfiles/theia-vsix-installer/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/../build.include
+
+init --name:theia-vsix-installer "$@"
+build

--- a/dockerfiles/theia-vsix-installer/docker/alpine/from.dockerfile
+++ b/dockerfiles/theia-vsix-installer/docker/alpine/from.dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.13.4 as runtime

--- a/dockerfiles/theia-vsix-installer/docker/alpine/setup.dockerfile
+++ b/dockerfiles/theia-vsix-installer/docker/alpine/setup.dockerfile
@@ -1,0 +1,1 @@
+RUN apk add --update --no-cache curl bash

--- a/dockerfiles/theia-vsix-installer/docker/ubi8/from.dockerfile
+++ b/dockerfiles/theia-vsix-installer/docker/ubi8/from.dockerfile
@@ -1,0 +1,2 @@
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
+FROM registry.access.redhat.com/ubi8-minimal:8.3-291 as runtime

--- a/dockerfiles/theia-vsix-installer/docker/ubi8/setup.dockerfile
+++ b/dockerfiles/theia-vsix-installer/docker/ubi8/setup.dockerfile
@@ -1,0 +1,1 @@
+# curl already installed in ubi8

--- a/dockerfiles/theia-vsix-installer/src/entrypoint.sh
+++ b/dockerfiles/theia-vsix-installer/src/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+KUBE_API_ENDPOINT="https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${DEVWORKSPACE_NAMESPACE}/devworkspaces/${DEVWORKSPACE_NAME}"
+TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+WORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer ${TOKEN}" "$KUBE_API_ENDPOINT")
+IFS=$'\n'
+for container in $(echo "$WORKSPACE" | sed -e 's|[[,]\({"attributes":{"app.kubernetes.io\)|\n\1|g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do
+    dest=$(echo "$container" | sed 's|.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*|\1|' - )
+    urls=$(echo "$container" | sed 's|.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*|\1|' - )
+    mkdir -p "$dest"
+    unset IFS
+    for url in $(echo "$urls" | sed 's/[",]/ /g' - ); do
+        echo; echo "downloading $urls to $dest"
+        curl -L "$url" > "$dest/$(basename "$url")"
+    done
+done


### PR DESCRIPTION
### What does this PR do?
Provides basic vsix-installer for downloading vsix files for theia or sidecars.
Definition is coming from https://github.com/devfile/devworkspace-operator/blob/95cb199a135518aa9909c8868b1342b85c509523/samples/flattened_theia-nodejs.yaml#L101-L130

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18668

### How to test this PR?
1. Build the vsix-installer image and publish it on a OCI registry (or use `quay.io/fbenoit/che-theia-vsix-installer:20210402`)
2. In https://github.com/devfile/devworkspace-operator/blob/95cb199a135518aa9909c8868b1342b85c509523/samples/flattened_theia-nodejs.yaml#L101-L130
remove all args, and use image `quay.io/fbenoit/che-theia-vsix-installer:20210402` (or the one you built)
3. deploy this workspace: `kubectl apply -f flattened_theia-nodejs.yaml -n <your-favorite-namespace>`
4. Check that sidecar is booted and vsix files have been downloaded (plug-in should work)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next

Change-Id: Ib38d16147995aa527cf2454a18f0ce539bfb91f7
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
