### PR TITLE
fix(recommendations): promise were not added anymore to the waiting list

### DIFF
--- a/extensions/eclipse-che-theia-remote-api/src/common/devfile-service.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/common/devfile-service.ts
@@ -142,7 +142,7 @@ export interface DevfileV1PluginComponent {
   mountSources?: boolean;
   sourceMapping?: string;
   volumeMounts?: DevfileComponentVolumeMount[];
-  preferences?: { [preferenceName: string]: unknown };
+  preferences?: { [preferenceName: string]: string | number | boolean };
 }
 export interface DevfileComponent {
   name?: string;

--- a/plugins/recommendations-plugin/__mocks__/@theia/plugin.ts
+++ b/plugins/recommendations-plugin/__mocks__/@theia/plugin.ts
@@ -30,5 +30,8 @@ theia.workspace = {
   workspaceFolders: undefined,
   onDidOpenTextDocument: jest.fn(),
 };
+theia.Uri = {
+  parse: jest.fn()
+}
 theia.plugins.getPlugin = jest.fn();
 module.exports = theia;

--- a/plugins/recommendations-plugin/tests/plugin/recommendations-plugin.spec.ts
+++ b/plugins/recommendations-plugin/tests/plugin/recommendations-plugin.spec.ts
@@ -108,6 +108,8 @@ describe('Test recommendation Plugin', () => {
   });
 
   test('Check onClone callback is registered', async () => {
+    theia.workspace.workspaceFolders = undefined;
+
     (theia.plugins.getPlugin as jest.Mock).mockReturnValue(workspacePluginMock);
     const recommendationsPlugin = container.get(RecommendationsPlugin);
     const spyAfterClone = jest.spyOn(recommendationsPlugin, 'afterClone');
@@ -228,6 +230,14 @@ describe('Test recommendation Plugin', () => {
   });
 
   test('Check featuredPlugins with plugins in the devfile (user click no on suggestion)', async () => {
+    theia.workspace.workspaceFolders = [
+      {
+        uri: theia.Uri.parse('/projects'),
+        name: 'project',
+        index: 0,
+      },
+    ];
+
     (theia.plugins.getPlugin as jest.Mock).mockReturnValue(workspacePluginMock);
 
     // no devfile plugins

--- a/plugins/workspace-plugin/src/workspace-projects-manager.ts
+++ b/plugins/workspace-plugin/src/workspace-projects-manager.ts
@@ -98,11 +98,12 @@ export class WorkspaceProjectsManager {
         let cloningPromise = cloneCommand.execute();
 
         if (isMultiRoot) {
-          cloningPromise = cloningPromise.then(projectPath => {
-            this.workspaceFolderUpdater.addWorkspaceFolder(projectPath);
+          cloningPromise = cloningPromise.then(async projectPath => {
+            await this.workspaceFolderUpdater.addWorkspaceFolder(projectPath);
             return projectPath;
           });
         }
+        cloningPromises.push(cloningPromise);
       } catch (e) {
         this.outputChannel.appendLine(`Error while cloning: ${e}`);
         // we continue to clone other projects even if a clone process failed for a project


### PR DESCRIPTION

### What does this PR do?
After latest refactoring of https://github.com/eclipse-che/che-theia/pull/1079, the push of promises was gone, fixing it

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19610

### How to test this PR?
Open a workspace without plug-ins (but this customized editor) you should see some recommendation popup
(but do not use workspaces.openshift.com that don't have any featured plug-in on its plug-in registry)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next


Change-Id: I74fd1c366f6ba0fa583ce14935e60f5ae4efd5a4
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
