### PR TITLE
Add tests for WorkspaceProjectsManager

### DIFF
--- a/plugins/workspace-plugin/__mocks__/@eclipse-che/plugin.ts
+++ b/plugins/workspace-plugin/__mocks__/@eclipse-che/plugin.ts
@@ -10,4 +10,5 @@
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const chePlugin: any = {};
+chePlugin.devfile = {};
 module.exports = chePlugin;

--- a/plugins/workspace-plugin/__mocks__/@theia/plugin.ts
+++ b/plugins/workspace-plugin/__mocks__/@theia/plugin.ts
@@ -10,5 +10,26 @@
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const theiaPlugin: any = {};
-theiaPlugin.window = {};
+theiaPlugin.OutputChannel = {};
+theiaPlugin.window = {
+  createOutputChannel: jest.fn(),
+  withProgress: jest.fn(),
+  showWarningMessage: jest.fn(),
+  showInformationMessage: jest.fn(),
+};
+
+export class EventEmitter {
+  constructor() {}
+  fire() {}
+}
+
+theiaPlugin.Disposable = {
+  create: jest.fn(),
+};
+
+theiaPlugin.ProgressLocation = {
+  Notification: 15,
+};
+
+theiaPlugin.EventEmitter = EventEmitter;
 module.exports = theiaPlugin;

--- a/plugins/workspace-plugin/src/workspace-projects-manager.ts
+++ b/plugins/workspace-plugin/src/workspace-projects-manager.ts
@@ -128,24 +128,6 @@ export class WorkspaceProjectsManager {
     await che.devfile.update(devfile);
   }
 
