### PR TITLE
fix(workspace-plugin): multiroot promise is not finished when returning from the method

### DIFF
--- a/plugins/recommendations-plugin/src/plugin/recommendations-plugin.ts
+++ b/plugins/recommendations-plugin/src/plugin/recommendations-plugin.ts
@@ -127,6 +127,9 @@ export class RecommendationsPlugin {
   async afterClone(): Promise<void> {
     // current workspaces
     const workspaceFolders = theia.workspace.workspaceFolders || [];
+    this.outputChannel.appendLine(
+      `Workspace folders after clone: workspaceFolders=${JSON.stringify(workspaceFolders)}`
+    );
 
     // Grab file extensions used in all projects being in the workspace folder (that have been cloned) (with a timeout)
     const extensionsInCheWorkspace = await this.findFileExtensions.find(workspaceFolders);

--- a/plugins/workspace-plugin/src/workspace-projects-manager.ts
+++ b/plugins/workspace-plugin/src/workspace-projects-manager.ts
@@ -92,21 +92,22 @@ export class WorkspaceProjectsManager {
 
     theia.window.showInformationMessage('Che Workspace: Starting importing projects.');
 
-    const cloningPromises: PromiseLike<string>[] = [];
+    const cloningPromises: Promise<string>[] = [];
     for (const cloneCommand of cloneCommandList) {
       try {
-        const cloningPromise = cloneCommand.execute();
-        cloningPromises.push(cloningPromise);
+        let cloningPromise = cloneCommand.execute();
 
         if (isMultiRoot) {
-          cloningPromise.then(projectPath => this.workspaceFolderUpdater.addWorkspaceFolder(projectPath));
+          cloningPromise = cloningPromise.then(projectPath => {
+            this.workspaceFolderUpdater.addWorkspaceFolder(projectPath);
+            return projectPath;
+          });
         }
       } catch (e) {
         this.outputChannel.appendLine(`Error while cloning: ${e}`);
         // we continue to clone other projects even if a clone process failed for a project
       }
     }
-
     await Promise.all(cloningPromises);
 
     theia.window.showInformationMessage('Che Workspace: Finished importing projects.');


### PR DESCRIPTION
### What does this PR do?
await all promises before returning from clone operation

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/19610


### How to test this PR?
Use a factory link like `#https://github.com/spring-projects/spring-petclinic` with this image but not on workspaces.openshift.com as this instance does not have yet the plug-in registry featured list

You should see some plugins recommandations

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next

Change-Id: I3488f01c3e31bb65a41e5e28a0778f81aac367ca
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
