### PR TITLE
Add tests related to backward compatibility for single-root workspaces

### DIFF
--- a/plugins/workspace-plugin/tests/workspace-projects-manager.spec.ts
+++ b/plugins/workspace-plugin/tests/workspace-projects-manager.spec.ts
@@ -9,6 +9,7 @@
  ***********************************************************************/
 
 import * as che from '@eclipse-che/plugin';
+import * as fs from 'fs';
 import * as git from '../src/git';
 import * as projectsHelper from '../src/projects';
 import * as theia from '@theia/plugin';
@@ -20,6 +21,7 @@ import { WorkspaceFolderUpdater } from '../src/workspace-folder-updater';
 
 jest.mock('../src/workspace-folder-updater');
 jest.mock('../src/projects');
+jest.mock('fs');
 
 const PROJECTS_ROOT = '/projects';
 const firstProject: che.devfile.DevfileProject = {
@@ -28,6 +30,9 @@ const firstProject: che.devfile.DevfileProject = {
 const secondProject: che.devfile.DevfileProject = {
   name: 'theia',
 };
+
+const existsSyncMock = jest.fn();
+Object.assign(fs, { existsSync: existsSyncMock });
 
 const uri: theia.Uri = {
   authority: '',
@@ -317,5 +322,26 @@ describe('Test Workspace Projects Manager', () => {
     expect(getDevfileMock).toBeCalledTimes(0);
     expect(updateDevfileMock).toBeCalledTimes(0);
     expect(deleteProjectFromDevfileMock).toBeCalledTimes(0);
+  });
+
+  // Backward compatibility for single-root workspaces
+  // we need it to support workspaces which were created before switching multi-root mode to ON by default
+  test('Should add projects as workspace folders when projects already exist on file system', async () => {
+    getDevfileMock.mockReturnValue(devfile_With_Two_Projects);
+    existsSyncMock.mockReturnValue(true);
+
+    await workspaceProjectsManager.run();
+
+    expect(addWorkspaceFolderMock).toBeCalledTimes(2);
+  });
+
+  test('Should not add projects as workspace folders: cloning failed and projects do not exist on file system', async () => {
+    getDevfileMock.mockReturnValue(devfile_With_Two_Projects);
+    existsSyncMock.mockReturnValue(false);
+    executeImportCommandMock.mockReset();
+
+    await workspaceProjectsManager.run();
+
+    expect(addWorkspaceFolderMock).toBeCalledTimes(0);
   });
 });


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Add tests related to backward compatibility for single-root workspaces

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
related to https://github.com/eclipse/che/issues/19551

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
the tests should pass successfully

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next
