### PR TITLE
Fix port evaluation for machine exec

### DIFF
--- a/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
+++ b/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
@@ -223,6 +223,7 @@ declare module '@eclipse-che/plugin' {
             attributes?: { [key: string]: string };
             url?: string;
             name: string;
+            targetPort: string;
             component: string;
           }
 

--- a/extensions/eclipse-che-theia-remote-api/src/common/endpoint-service.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/common/endpoint-service.ts
@@ -16,6 +16,7 @@ export interface ExposedEndpoint {
   attributes?: { [key: string]: string };
   url?: string;
   name: string;
+  targetPort: string;
   component: string;
 }
 

--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-endpoint-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-endpoint-service-impl.ts
@@ -49,6 +49,7 @@ export class CheServerEndpointServiceImpl implements EndpointService {
             url: server.url,
             attributes: server.attributes,
             name: serverName,
+            targetPort: server.attributes?.port || '',
             component: machineName,
           });
         }
@@ -80,6 +81,7 @@ export class CheServerEndpointServiceImpl implements EndpointService {
             url: server.url,
             attributes: server.attributes,
             name: serverName,
+            targetPort: server.attributes.port,
             component: machineName,
           });
         }

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-endpoint-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-endpoint-service-impl.ts
@@ -34,10 +34,11 @@ export class K8sEndpointServiceImpl implements EndpointService {
       const endpoints: ExposedEndpoint[] = [];
       if (component.container?.endpoints) {
         component.container.endpoints.forEach(endpoint => {
-          const componentExposedEndpoint = {
+          const componentExposedEndpoint: ExposedEndpoint = {
             attributes: endpoint.attributes,
             name: endpoint.name,
             component: component.name || '',
+            targetPort: endpoint.targetPort.toString(),
             url: endpoint.attributes?.['controller.devfile.io/endpoint-url'],
           };
           endpoints.push(componentExposedEndpoint);

--- a/plugins/task-plugin/src/che-workspace-client.ts
+++ b/plugins/task-plugin/src/che-workspace-client.ts
@@ -45,7 +45,7 @@ export class CheWorkspaceClient {
 
   async getMachineExecServerURL(): Promise<string> {
     const machineExecEndpoint = await this.getMachineExecEndpoint();
-    const port = machineExecEndpoint.attributes?.port || machineExecEndpoint.targetPort;
+    const port = machineExecEndpoint.targetPort;
     return `ws://127.0.0.1:${port}`;
   }
 

--- a/plugins/task-plugin/src/che-workspace-client.ts
+++ b/plugins/task-plugin/src/che-workspace-client.ts
@@ -45,7 +45,7 @@ export class CheWorkspaceClient {
 
   async getMachineExecServerURL(): Promise<string> {
     const machineExecEndpoint = await this.getMachineExecEndpoint();
-    const port = machineExecEndpoint.attributes?.port || machineExecEndpoint.attributes?.targetPort;
+    const port = machineExecEndpoint.attributes?.port || machineExecEndpoint.targetPort;
     return `ws://127.0.0.1:${port}`;
   }
 

--- a/plugins/task-plugin/tests/che-workspace-client.spec.ts
+++ b/plugins/task-plugin/tests/che-workspace-client.spec.ts
@@ -40,6 +40,7 @@ describe('Test containers service', () => {
     const exposedEndpoints: che.endpoint.ExposedEndpoint[] = [
       {
         name: 'che-machine-exec',
+        targetPort: '4444',
         component: 'machine-exec',
         attributes: {
           type: 'collocated-terminal',


### PR DESCRIPTION
### What does this PR do?
Fix port evaluation for machine exec.

### Screenshot/screencast of this PR
**Before**:
![Screenshot_20210514_143215](https://user-images.githubusercontent.com/5887312/118274829-4d6a3200-b4ce-11eb-954e-81cf1f2e17d1.png)

**After**:
![Screenshot_20210514_160551](https://user-images.githubusercontent.com/5887312/118274924-6a066a00-b4ce-11eb-8d17-f2e2a51cf942.png)


### What issues does this PR fix or reference?
it's for https://github.com/eclipse/che/issues/19810


### How to test this PR?
1. Create devworkspace like https://github.com/sleshchenko/NodeJS-Sample-App/blob/main/devfile.yaml
2. Try to execute the command


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
