### PR TITLE
feat(env-var): Allow to use both che-server env variables and DevWorkspace env variables

### DIFF
--- a/dockerfiles/theia/src/entrypoint.sh
+++ b/dockerfiles/theia/src/entrypoint.sh
@@ -81,7 +81,8 @@ fi
 shopt -u nocasematch
 
 # run Che-Theia
-PROJ_ROOT=${CHE_PROJECTS_ROOT:-/projects}
+PROJ_ROOT=${PROJECTS_ROOT:-}
+[[ -z "$PROJ_ROOT" ]] && PROJ_ROOT=${CHE_PROJECTS_ROOT:-/projects}
 node src-gen/backend/main.js ${PROJ_ROOT} --hostname=${THEIA_HOST} --port=${THEIA_PORT} &
 
 PID=$!

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-task-terminal-widget-manager.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-task-terminal-widget-manager.ts
@@ -38,7 +38,7 @@ export namespace RemoteTerminalOptions {
       return false;
     }
 
-    const containerName = attributes['CHE_MACHINE_NAME'];
+    const containerName = attributes['TERMINAL_COMPONENT_NAME'];
     if (containerName) {
       return true;
     }

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/task-config-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/task-config-service.ts
@@ -102,7 +102,7 @@ export class TaskConfigurationsService extends TaskService {
         remote: isRemote ? 'true' : 'false',
         closeWidgetExitOrError: 'false',
         interruptProcessOnClose: 'true',
-        CHE_MACHINE_NAME: isRemote ? this.getContainerName(config) || '' : '',
+        TERMINAL_COMPONENT_NAME: isRemote ? this.getContainerName(config) || '' : '',
       },
     };
   }

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-sidecar-content-reader.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-sidecar-content-reader.ts
@@ -18,9 +18,9 @@ import { URI } from 'vscode-uri';
 export class CheSideCarContentReaderImpl implements CheSideCarContentReader {
   constructor(rpc: RPCProtocol) {
     const delegate = rpc.getProxy(PLUGIN_RPC_CONTEXT.CHE_SIDERCAR_CONTENT_READER_MAIN);
-    const machineName = process.env.CHE_MACHINE_NAME;
-    if (machineName) {
-      delegate.$registerContentReader(`file-sidecar-${machineName}`);
+    const componentName = process.env.DEVWORKSPACE_COMPONENT_NAME || process.env.CHE_MACHINE_NAME;
+    if (componentName) {
+      delegate.$registerContentReader(`file-sidecar-${componentName}`);
     }
   }
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-sidecar-file-system.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-sidecar-file-system.ts
@@ -72,9 +72,9 @@ export class CheSideCarFileSystemImpl implements CheSideCarFileSystem {
 
   constructor(rpc: RPCProtocol) {
     const delegate = rpc.getProxy(PLUGIN_RPC_CONTEXT.CHE_SIDECAR_FILE_SYSTEM_MAIN);
-    const machineName = process.env.CHE_MACHINE_NAME;
-    if (machineName) {
-      delegate.$registerFileSystemProvider(`file-sidecar-${machineName}`);
+    const componentName = process.env.DEVWORKSPACE_COMPONENT_NAME || process.env.CHE_MACHINE_NAME;
+    if (componentName) {
+      delegate.$registerFileSystemProvider(`file-sidecar-${componentName}`);
     }
   }
 

--- a/extensions/eclipse-che-theia-plugin-ext/tests/plugin/che-sidecar-file-system.spec.node.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/tests/plugin/che-sidecar-file-system.spec.node.ts
@@ -25,8 +25,8 @@ describe('Test CheSideCarFileSystemImpl', () => {
   let workspace: string;
 
   beforeAll(() => {
-    const machineName = 'test';
-    process.env.CHE_MACHINE_NAME = machineName;
+    const componentName = 'test';
+    process.env.DEVWORKSPACE_COMPONENT_NAME = componentName;
 
     const registerFileSystemMock = jest.fn();
 
@@ -39,7 +39,7 @@ describe('Test CheSideCarFileSystemImpl', () => {
     fs = new CheSideCarFileSystemImpl(rpcProtocol);
 
     expect(registerFileSystemMock).toHaveBeenCalledTimes(1);
-    expect(registerFileSystemMock).toHaveBeenCalledWith(`file-sidecar-${machineName}`);
+    expect(registerFileSystemMock).toHaveBeenCalledWith(`file-sidecar-${componentName}`);
   });
 
   afterAll(() => {
@@ -432,5 +432,29 @@ describe('Test CheSideCarFileSystemImpl', () => {
     await expect(fs.$readdir(nonExistentSourceFolder)).rejects.toThrow(
       `Error: ENOENT: no such file or directory, scandir '${nonExistentSourceFolder}'`
     );
+  });
+});
+
+describe('Test CheSideCarFileSystemImpl with che server', () => {
+  beforeAll(() => {
+    const componentName = 'test';
+    process.env.MACHINE_NAME = componentName;
+
+    const registerFileSystemMock = jest.fn();
+
+    jest.doMock('@theia/plugin-ext/lib/common/rpc-protocol', () => ({
+      getProxy: jest.fn(() => ({
+        $registerFileSystemProvider: registerFileSystemMock,
+      })),
+    }));
+    const rpcProtocol = require('@theia/plugin-ext/lib/common/rpc-protocol') as RPCProtocol;
+    new CheSideCarFileSystemImpl(rpcProtocol);
+
+    expect(registerFileSystemMock).toHaveBeenCalledTimes(1);
+    expect(registerFileSystemMock).toHaveBeenCalledWith(`file-sidecar-${componentName}`);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
   });
 });

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/che-content-aware-utils.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/che-content-aware-utils.ts
@@ -17,10 +17,12 @@ export function overrideUri(uri: {
   scheme: string;
   with: (change: { scheme?: string }) => URI | theia.Uri;
 }): URI {
-  const cheProjectsRoot = process.env.CHE_PROJECTS_ROOT;
-  const machineName = process.env.CHE_MACHINE_NAME;
-  if (uri.scheme === 'file' && machineName && cheProjectsRoot && !uri.path.startsWith(cheProjectsRoot)) {
-    return uri.with({ scheme: `file-sidecar-${machineName}` });
+  // If PROJECTS_ROOT is defined use it else switch to old CHE_PROJECTS_ROOT env name or use default
+  const projectsRoot = process.env.PROJECTS_ROOT || process.env.CHE_PROJECTS_ROOT || '/projects';
+  // If DEVWORKSPACE_COMPONENT_NAME is defined use it else switch to old CHE_MACHINE_NAME env name
+  const componentName = process.env.DEVWORKSPACE_COMPONENT_NAME || process.env.CHE_MACHINE_NAME;
+  if (uri.scheme === 'file' && componentName && projectsRoot && !uri.path.startsWith(projectsRoot)) {
+    return uri.with({ scheme: `file-sidecar-${componentName}` });
   } else {
     return uri.with({ scheme: uri.scheme });
   }

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-init.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-init.ts
@@ -288,7 +288,9 @@ to pick-up automatically a free port`)
     );
 
     let channelName = '';
-    if (process.env.CHE_MACHINE_NAME) {
+    if (process.env.DEVWORKSPACE_COMPONENT_NAME) {
+      channelName = `Extension host (${process.env.DEVWORKSPACE_COMPONENT_NAME}) log`;
+    } else if (process.env.CHE_MACHINE_NAME) {
       channelName = `Extension host (${process.env.CHE_MACHINE_NAME}) log`;
     } else {
       channelName = `Extension host (${this.pluginPort}) log`;

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote.ts
@@ -38,10 +38,11 @@ process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
     if (index >= 0) {
       promise.catch(err => {
         unhandledPromises.splice(index, 1);
-        const containerName = process.env['CHE_MACHINE_NAME'];
-        console.error(`Remote plugin in ${containerName}: promise rejection is not handled in two seconds: ${err}`);
+        // If DEVWORKSPACE_COMPONENT_NAME is defined use it else switch to che server CHE_MACHINE_NAME env name
+        const componentName = process.env.DEVWORKSPACE_COMPONENT_NAME || process.env.CHE_MACHINE_NAME;
+        console.error(`Remote plugin in ${componentName}: promise rejection is not handled in two seconds: ${err}`);
         if (err && err.stack) {
-          console.error(`Remote plugin in ${containerName}: promise rejection stack trace: ${err.stack}`);
+          console.error(`Remote plugin in ${componentName}: promise rejection stack trace: ${err.stack}`);
         }
       });
     }

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/webviews-content-aware.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/webviews-content-aware.ts
@@ -87,7 +87,9 @@ export class WebviewsContentAware {
         return this._html;
       }.bind(this),
       set: function (value: string) {
-        const sideCarScheme = `file-sidecar-${process.env.CHE_MACHINE_NAME}`;
+        // If DEVWORKSPACE_COMPONENT_NAME is defined use it else switch to che-server CHE_MACHINE_NAME env name
+        const componentName = process.env.DEVWORKSPACE_COMPONENT_NAME || process.env.CHE_MACHINE_NAME;
+        const sideCarScheme = `file-sidecar-${componentName}`;
         // @ts-ignore
         this._html = value.replace(
           /(["'])(vscode|theia)-resource:(\/\/([^\s\/'"]+?)(?=\/))?([^\s'"]+?)(["'])/gi,

--- a/extensions/eclipse-che-theia-remote-api/src/common/workspace-service.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/common/workspace-service.ts
@@ -67,4 +67,9 @@ export interface WorkspaceService {
   stop(): Promise<void>;
 
   getContainerList(): Promise<Container[]>;
+
+  /**
+   * Provides the root directory like /projects
+   */
+  getProjectsRootDirectory(): Promise<string>;
 }

--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-workspace-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-workspace-service-impl.ts
@@ -30,11 +30,21 @@ export class CheServerWorkspaceServiceImpl implements WorkspaceService {
    */
   private readonly workspaceId: string;
 
+  /**
+   * projectsRoot - Root directory for projects, default being /projects
+   */
+  private readonly projectsRoot: string;
+
   constructor() {
     if (process.env.CHE_WORKSPACE_ID === undefined) {
       console.error('Environment variable CHE_WORKSPACE_ID is not set');
     } else {
       this.workspaceId = process.env.CHE_WORKSPACE_ID;
+    }
+    if (process.env.CHE_PROJECTS_ROOT === undefined) {
+      console.error('Environment variable CHE_PROJECTS_ROOT is not set');
+    } else {
+      this.projectsRoot = process.env.CHE_PROJECTS_ROOT;
     }
   }
 
@@ -95,5 +105,12 @@ export class CheServerWorkspaceServiceImpl implements WorkspaceService {
     }
 
     return containers;
+  }
+
+  /**
+   * Provides the root directory like /projects
+   */
+  async getProjectsRootDirectory(): Promise<string> {
+    return this.projectsRoot;
   }
 }

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-devworkspace-env-variables.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-devworkspace-env-variables.ts
@@ -35,6 +35,11 @@ export class K8sDevWorkspaceEnvVariables {
    */
   private readonly devWorkspaceFlattenedDevfilePath: string;
 
+  /**
+   * projectsRoot - Root directory for projects, default being /projects
+   */
+  private readonly projectsRoot: string;
+
   constructor() {
     if (process.env.DEVWORKSPACE_ID === undefined) {
       console.error('Environment variable DEVWORKSPACE_ID is not set');
@@ -56,6 +61,11 @@ export class K8sDevWorkspaceEnvVariables {
     } else {
       this.devWorkspaceFlattenedDevfilePath = process.env.DEVWORKSPACE_FLATTENED_DEVFILE;
     }
+    if (process.env.PROJECTS_ROOT === undefined) {
+      console.error('Environment variable PROJECTS_ROOT is not set');
+    } else {
+      this.projectsRoot = process.env.PROJECTS_ROOT;
+    }
   }
 
   getWorkspaceId(): string {
@@ -72,5 +82,9 @@ export class K8sDevWorkspaceEnvVariables {
 
   getDevWorkspaceFlattenedDevfilePath(): string {
     return this.devWorkspaceFlattenedDevfilePath;
+  }
+
+  getProjectsRoot(): string {
+    return this.projectsRoot;
   }
 }

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-workspace-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-workspace-service-impl.ts
@@ -91,4 +91,11 @@ export class K8sWorkspaceServiceImpl implements WorkspaceService {
 
     return containers;
   }
+
+  /**
+   * Provides the root directory like /projects
+   */
+  async getProjectsRootDirectory(): Promise<string> {
+    return this.env.getProjectsRoot();
+  }
 }

--- a/extensions/eclipse-che-theia-terminal/src/browser/contribution/exec-terminal-contribution.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/contribution/exec-terminal-contribution.ts
@@ -239,7 +239,7 @@ export class ExecTerminalFrontendContribution extends TerminalFrontendContributi
         return super.newTerminal(options);
       }
 
-      containerName = attributes['CHE_MACHINE_NAME'];
+      containerName = attributes['TERMINAL_COMPONENT_NAME'];
 
       const closeWidgetOnExitOrErrorValue = attributes['closeWidgetExitOrError'];
       if (closeWidgetOnExitOrErrorValue) {

--- a/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
+++ b/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
@@ -16,6 +16,7 @@ import { inject, injectable } from 'inversify';
 import { DefaultWorkspaceServer } from '@theia/workspace/lib/node/default-workspace-server';
 import { DevfileService } from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
 import { FileUri } from '@theia/core/lib/node';
+import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
 
 interface TheiaWorkspace {
   folders: TheiaWorkspacePath[];
@@ -30,6 +31,9 @@ export class CheWorkspaceServer extends DefaultWorkspaceServer {
   @inject(DevfileService)
   protected devfileService: DevfileService;
 
+  @inject(WorkspaceService)
+  protected workspaceService: WorkspaceService;
+
   // override any workspace that could have been defined through CLI and use entries from the devfile
   // if not possible, use default method
   protected async getRoot(): Promise<string | undefined> {
@@ -38,8 +42,7 @@ export class CheWorkspaceServer extends DefaultWorkspaceServer {
       return super.getRoot();
     }
 
-    const projectsRootEnvVariable = process.env.CHE_PROJECTS_ROOT;
-    const projectsRoot = projectsRootEnvVariable ? projectsRootEnvVariable : '/projects';
+    const projectsRoot = await this.workspaceService.getProjectsRootDirectory();
 
     // first, check if we have a che.theia-workspace file
     const cheTheiaWorkspaceFile = path.resolve(projectsRoot, 'che.theia-workspace');

--- a/plugins/task-plugin/src/variable/project-path-variable-resolver.ts
+++ b/plugins/task-plugin/src/variable/project-path-variable-resolver.ts
@@ -19,7 +19,8 @@ const fs = require('fs');
 
 const VARIABLE_NAME = 'current.project.path';
 const SELECTED_CONTEXT_COMMAND = 'theia.plugin.workspace.selectedContext';
-const PROJECTS_ROOT_VARIABLE = 'CHE_PROJECTS_ROOT';
+const PROJECTS_ROOT_VARIABLE = 'PROJECTS_ROOT';
+const PROJECTS_ROOT_ALTERNATE_VARIABLE = 'CHE_PROJECTS_ROOT';
 const SELECT_PROJECT_MESSAGE =
   'Please select a project before executing a command to make it possible to resolve the current project path.';
 /**
@@ -30,12 +31,13 @@ export class ProjectPathVariableResolver {
   private projectsRoot: string;
 
   async registerVariables(): Promise<void> {
-    const projectsRoot = await theia.env.getEnvVariable(PROJECTS_ROOT_VARIABLE);
-    if (projectsRoot === undefined) {
-      return Promise.reject('Projects root is not provided');
+    const projectsRootEnvVar =
+      (await theia.env.getEnvVariable(PROJECTS_ROOT_VARIABLE)) ||
+      (await theia.env.getEnvVariable(PROJECTS_ROOT_ALTERNATE_VARIABLE));
+    if (!projectsRootEnvVar) {
+      throw new Error('Projects root is not provided');
     }
-
-    this.projectsRoot = projectsRoot;
+    this.projectsRoot = projectsRootEnvVar;
 
     const variableSubscription = await che.variables.registerVariable(this.createVariable());
     startPoint.getSubscriptions().push(variableSubscription);

--- a/plugins/workspace-plugin/src/workspace-plugin.ts
+++ b/plugins/workspace-plugin/src/workspace-plugin.ts
@@ -22,9 +22,15 @@ interface API {
 
 export async function start(context: theia.PluginContext): Promise<API> {
   let projectsRoot = '/projects';
-  const projectsRootEnvVar = await theia.env.getEnvVariable('CHE_PROJECTS_ROOT');
+  // If PROJECTS_ROOT is defined use it else switch to old env name
+  const projectsRootEnvVar = await theia.env.getEnvVariable('PROJECTS_ROOT');
   if (projectsRootEnvVar) {
     projectsRoot = projectsRootEnvVar;
+  } else {
+    const cheProjectsRootEnvVar = await theia.env.getEnvVariable('CHE_PROJECTS_ROOT');
+    if (cheProjectsRootEnvVar) {
+      projectsRoot = cheProjectsRootEnvVar;
+    }
   }
 
   new Devfile(context).init();


### PR DESCRIPTION
### What does this PR do?
DevWorkspace is dropping old CHE_* env variables
So CheTheia needs to work in both mode

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/devfile/devworkspace-operator/issues/344


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next

Change-Id: Ifb177150471a4f8a818b65e6eb413fcc61a3eae2
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
