### PR TITLE
fix(regexp): vsix-extensions is not the only attribute, so we may have extra attributes to handle

### DIFF
--- a/dockerfiles/theia-vsix-installer/src/entrypoint.sh
+++ b/dockerfiles/theia-vsix-installer/src/entrypoint.sh
@@ -16,7 +16,7 @@ WORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.
 IFS=$'\n'
 for container in $(echo "$WORKSPACE" | sed -e 's|[[,]\({"attributes":{"app.kubernetes.io\)|\n\1|g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do
     dest=$(echo "$container" | sed 's|.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*|\1|' - )
-    urls=$(echo "$container" | sed 's|.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\]}.*|\1|' - )
+    urls=$(echo "$container" | sed 's|.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\].*|\1|' - )
     mkdir -p "$dest"
     unset IFS
     for url in $(echo "$urls" | sed 's/[",]/ /g' - ); do


### PR DESCRIPTION
### What does this PR do?
theia-vsix installer component is reading attributes of kubernetes container but it may fail on some configurations (like lot of attributes)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
N/A

### How to test this PR?
use the container field
```json
{"attributes":{"app.kubernetes.io/component":"vscode-extension","app.kubernetes.io/name":"maven","app.kubernetes.io/part-of–":"che-theia.eclipse.org","che-theia.eclipse.org/vscode-extensions":["https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.75.0-60.vsix","https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix","https://open-vsx.org/api/vscjava/vscode-java-test/0.28.1/file/vscjava.vscode-java-test-0.28.1.vsix"],"che-theia.eclipse.org/vscode-preferences":{"java.server.launchMode":"Standard"}},"container":{"env":[{"name":"PLUGIN_REMOTE_ENDPOINT_EXECUTABLE","value":"/remote-endpoint/plugin-remote-endpoint"},{"name":"THEIA_PLUGINS","value":"local-dir:///plugins/sidecars/maven"}],"image":"quay.io/eclipse/che-java11-maven:nightly","memoryLimit":"1536M","volumeMounts":[{"name":"m2","path":"/root/.m2"},{"name":"remote-endpoint","path":"/remote-endpoint"},{"name":"plugins","path":"/plugins"}]},"name":"maven"},{"name":"m2","volume":{"size":"1G"}},{"name":"theia-ide","plugin":{"kubernetes":{"name":"theia-ide"}}},{"name":"che-theia-vsix-installer","plugin":{"kubernetes":{"name":"che-theia-vsix-installer"}}}],"projects":[{"git":{"remotes":{"origin":"https://github.com/benoitf/spring-petclinic"}},"name":"spring-petclinic"}]}}}
```

on https://sed.js.org/ for example
![Screenshot 2021-05-10 at 14 40 07](https://user-images.githubusercontent.com/436777/117661018-1dedb980-b19e-11eb-9a58-54f3d20186b3.png)

(or already built image: `quay.io/fbenoit/che-theia-vsix-installer:20210510`)
with this sample on devWorkspace operator

```bash
$ kubectl apply -f https://gist.githubusercontent.com/benoitf/b048e5d593826e8ba8a0b9f8eaf8220c/raw/25dd46f82312bef15b430c3909a638ef86bd4409/all-in-one.yaml -n <your-namespace>
```


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next

Change-Id: I777bb7a51e501d66d3721443137616d50f789dea
Signed-off-by: Florent Benoit <fbenoit@redhat.com>