### PR TITLE
Handle cheEditor component in addition to chePlugin

### DIFF
--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-devfile-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-devfile-service-impl.ts
@@ -163,7 +163,7 @@ export class CheServerDevfileServiceImpl implements DevfileService {
     const devfileV1Component: cheApi.workspace.devfile.Component = {};
 
     if (componentV2.plugin) {
-      devfileV1Component.type = 'chePlugin';
+      devfileV1Component.type = componentV2.attributes?.['source-origin'] || 'chePlugin';
 
       if (componentV2.plugin.memoryLimit) {
         devfileV1Component.memoryLimit = componentV2.plugin.memoryLimit;
@@ -284,8 +284,13 @@ export class CheServerDevfileServiceImpl implements DevfileService {
       devfileV2Component.container.env = this.componentEnvV1toComponentEnvV2(componentV1.env);
       devfileV2Component.container.volumeMounts = this.componentVolumeV1toComponentVolumeV2(componentV1.volumes);
       devfileV2Component.container.endpoints = this.componentEndpointV1toComponentEndpointV2(componentV1.endpoints);
-    } else if (componentV1.type === 'chePlugin') {
+    } else if (componentV1.type === 'chePlugin' || componentV1.type === 'cheEditor') {
       devfileV2Component.plugin = {};
+      if (!devfileV2Component.attributes) {
+        devfileV2Component.attributes = {};
+      }
+      devfileV2Component.attributes['source-origin'] = componentV1.type;
+
       if (componentV1.id) {
         devfileV2Component.plugin.id = componentV1.id;
       }
@@ -631,10 +636,7 @@ export class CheServerDevfileServiceImpl implements DevfileService {
     const workspace = await this.workspaceService.currentWorkspace();
 
     // convert devfile v2 to devfile v1
-    const devfileV1 = {
-      projects: (devfile.projects || []).map(project => this.projectV2toProjectV1(project)),
-      components: [],
-    };
+    const devfileV1 = this.devfileV2toDevfileV1(devfile);
 
     workspace.devfile = devfileV1;
     await this.workspaceService.updateWorkspace(workspace.id!, workspace);

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-custom-editor.yaml
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-custom-editor.yaml
@@ -1,0 +1,17 @@
+{
+  apiVersion: "1.0.0",
+  metadata: { generateName: "hello" },
+  projects:
+    [
+      {
+        name: "my-project",
+        source:
+          {
+            type: "git",
+            location: "https://github.com/this-is-a-test",
+            branch: "myBranch",
+          },
+      },
+    ],
+  components: [{ type: "cheEditor", reference: "https://reference" }],
+}

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-devfile-service-impl.spec.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-devfile-service-impl.spec.ts
@@ -176,4 +176,14 @@ describe('Test CheServerDevfileServiceImpl', () => {
     const convertedDevfileV1 = cheServerDevfileServiceImpl.devfileV2toDevfileV1(convertedDevfileV2);
     expect(convertedDevfileV1).toEqual(devfileV1);
   });
+
+  test('convert v1/v2 custom editor devfile.yaml', async () => {
+    const cheTheiaDevfileYamlPath = path.resolve(__dirname, '..', '_data', 'devfile-custom-editor.yaml');
+    const devfileContent = await fs.readFile(cheTheiaDevfileYamlPath, 'utf-8');
+    const devfileV1 = jsYaml.safeLoad(devfileContent);
+
+    const convertedDevfileV2 = cheServerDevfileServiceImpl.devfileV1toDevfileV2(devfileV1);
+    const convertedDevfileV1 = cheServerDevfileServiceImpl.devfileV2toDevfileV1(convertedDevfileV2);
+    expect(convertedDevfileV1).toEqual(devfileV1);
+  });
 });


### PR DESCRIPTION
### What does this PR do?
Backport of https://github.com/eclipse-che/che-theia/pull/1084

Fixes the problem with installing plugins from Plugins view

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2021 04 20-23_38_44](https://user-images.githubusercontent.com/1271546/115460978-957c9880-a231-11eb-8bba-d40a725fba57.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19623

### How to test this PR?
try to add this component into your devfile:
```yaml
  - type: cheEditor
    reference: 'https://gist.githubusercontent.com/svor/966bff2009ceaad7d64d8d14fd040155/raw/f28318b9a4f308012171bce1590ec725ca913306/che-theia-editor.yaml'
```


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next