### PR TITLE
fix(recommendations): Do not try to suggest a different version of an existing plug-in

### DIFF
--- a/plugins/recommendations-plugin/src/plugin/recommendations-plugin.ts
+++ b/plugins/recommendations-plugin/src/plugin/recommendations-plugin.ts
@@ -123,6 +123,11 @@ export class RecommendationsPlugin {
     });
   }
 
+  // remove the digits on a given string so it will return for example redhat/java if we give redhat/java11
+  removeDigits(content: string): string {
+    return content.replace(/[0-9]/g, '');
+  }
+
   // called after projects are cloned (like the first import)
   async afterClone(): Promise<void> {
     // current workspaces
@@ -148,7 +153,11 @@ export class RecommendationsPlugin {
     const inDevfilePlugins = await this.devfileHandler.getPlugins();
     this.outputChannel.appendLine(`inDevfilePlugins=${inDevfilePlugins}`);
 
-    featuredPlugins = featuredPlugins.filter(plugin => !inDevfilePlugins.includes(plugin));
+    // here we need to compare without digits (for example if java8 plug-in is installed but we suggest java11 it should match the same plug-in)
+    featuredPlugins = featuredPlugins.filter(
+      plugin =>
+        !inDevfilePlugins.some(inDevVilePlugin => this.removeDigits(inDevVilePlugin) === this.removeDigits(plugin))
+    );
     this.outputChannel.appendLine(`filteredFeaturedPlugins=${featuredPlugins}`);
 
     // do we have plugins in the devfile ?


### PR DESCRIPTION
### What does this PR do?
if user has a devfile with `redhat/java8` it won't suggest `redhat/java11`

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1789

### How to test this PR?
Use a devfile with `redhat/java8` plug-in and see if `redhat/java11` is suggested or not
And check that with a java project without any plug-in, `redhat/java11` is suggested

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next


Change-Id: I7d1fa5a3e6ee0d1677132ffacf56e55580862cfa
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
