### PR TITLE
Auto detect projects in multiroot workspace

### DIFF
--- a/build.include
+++ b/build.include
@@ -58,17 +58,17 @@ is_publish_images() {
 
 # KEEP RIGHT ORDER!!!
 DOCKER_FILES_LOCATIONS=(
-  dockerfiles/theia-dev
+  # dockerfiles/theia-dev
   dockerfiles/theia
-  dockerfiles/theia-endpoint-runtime-binary
-  dockerfiles/theia-vsix-installer
+  # dockerfiles/theia-endpoint-runtime-binary
+  # dockerfiles/theia-vsix-installer
 )
 
 PUBLISH_IMAGES_LIST=(
-  eclipse/che-theia-dev
+  # eclipse/che-theia-dev
   eclipse/che-theia
-  eclipse/che-theia-endpoint-runtime-binary
-  eclipse/che-theia-vsix-installer
+  # eclipse/che-theia-endpoint-runtime-binary
+  # eclipse/che-theia-vsix-installer
 )
 
 getImages() {

--- a/che-theia-init-sources.yml
+++ b/che-theia-init-sources.yml
@@ -24,12 +24,12 @@ sources:
   plugins:
     - plugins/containers-plugin
     - plugins/ext-plugin
-    - plugins/workspace-plugin
+    # - plugins/workspace-plugin
     - plugins/resource-monitor-plugin
     - plugins/ports-plugin
     - plugins/task-plugin
     - plugins/welcome-plugin
-    - plugins/ssh-plugin
+    # - plugins/ssh-plugin
     - plugins/telemetry-plugin
     - plugins/github-auth-plugin
     - plugins/recommendations-plugin

--- a/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
+++ b/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
@@ -43,14 +43,14 @@ export class CheWorkspaceServer extends DefaultWorkspaceServer {
 
     // first, check if we have a che.theia-workspace file
     const cheTheiaWorkspaceFile = path.resolve(projectsRoot, 'che.theia-workspace');
-    const cheTheiaWorkspaceFileUri = FileUri.create(cheTheiaWorkspaceFile);
-    const exists = await fs.pathExists(cheTheiaWorkspaceFile);
-    if (!exists) {
+
+    const workspaceFileExists = await fs.pathExists(cheTheiaWorkspaceFile);
+    if (!workspaceFileExists) {
       // no, then create the file
       const theiaWorkspace: TheiaWorkspace = { folders: [] };
       await fs.writeFile(cheTheiaWorkspaceFile, JSON.stringify(theiaWorkspace), { encoding: 'utf8' });
     }
 
-    return cheTheiaWorkspaceFileUri.toString();
+    return FileUri.create(cheTheiaWorkspaceFile).toString();
   }
 }

--- a/plugins/workspace-plugin/src/ca-cert.ts
+++ b/plugins/workspace-plugin/src/ca-cert.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/plugins/workspace-plugin/src/create-workspace-command.ts
+++ b/plugins/workspace-plugin/src/create-workspace-command.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,7 @@ const CREATE_WORKSPACE_COMMAND = {
   tooltip: 'Create workspace from this DevFile',
 };
 
-export class Devfile {
+export class CreateWorkspaceCommand {
   constructor(private context: theia.PluginContext) {}
 
   init(): void {

--- a/plugins/workspace-plugin/src/exec.ts
+++ b/plugins/workspace-plugin/src/exec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/plugins/workspace-plugin/src/file-uri.ts
+++ b/plugins/workspace-plugin/src/file-uri.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2018-2020 Red Hat, Inc.
+ * Copyright (c) 2018-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,28 +10,6 @@
 
 import * as path from 'path';
 
-export function convertToFileURI(file: string, rootFolder?: string): string {
-  if (file.startsWith('file://')) {
-    return file;
-  }
-  if (!rootFolder) {
-    rootFolder = '/projects';
-  }
-  if (rootFolder.endsWith('/')) {
-    rootFolder = rootFolder.substring(0, rootFolder.length - 1);
-  }
-  if (!file.startsWith('/')) {
-    file = `/${file}`;
-  }
-  if (rootFolder.startsWith('file://')) {
-    return rootFolder + file;
-  }
-  if (!rootFolder.startsWith('/')) {
-    rootFolder = `/${rootFolder}`;
-  }
-  return `file://${rootFolder}${file}`;
-}
-
 /**
  * Returns path of the given project according projects directory.
  * Given project should be in subtree of root projects directory.
@@ -40,9 +18,5 @@ export function convertToFileURI(file: string, rootFolder?: string): string {
  * @param rootFolder root folder for all projects in workspace
  */
 export function convertToCheProjectPath(fileURI: string, rootFolder: string): string {
-  if (!rootFolder) {
-    // default value
-    rootFolder = '/projects';
-  }
   return path.relative(rootFolder, fileURI);
 }

--- a/plugins/workspace-plugin/src/theia-commands.ts
+++ b/plugins/workspace-plugin/src/theia-commands.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2018-2020 Red Hat, Inc.
+ * Copyright (c) 2018-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -9,7 +9,6 @@
  ***********************************************************************/
 
 import * as che from '@eclipse-che/plugin';
-import * as fileuri from './file-uri';
 import * as fs from 'fs-extra';
 import * as git from './git';
 import * as os from 'os';
@@ -17,19 +16,8 @@ import * as path from 'path';
 import * as ssh from './ssh';
 import * as theia from '@theia/plugin';
 
-import { TaskScope } from '@eclipse-che/plugin';
 import { execute } from './exec';
 import { getCertificate } from './ca-cert';
-
-const CHE_TASK_TYPE = 'che';
-
-/**
- * Enumeration ID's of ide actions.
- */
-export enum ActionId {
-  OPEN_FILE = 'openFile',
-  RUN_COMMAND = 'runCommand',
-}
 
 export interface TheiaImportCommand {
   /** @returns the path to the imported project */
@@ -324,50 +312,5 @@ export class TheiaImportZipCommand implements TheiaImportCommand {
       },
       (progress, token) => importZip(progress, token)
     );
-  }
-}
-
-export class TheiaCommand {
-  constructor(
-    protected readonly id: string,
-    protected readonly properties?: {
-      name?: string;
-      file?: string;
-      greetingTitle?: string;
-      greetingContentUrl?: string;
-    }
-  ) {}
-
-  execute(): PromiseLike<void> {
-    if (this.id === ActionId.OPEN_FILE) {
-      if (this.properties && this.properties.file) {
-        const fileLocation = fileuri.convertToFileURI(this.properties.file);
-        return theia.commands.executeCommand('file-search.openFile', fileLocation).then(
-          () => {},
-          e => {
-            theia.window.showErrorMessage(`Could not open file: ${e.message}`);
-            console.log('Could not open file ', e);
-          }
-        );
-      }
-    }
-
-    if (this.id === ActionId.RUN_COMMAND) {
-      if (this.properties) {
-        return theia.commands.executeCommand('task:run', CHE_TASK_TYPE, this.properties.name, TaskScope.Global).then(
-          () => {
-            theia.window.showInformationMessage('Executed che command succesfully');
-          },
-          e => {
-            theia.window.showErrorMessage(`Could not execute Che command: ${e.message}`);
-            console.log('Could not execute Che command', e);
-          }
-        );
-      }
-    }
-
-    return new Promise(() => {
-      console.error('action nor openfile nor run command');
-    });
   }
 }

--- a/plugins/workspace-plugin/src/workspace-folder-updater.ts
+++ b/plugins/workspace-plugin/src/workspace-folder-updater.ts
@@ -76,6 +76,15 @@ export class WorkspaceFolderUpdater {
     });
   }
 
+  async removeWorkspaceFolder(path: string): Promise<void> {
+    const workspaceFolders: theia.WorkspaceFolder[] = theia.workspace.workspaceFolders || [];
+
+    const index = workspaceFolders.findIndex((folder: theia.WorkspaceFolder) => folder.uri.path === path);
+    if (index >= 0) {
+      theia.workspace.updateWorkspaceFolders(index, 1);
+    }
+  }
+
   protected toValidWorkspaceFolderPath(path: string): string {
     if (path.endsWith('/')) {
       return path.slice(0, -1);

--- a/plugins/workspace-plugin/src/workspace-plugin.ts
+++ b/plugins/workspace-plugin/src/workspace-plugin.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2018-2020 Red Hat, Inc.
+ * Copyright (c) 2018-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,9 +10,9 @@
 
 import * as theia from '@theia/plugin';
 
-import { handleWorkspaceProjects, onDidCloneSources } from './workspace-projects-manager';
+import { WorkspaceProjectsManager, onDidCloneSources } from './workspace-projects-manager';
 
-import { Devfile } from './devfile';
+import { CreateWorkspaceCommand } from './create-workspace-command';
 import { EphemeralWorkspaceChecker } from './ephemeral-workspace-checker';
 import { initAskpassEnv } from './askpass/askpass';
 
@@ -21,16 +21,17 @@ interface API {
 }
 
 export async function start(context: theia.PluginContext): Promise<API> {
-  let projectsRoot = '/projects';
-  const projectsRootEnvVar = await theia.env.getEnvVariable('CHE_PROJECTS_ROOT');
-  if (projectsRootEnvVar) {
-    projectsRoot = projectsRootEnvVar;
-  }
+  const root = process.env['PROJECTS_ROOT'] || process.env['CHE_PROJECTS_ROOT'] || '/projects';
 
-  new Devfile(context).init();
+  // command to create a workspace from devfile
+  new CreateWorkspaceCommand(context).init();
+
+  // status bar item indicating that this workpace is ephemeral
   new EphemeralWorkspaceChecker().check();
+
   await initAskpassEnv();
-  handleWorkspaceProjects(context, projectsRoot);
+
+  new WorkspaceProjectsManager(context, root).run();
 
   return {
     get onDidCloneSources(): theia.Event<void> {

--- a/plugins/workspace-plugin/tests/file-uri.spec.ts
+++ b/plugins/workspace-plugin/tests/file-uri.spec.ts
@@ -8,21 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-import { convertToCheProjectPath, convertToFileURI } from '../src/file-uri';
-
-describe('Test exec commands', () => {
-  test('Convert a openfile file property to file URI', async () => {
-    expect(convertToFileURI('/che/README.md')).toBe('file:///projects/che/README.md');
-    expect(convertToFileURI('che/README.md')).toBe('file:///projects/che/README.md');
-    expect(convertToFileURI('file:///test-project/che/README.md')).toBe('file:///test-project/che/README.md');
-    expect(convertToFileURI('che/README.md', '/test-projects')).toBe('file:///test-projects/che/README.md');
-    expect(convertToFileURI('che/README.md', 'file:///test-projects')).toBe('file:///test-projects/che/README.md');
-    expect(convertToFileURI('/che/README.md', '/test-projects')).toBe('file:///test-projects/che/README.md');
-    expect(convertToFileURI('/che/README.md', 'file:///test-projects')).toBe('file:///test-projects/che/README.md');
-    expect(convertToFileURI('/che/README.md', 'test-projects')).toBe('file:///test-projects/che/README.md');
-    expect(convertToFileURI('/che/', 'test-projects')).toBe('file:///test-projects/che/');
-  });
-});
+import { convertToCheProjectPath } from '../src/file-uri';
 
 describe('Testing convertion of project paths to be stored in the workspace config', () => {
   test('Converting fs project path to che project path', async () => {
@@ -34,6 +20,5 @@ describe('Testing convertion of project paths to be stored in the workspace conf
     expect(convertToCheProjectPath('/projects/theiadev_projects/blog.sunix.org/', '/projects/theiadev_projects')).toBe(
       'blog.sunix.org'
     );
-    expect(convertToCheProjectPath('/projects/che/che-workspace-extension/', '')).toBe('che/che-workspace-extension');
   });
 });

--- a/plugins/workspace-plugin/tests/workspace-projects-manager.spec.ts
+++ b/plugins/workspace-plugin/tests/workspace-projects-manager.spec.ts
@@ -14,9 +14,8 @@ import * as projectsHelper from '../src/projects';
 import * as theia from '@theia/plugin';
 import * as theiaCommands from '../src/theia-commands';
 
-import { WorkspaceProjectsManager, handleWorkspaceProjects } from '../src/workspace-projects-manager';
-
 import { WorkspaceFolderUpdater } from '../src/workspace-folder-updater';
+import { WorkspaceProjectsManager } from '../src/workspace-projects-manager';
 
 jest.mock('../src/workspace-folder-updater');
 jest.mock('../src/projects');
@@ -72,6 +71,7 @@ const context: theia.PluginContext = {
 
 const outputChannelMock = {
   appendLine: jest.fn(),
+  show: jest.fn(),
 };
 
 const getDevfileMock = jest.fn();
@@ -155,7 +155,8 @@ describe('Test Workspace Projects Manager', () => {
   });
 
   test('Should create an instanse of the WorkspaceProjectsManager and run it', async () => {
-    handleWorkspaceProjects(context, PROJECTS_ROOT);
+    // handleWorkspaceProjects(context, PROJECTS_ROOT);
+    new WorkspaceProjectsManager(context, PROJECTS_ROOT).run();
 
     expect(getDevfileMock).toBeCalledTimes(1); // workspaceProjectsManager.run() is called
   });
@@ -304,7 +305,7 @@ describe('Test Workspace Projects Manager', () => {
   test('Should delete a project from Devfile', async () => {
     getDevfileMock.mockReturnValue(devfile_Without_Attributes);
 
-    await workspaceProjectsManager.deleteProjectInWorkspace('/projects/che-theia');
+    await workspaceProjectsManager.deleteProjectFromWorkspace('/projects/che-theia');
 
     expect(getDevfileMock).toBeCalledTimes(1);
     expect(updateDevfileMock).toBeCalledTimes(1);
@@ -312,7 +313,7 @@ describe('Test Workspace Projects Manager', () => {
   });
 
   test('Should NOT delete a project when given Uri is not defined', async () => {
-    await workspaceProjectsManager.deleteProjectInWorkspace('');
+    await workspaceProjectsManager.deleteProjectFromWorkspace('');
 
     expect(getDevfileMock).toBeCalledTimes(0);
     expect(updateDevfileMock).toBeCalledTimes(0);


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds additional watcher for `/projects` directory to detect projects, that have been cloned by external tool or by a git command, running in terminal.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Screenshot from 2021-04-13 14-21-06](https://user-images.githubusercontent.com/1655894/114544575-83b05980-9c63-11eb-83e3-00a27deabe41.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19544
https://github.com/eclipse/che/issues/19101
https://github.com/eclipse/che/issues/19489

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