-  async selectProjectToCloneCommands(devfile: che.devfile.Devfile): Promise<TheiaImportCommand[]> {
-    const instance = this;
-
-    const projects = devfile.projects;
-    if (!projects) {
-      return [];
-    }
-
-    return projects
-      .filter(project => {
-        const projectPath = project.clonePath
-          ? path.join(instance.projectsRoot, project.clonePath)
-          : path.join(instance.projectsRoot, project.name);
-        return !fs.existsSync(projectPath);
-      })
-      .map(project => buildProjectImportCommand(project, instance.projectsRoot)!);
-  }
-
   async updateOrCreateProject(devfile: che.devfile.Devfile, projectFolderURI: string): Promise<void> {
     const projectUpstreamBranch: git.GitUpstreamBranch | undefined = await git.getUpstreamBranch(projectFolderURI);
     if (!projectUpstreamBranch || !projectUpstreamBranch.remoteURL) {

--- a/plugins/workspace-plugin/tests/workspace-projects-manager.spec.ts
+++ b/plugins/workspace-plugin/tests/workspace-projects-manager.spec.ts
@@ -1,0 +1,307 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as che from '@eclipse-che/plugin';
+import * as git from '../src/git';
+import * as projectsHelper from '../src/projects';
+import * as theia from '@theia/plugin';
+import * as theiaCommands from '../src/theia-commands';
+
+import { WorkspaceProjectsManager, handleWorkspaceProjects } from '../src/workspace-projects-manager';
+
+import { WorkspaceFolderUpdater } from '../src/workspace-folder-updater';
+
+jest.mock('../src/workspace-folder-updater');
+jest.mock('../src/projects');
+
+const PROJECTS_ROOT = '/projects';
+const firstProject: che.devfile.DevfileProject = {
+  name: 'che-theia',
+};
+const secondProject: che.devfile.DevfileProject = {
+  name: 'theia',
+};
+
+const context: theia.PluginContext = {
+  environmentVariableCollection: {
+    persistent: false,
+    append: jest.fn(),
+    clear: jest.fn(),
+    delete: jest.fn(),
+    forEach: jest.fn(),
+    get: jest.fn(),
+    prepend: jest.fn(),
+    replace: jest.fn(),
+  },
+  extensionPath: '',
+  globalState: {
+    get: jest.fn(),
+    update: jest.fn(),
+  },
+  globalStoragePath: '',
+  logPath: '',
+  storagePath: '',
+  subscriptions: [],
+  workspaceState: {
+    get: jest.fn(),
+    update: jest.fn(),
+  },
+  asAbsolutePath: jest.fn(),
+};
+
+const outputChannelMock = {
+  appendLine: jest.fn(),
+};
+
+const getDevfileMock = jest.fn();
+che.devfile.get = getDevfileMock;
+
+const updateDevfileMock = jest.fn();
+che.devfile.update = updateDevfileMock;
+
+const devfile_Without_Attributes = {
+  metadata: {},
+  projects: [firstProject],
+};
+
+const devfile_With_Two_Projects = {
+  metadata: {},
+  projects: [firstProject, secondProject],
+};
+
+const devfileWith_MultiRoot_On_Attribute = {
+  metadata: {
+    attributes: {
+      multiRoot: 'on',
+    },
+  },
+  projects: [firstProject],
+};
+
+const devfileWith_MultiRoot_Off_Attribute = {
+  metadata: {
+    attributes: {
+      multiRoot: 'off',
+    },
+  },
+  projects: [firstProject],
+};
+
+const fileSystemWatcherMock = {
+  onDidCreate: jest.fn(),
+  onDidChange: jest.fn(),
+  onDidDelete: jest.fn(),
+  dispose: jest.fn(),
+};
+const createFileSystemWatcherMock = jest.fn();
+createFileSystemWatcherMock.mockReturnValue(fileSystemWatcherMock);
+(theia.window.createOutputChannel as jest.Mock).mockReturnValue(outputChannelMock);
+const showInfoMessageMock = theia.window.showInformationMessage as jest.Mock;
+
+const workspace = { createFileSystemWatcher: createFileSystemWatcherMock };
+Object.assign(theia, { workspace });
+
+const buildProjectImportCommandMock = jest.fn();
+Object.assign(theiaCommands, { buildProjectImportCommand: buildProjectImportCommandMock });
+
+const theiaImportCommand: theiaCommands.TheiaImportCommand = new theiaCommands.TheiaGitCloneCommand(
+  firstProject,
+  PROJECTS_ROOT
+);
+const executeImportCommandMock = jest.fn();
+theiaImportCommand.execute = executeImportCommandMock;
+
+const updateOrCreateGitProjectInDevfileMock = projectsHelper.updateOrCreateGitProjectInDevfile as jest.Mock;
+const deleteProjectFromDevfileMock = projectsHelper.deleteProjectFromDevfile as jest.Mock;
+
+describe('Test Workspace Projects Manager', () => {
+  const workspaceProjectsManager: WorkspaceProjectsManager = new WorkspaceProjectsManager(context, PROJECTS_ROOT);
+
+  const workspaceFolderUpdaterInstance = (WorkspaceFolderUpdater as jest.Mock).mock.instances[0];
+  const addWorkspaceFolderMock = workspaceFolderUpdaterInstance.addWorkspaceFolder;
+
+  beforeEach(() => {
+    executeImportCommandMock.mockClear();
+    showInfoMessageMock.mockClear();
+    addWorkspaceFolderMock.mockClear();
+    getDevfileMock.mockClear();
+    updateDevfileMock.mockClear();
+    updateOrCreateGitProjectInDevfileMock.mockClear();
+    deleteProjectFromDevfileMock.mockClear();
+
+    buildProjectImportCommandMock.mockReturnValue(theiaImportCommand);
+    executeImportCommandMock.mockResolvedValue('');
+  });
+
+  test('Should create an instanse of the WorkspaceProjectsManager and run it', async () => {
+    handleWorkspaceProjects(context, PROJECTS_ROOT);
+
+    expect(getDevfileMock).toBeCalledTimes(1); // workspaceProjectsManager.run() is called
+  });
+
+  test('Should add workspace folder when there are no attributes - multi root mode is ON by default', async () => {
+    getDevfileMock.mockReturnValue(devfile_Without_Attributes);
+
+    await workspaceProjectsManager.run();
+
+    expect(addWorkspaceFolderMock).toBeCalledTimes(1);
+  });
+
+  test('Should add workspace folder when there is the `multiRoot` attribute with `on` value', async () => {
+    getDevfileMock.mockReturnValue(devfileWith_MultiRoot_On_Attribute);
+
+    await workspaceProjectsManager.run();
+
+    expect(addWorkspaceFolderMock).toBeCalledTimes(1);
+  });
+
+  test('Should NOT add workspace folder when there is the `multiRoot` attribute with `off` value', async () => {
+    getDevfileMock.mockReturnValue(devfileWith_MultiRoot_Off_Attribute);
+
+    await workspaceProjectsManager.run();
+
+    expect(addWorkspaceFolderMock).toBeCalledTimes(0);
+    expect(showInfoMessageMock).toBeCalledTimes(2);
+  });
+
+  test('Should clone the second project and add it as workspace folder when cloning of the first project was failed', async () => {
+    const failedImportCommand: theiaCommands.TheiaImportCommand = new theiaCommands.TheiaGitCloneCommand(
+      secondProject,
+      PROJECTS_ROOT
+    );
+
+    const executeFailedImportCommandMock = jest.fn();
+    executeFailedImportCommandMock.mockImplementation(() => {
+      throw new Error('some error happened at clone process execution');
+    });
+    failedImportCommand.execute = executeFailedImportCommandMock;
+
+    getDevfileMock.mockReturnValue(devfile_With_Two_Projects);
+    buildProjectImportCommandMock.mockReturnValueOnce(failedImportCommand);
+    buildProjectImportCommandMock.mockReturnValueOnce(theiaImportCommand);
+
+    await workspaceProjectsManager.run();
+
+    expect(addWorkspaceFolderMock).toBeCalledTimes(1); // there 2 projects for cloning, but only one was cloned successfully
+    expect(executeImportCommandMock).toBeCalledTimes(1);
+    expect(executeFailedImportCommandMock).toBeCalledTimes(1);
+    expect(showInfoMessageMock).toBeCalledTimes(2);
+  });
+
+  test('Should check steps of successful cloning process execution', async () => {
+    getDevfileMock.mockReturnValue(devfile_Without_Attributes);
+
+    await workspaceProjectsManager.run();
+
+    expect(addWorkspaceFolderMock).toBeCalledTimes(1);
+    expect(executeImportCommandMock).toBeCalledTimes(1);
+    expect(showInfoMessageMock).toBeCalledTimes(2);
+  });
+
+  test('Should clone two projects and add them as workspace folders', async () => {
+    const secondImportCommand: theiaCommands.TheiaImportCommand = new theiaCommands.TheiaGitCloneCommand(
+      secondProject,
+      PROJECTS_ROOT
+    );
+
+    const executeSecondImportCommandMock = jest.fn();
+    executeSecondImportCommandMock.mockResolvedValue('');
+    secondImportCommand.execute = executeSecondImportCommandMock;
+
+    getDevfileMock.mockReturnValue(devfile_With_Two_Projects);
+    buildProjectImportCommandMock.mockReturnValueOnce(secondImportCommand);
+    buildProjectImportCommandMock.mockReturnValueOnce(theiaImportCommand);
+
+    await workspaceProjectsManager.run();
+
+    expect(addWorkspaceFolderMock).toBeCalledTimes(2);
+    expect(executeImportCommandMock).toBeCalledTimes(1);
+    expect(executeSecondImportCommandMock).toBeCalledTimes(1);
+    expect(showInfoMessageMock).toBeCalledTimes(2);
+  });
+
+  test('Commands were NOT found for execution cloning process', async () => {
+    buildProjectImportCommandMock.mockReturnValue(undefined);
+    getDevfileMock.mockReturnValue(devfile_Without_Attributes);
+
+    await workspaceProjectsManager.run();
+
+    expect(addWorkspaceFolderMock).toBeCalledTimes(0);
+    expect(executeImportCommandMock).toBeCalledTimes(0);
+    expect(showInfoMessageMock).toBeCalledTimes(0);
+  });
+
+  test('Should create a git project in a Devfile', async () => {
+    getDevfileMock.mockReturnValue(devfile_Without_Attributes);
+
+    const getUpstreamBranchSpy = jest.spyOn(git, 'getUpstreamBranch');
+    getUpstreamBranchSpy.mockResolvedValueOnce({
+      branch: 'branch',
+      remote: 'remote',
+      remoteURL: 'someRemoteUrl',
+    });
+
+    await workspaceProjectsManager.updateOrCreateProjectInWorkspace('/projects/che-theia');
+
+    expect(updateOrCreateGitProjectInDevfileMock).toBeCalledTimes(1);
+  });
+
+  test('Should NOT create a project when given Uri is not defined', async () => {
+    await workspaceProjectsManager.updateOrCreateProjectInWorkspace('');
+
+    expect(getDevfileMock).toBeCalledTimes(0);
+    expect(updateDevfileMock).toBeCalledTimes(0);
+    expect(updateOrCreateGitProjectInDevfileMock).toBeCalledTimes(0);
+  });
+
+  test('Should NOT create a git project in a Devfile when `remoteURL` is not defined', async () => {
+    getDevfileMock.mockReturnValue(devfile_Without_Attributes);
+
+    const getUpstreamBranchSpy = jest.spyOn(git, 'getUpstreamBranch');
+    getUpstreamBranchSpy.mockResolvedValueOnce({
+      branch: 'branch',
+      remote: 'remote',
+      remoteURL: '', // not defined
+    });
+
+    await workspaceProjectsManager.updateOrCreateProjectInWorkspace('/projects/che-theia');
+
+    expect(updateOrCreateGitProjectInDevfileMock).toBeCalledTimes(0);
+  });
+
+  test('Should NOT create a git project in a Devfile when upstream branch is `undefined`', async () => {
+    getDevfileMock.mockReturnValue(devfile_Without_Attributes);
+
+    const getUpstreamBranchSpy = jest.spyOn(git, 'getUpstreamBranch');
+    getUpstreamBranchSpy.mockResolvedValueOnce(undefined);
+
+    await workspaceProjectsManager.updateOrCreateProjectInWorkspace('/projects/che-theia');
+
+    expect(updateOrCreateGitProjectInDevfileMock).toBeCalledTimes(0);
+  });
+
+  test('Should delete a project from Devfile', async () => {
+    getDevfileMock.mockReturnValue(devfile_Without_Attributes);
+
+    await workspaceProjectsManager.deleteProjectInWorkspace('/projects/che-theia');
+
+    expect(getDevfileMock).toBeCalledTimes(1);
+    expect(updateDevfileMock).toBeCalledTimes(1);
+    expect(deleteProjectFromDevfileMock).toBeCalledTimes(1);
+  });
+
+  test('Should NOT delete a project when given Uri is not defined', async () => {
+    await workspaceProjectsManager.deleteProjectInWorkspace('');
+
+    expect(getDevfileMock).toBeCalledTimes(0);
+    expect(updateDevfileMock).toBeCalledTimes(0);
+    expect(deleteProjectFromDevfileMock).toBeCalledTimes(0);
+  });
+});


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- Provide tests for `WorkspaceProjectsManager` logic.
- Remove unused method from `WorkspaceProjectsManager`

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
No issue.

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
The tests for `WorkspaceProjectsManager` should be happy.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
