### PR TITLE
Check path to be a file when reading certificates (#1072)

### DIFF
--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-certificate-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-certificate-service-impl.ts
@@ -31,8 +31,10 @@ export class CheServerCertificateServiceImpl implements CertificateService {
       const publicCertificates = await fs.readdir(PUBLIC_CRT_PATH);
       for (const publicCertificate of publicCertificates) {
         const certPath = path.join(PUBLIC_CRT_PATH, publicCertificate);
-        const content = await fs.readFile(certPath);
-        certificateAuthority.push(content);
+        if ((await fs.pathExists(certPath)) && (await fs.stat(certPath)).isFile()) {
+          const content = await fs.readFile(certPath);
+          certificateAuthority.push(content);
+        }
       }
     }
 

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-certificate-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-certificate-service-impl.ts
@@ -31,8 +31,10 @@ export class K8sCertificateServiceImpl implements CertificateService {
       const publicCertificates = await fs.readdir(PUBLIC_CRT_PATH);
       for (const publicCertificate of publicCertificates) {
         const certPath = path.join(PUBLIC_CRT_PATH, publicCertificate);
-        const content = await fs.readFile(certPath);
-        certificateAuthority.push(content);
+        if ((await fs.pathExists(certPath)) && (await fs.stat(certPath)).isFile()) {
+          const content = await fs.readFile(certPath);
+          certificateAuthority.push(content);
+        }
       }
     }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?

Fixes a bug when the plugins view shows an empty list.
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-1710

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Start a workspace
2. Open the Plugins view: View => Plugins
3. See: plugins list must be loaded.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
