### PR TITLE
Devfile: preserve attributes

### DIFF
--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-devfile-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-devfile-service-impl.ts
@@ -579,35 +579,51 @@ export class CheServerDevfileServiceImpl implements DevfileService {
       components: (devfileV1.components || []).map(component => this.componentV1toComponentV2(component)),
       commands: (devfileV1.commands || []).map(command => this.commandV1toCommandV2(command)),
     };
+
     if (devfileV1.attributes) {
       devfileV2.metadata.attributes = devfileV2.metadata.attributes || {};
       Object.keys(devfileV1.attributes).forEach(attributeName => {
         devfileV2.metadata.attributes![attributeName] = devfileV1.attributes![attributeName];
       });
     }
+
     return devfileV2;
   }
 
   devfileV2toDevfileV1(devfileV2: Devfile): cheApi.workspace.devfile.Devfile {
-    const devfileV1 = {
+    const devfileV1: cheApi.workspace.devfile.Devfile = {
       apiVersion: '1.0.0',
       metadata: this.metadataV2toMetadataV1(devfileV2.metadata),
       projects: (devfileV2.projects || []).map(project => this.projectV2toProjectV1(project)),
       components: (devfileV2.components || []).map(component => this.componentV2toComponentV1(component)),
       commands: (devfileV2.commands || []).map(command => this.commandV2toCommandV1(command)),
     };
+
+    if (devfileV2.metadata.attributes) {
+      const attributeKeys = Object.keys(devfileV2.metadata.attributes);
+      if (attributeKeys.length > 0) {
+        devfileV1.attributes = devfileV1.attributes || {};
+        attributeKeys.forEach(attributeName => {
+          devfileV1.attributes![attributeName] = devfileV2.metadata.attributes![attributeName];
+        });
+      }
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const devfileV1Any = devfileV1 as any;
 
-    if (devfileV1.components.length === 0) {
+    if (devfileV1.components && devfileV1.components.length === 0) {
       delete devfileV1Any.components;
     }
-    if (devfileV1.projects.length === 0) {
+
+    if (devfileV1.projects && devfileV1.projects.length === 0) {
       delete devfileV1Any.projects;
     }
-    if (devfileV1.commands.length === 0) {
+
+    if (devfileV1.commands && devfileV1.commands.length === 0) {
       delete devfileV1Any.commands;
     }
+
     return devfileV1;
   }
 

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-attributes.yaml
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-attributes.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: 1.0.0
+attributes:
+  multiRoot: 'off'
+metadata:
+  name: test

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-devfile-service-impl.spec.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-devfile-service-impl.spec.ts
@@ -214,6 +214,16 @@ describe('Test CheServerDevfileServiceImpl', () => {
     expect(convertedDevfileV1).toEqual(devfileV1);
   });
 
+  test('convert v1/v2 devfile-attributes.yaml', async () => {
+    const cheTheiaDevfileYamlPath = path.resolve(__dirname, '..', '_data', 'devfile-attributes.yaml');
+    const devfileContent = await fs.readFile(cheTheiaDevfileYamlPath, 'utf-8');
+    const devfileV1 = jsYaml.safeLoad(devfileContent);
+
+    const convertedDevfileV2 = cheServerDevfileServiceImpl.devfileV1toDevfileV2(devfileV1);
+    const convertedDevfileV1 = cheServerDevfileServiceImpl.devfileV2toDevfileV1(convertedDevfileV2);
+    expect(convertedDevfileV1).toEqual(devfileV1);
+  });
+
   test('getComponentStatus', async () => {
     const workspaceJsonPath = path.resolve(__dirname, '..', '_data', 'workspace-status-runtime.json');
     const workspaceJsonContent = await fs.readFile(workspaceJsonPath, 'utf-8');


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Preserves devfile attributes when changing the devfile from Che-Theia

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
is needed for
- https://issues.redhat.com/browse/CRW-1746
- https://github.com/eclipse/che/issues/19544

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Create workspace from the devfile
```
---
apiVersion: 1.0.0
attributes:
  multiRoot: 'off'
metadata:
  name: test
```

2. Go to Plugins view and install any plugin.

3. Open dashboard and check the devfile, it should contain `multiRoot` attribute.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next
