### PR TITLE
Inlive Devfile V1 kubernetes component when converting to Devfile V2

### DIFF
--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-devfile-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-devfile-service-impl.ts
@@ -166,6 +166,14 @@ export class CheServerDevfileServiceImpl implements DevfileService {
   }
 
   componentV2toComponentV1(componentV2: DevfileComponent): cheApi.workspace.devfile.Component {
+    if (componentV2.kubernetes) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      return JSON.parse(componentV2.kubernetes!.inlined!) as cheApi.workspace.devfile.Component;
+    } else if (componentV2.openshift) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      return JSON.parse(componentV2.openshift!.inlined!) as cheApi.workspace.devfile.Component;
+    }
+
     const devfileV1Component: cheApi.workspace.devfile.Component = {};
 
     if (componentV2.plugin) {
@@ -321,6 +329,12 @@ export class CheServerDevfileServiceImpl implements DevfileService {
       devfileV2Component.plugin.env = this.componentEnvV1toComponentEnvV2(componentV1.env);
       devfileV2Component.plugin.volumeMounts = this.componentVolumeV1toComponentVolumeV2(componentV1.volumes);
       devfileV2Component.plugin.endpoints = this.componentEndpointV1toComponentEndpointV2(componentV1.endpoints);
+    } else if (componentV1.type === 'kubernetes') {
+      devfileV2Component.kubernetes = {};
+      devfileV2Component.kubernetes.inlined = JSON.stringify(componentV1);
+    } else if (componentV1.type === 'openshift') {
+      devfileV2Component.openshift = {};
+      devfileV2Component.openshift.inlined = JSON.stringify(componentV1);
     }
 
     return devfileV2Component;

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-custom-editor.yaml
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-custom-editor.yaml
@@ -1,17 +1,13 @@
-{
-  apiVersion: "1.0.0",
-  metadata: { generateName: "hello" },
-  projects:
-    [
-      {
-        name: "my-project",
-        source:
-          {
-            type: "git",
-            location: "https://github.com/this-is-a-test",
-            branch: "myBranch",
-          },
-      },
-    ],
-  components: [{ type: "cheEditor", reference: "https://reference" }],
-}
+---
+apiVersion: 1.0.0
+metadata:
+  generateName: hello
+projects:
+  - name: my-project
+    source:
+      type: git
+      location: 'https://github.com/this-is-a-test'
+      branch: myBranch
+components:
+  - type: cheEditor
+    reference: 'https://reference'

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-kubernetes-component.yaml
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-kubernetes-component.yaml
@@ -10,13 +10,8 @@ projects:
       branch: myBranch
 components:
   - type: kubernetes
-    alias: petclinic-db
-    reference: https://reference2
-    selector:
-      app.kubernetes.io/component: database
-  - type: kubernetes
     alias: petclinic-web
-    reference: 'https://reference3'
+    reference: 'https://reference'
     selector:
       app.kubernetes.io/component: webapp
     entrypoints:

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-kubernetes-components.yaml
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-kubernetes-components.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: 1.0.0
+metadata:
+  generateName: hello
+projects:
+  - name: my-project
+    source:
+      type: git
+      location: 'https://github.com/this-is-a-test'
+      branch: myBranch
+components:
+  - type: kubernetes
+    alias: petclinic-db
+    reference: https://reference2
+    selector:
+      app.kubernetes.io/component: database
+  - type: kubernetes
+    alias: petclinic-web
+    reference: 'https://reference3'
+    selector:
+      app.kubernetes.io/component: webapp
+    entrypoints:
+      - containerName: spring-boot
+        command: ["tail"]
+        args: ["-f", "/dev/null"]

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-openshift-component.yaml
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-openshift-component.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: 1.0.0
+metadata:
+  generateName: hello
+projects:
+  - name: my-project
+    source:
+      type: git
+      location: 'https://github.com/this-is-a-test'
+      branch: myBranch
+components:
+  - type: openshift
+    referenceContent: it is supposed to be a content of the file specified in the local field
+    reference: petclinic.yaml
+    selector:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/part-of: petclinic

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-devfile-service-impl.spec.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-devfile-service-impl.spec.ts
@@ -194,6 +194,16 @@ describe('Test CheServerDevfileServiceImpl', () => {
     expect(convertedDevfileV1).toEqual(devfileV1);
   });
 
+  test('convert v1/v2 kubernetes components devfile.yaml', async () => {
+    const cheTheiaDevfileYamlPath = path.resolve(__dirname, '..', '_data', 'devfile-kubernetes-components.yaml');
+    const devfileContent = await fs.readFile(cheTheiaDevfileYamlPath, 'utf-8');
+    const devfileV1 = jsYaml.safeLoad(devfileContent);
+
+    const convertedDevfileV2 = cheServerDevfileServiceImpl.devfileV1toDevfileV2(devfileV1);
+    const convertedDevfileV1 = cheServerDevfileServiceImpl.devfileV2toDevfileV1(convertedDevfileV2);
+    expect(convertedDevfileV1).toEqual(devfileV1);
+  });
+
   test('getComponentStatus', async () => {
     const workspaceJsonPath = path.resolve(__dirname, '..', '_data', 'workspace-status-runtime.json');
     const workspaceJsonContent = await fs.readFile(workspaceJsonPath, 'utf-8');

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-devfile-service-impl.spec.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-devfile-service-impl.spec.ts
@@ -194,8 +194,18 @@ describe('Test CheServerDevfileServiceImpl', () => {
     expect(convertedDevfileV1).toEqual(devfileV1);
   });
 
-  test('convert v1/v2 kubernetes components devfile.yaml', async () => {
-    const cheTheiaDevfileYamlPath = path.resolve(__dirname, '..', '_data', 'devfile-kubernetes-components.yaml');
+  test('convert v1/v2 kubernetes component devfile.yaml', async () => {
+    const cheTheiaDevfileYamlPath = path.resolve(__dirname, '..', '_data', 'devfile-kubernetes-component.yaml');
+    const devfileContent = await fs.readFile(cheTheiaDevfileYamlPath, 'utf-8');
+    const devfileV1 = jsYaml.safeLoad(devfileContent);
+
+    const convertedDevfileV2 = cheServerDevfileServiceImpl.devfileV1toDevfileV2(devfileV1);
+    const convertedDevfileV1 = cheServerDevfileServiceImpl.devfileV2toDevfileV1(convertedDevfileV2);
+    expect(convertedDevfileV1).toEqual(devfileV1);
+  });
+
+  test('convert v1/v2 openshift component devfile.yaml', async () => {
+    const cheTheiaDevfileYamlPath = path.resolve(__dirname, '..', '_data', 'devfile-openshift-component.yaml');
     const devfileContent = await fs.readFile(cheTheiaDevfileYamlPath, 'utf-8');
     const devfileV1 = jsYaml.safeLoad(devfileContent);
 


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Converts Devfile V1 `kubernetes` and `openshift` components into appropriate objects in Devfile V2.

Extends
- https://github.com/eclipse-che/che-theia/pull/1081
- https://github.com/eclipse-che/che-theia/pull/1084

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19634
https://github.com/eclipse/che/issues/19623

Is needed for https://github.com/eclipse-che/che-theia/pull/1076

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
See
- https://github.com/eclipse/che/issues/19634
- https://github.com/eclipse-che/che-theia/pull/1076

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next
