### PR TITLE
Fix plugin storage path after updating

### DIFF
--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-init.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-init.ts
@@ -167,6 +167,14 @@ export class PluginRemoteInit {
       return originalStart.call(this, params);
     };
 
+    const originalUpdateStoragePath = PluginManagerExtImpl.prototype.$updateStoragePath;
+    PluginManagerExtImpl.prototype.$updateStoragePath = async function (
+      storagePath: string | undefined
+    ): Promise<void> {
+      const overriddenStoragePath = storagePath ? modifyPathToLocal(storagePath) : undefined;
+      return originalUpdateStoragePath.call(this, overriddenStoragePath);
+    };
+
     // display message about process being started
     console.log(`Theia Endpoint ${process.pid}/pid listening on port`, this.pluginPort);
   }


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Modifies `storagePath` to use current home directory of a container where remote plugin is running.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1793


### How to test this PR?
-  Run a workspce with a java plugin where HOME is not `/home/theia` as an example you can take this patched plugin https://gist.githubusercontent.com/svor/58490c28fd6a8a2acdb85492f824b7a0/raw/413908f2b8ec5f5bd55db66f28296f19c08af08f/test-meta.yaml 
-  Open any java file, as a result Java LS should be initialized. Also `/home/jboss/.theia/workspace-storage` folder in vscode-java container should contain a subfolder.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
