### PR TITLE
fix(recommendations): Use Error message instead of Info message on errors

### DIFF
--- a/plugins/recommendations-plugin/__mocks__/@theia/plugin.ts
+++ b/plugins/recommendations-plugin/__mocks__/@theia/plugin.ts
@@ -26,6 +26,7 @@ theia.window.createOutputChannel.mockReturnValue(outputChannel);
 theia.plugins = {};
 theia.plugins.all = [];
 theia.window.showInformationMessage = jest.fn();
+theia.window.showErrorMessage = jest.fn();
 theia.workspace = {
   workspaceFolders: undefined,
   onDidOpenTextDocument: jest.fn(),

--- a/plugins/recommendations-plugin/src/fetch/featured-fetcher.ts
+++ b/plugins/recommendations-plugin/src/fetch/featured-fetcher.ts
@@ -30,7 +30,7 @@ export class FeaturedFetcher {
       featuredList = response.data.featured;
     } catch (error) {
       featuredList = [];
-      theia.window.showInformationMessage(`Error while fetching featured recommendation ${error}`);
+      theia.window.showErrorMessage(`Error while fetching featured recommendation ${error}`);
     }
     return featuredList;
   }

--- a/plugins/recommendations-plugin/src/fetch/plugins-by-language-fetcher.ts
+++ b/plugins/recommendations-plugin/src/fetch/plugins-by-language-fetcher.ts
@@ -32,7 +32,7 @@ export class PluginsByLanguageFetcher {
       languagePlugins = response.data;
     } catch (error) {
       if (error.response.status !== 404) {
-        theia.window.showInformationMessage(`Error while fetching featured recommendations ${error}`);
+        theia.window.showErrorMessage(`Error while fetching featured recommendations ${error}`);
       }
     }
     return languagePlugins;

--- a/plugins/recommendations-plugin/tests/fetch/featured-fetcher.spec.ts
+++ b/plugins/recommendations-plugin/tests/fetch/featured-fetcher.spec.ts
@@ -13,6 +13,7 @@ import 'reflect-metadata';
 
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import * as theia from '@theia/plugin';
 
 import { ChePluginRegistry } from '../../src/registry/che-plugin-registry';
 import { Container } from 'inversify';
@@ -58,5 +59,22 @@ describe('Test FeaturedFetcher', () => {
     expect(featuredList).toBeDefined();
     expect(featuredList.length).toBe(0);
     expect((axios as any).get).toBeCalledWith(`${fakeUrl}/che-theia/featured.json`);
+  });
+
+  test('unexpected error', async () => {
+    const error = {
+      response: {
+        status: 500,
+      },
+    };
+    (axios as any).__setError('https://my.registry/v3/che-theia/recommendations/language/java.json', error);
+
+    const featuredFetcher = container.get(FeaturedFetcher);
+    const featuredList = await featuredFetcher.fetch();
+    // no content
+    expect(featuredList).toBeDefined();
+    expect(featuredList.length).toBe(0);
+    // notify the user
+    expect(theia.window.showErrorMessage as jest.Mock).toBeCalled();
   });
 });

--- a/plugins/recommendations-plugin/tests/fetch/plugins-by-language-fetcher.spec.ts
+++ b/plugins/recommendations-plugin/tests/fetch/plugins-by-language-fetcher.spec.ts
@@ -80,6 +80,6 @@ describe('Test PluginsByLanguageFetcher', () => {
     expect(languageByPlugins).toBeDefined();
     expect(languageByPlugins.length).toBe(0);
     // notify the user
-    expect(theia.window.showInformationMessage as jest.Mock).toBeCalled();
+    expect(theia.window.showErrorMessage as jest.Mock).toBeCalled();
   });
 });


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Backport https://github.com/eclipse-che/che-theia/pull/1094 into 7.30.x

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
Fixes https://issues.redhat.com/browse/CRW-1714

### How to test this PR?
Look at unit tests or use https://issues.redhat.com/browse/CRW-1702 details to reproduce it ("spec.server.useInternalClusterSVCNames=false)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next

Change-Id: Id804f5605e5c686a43ad26d7de50fcfd7c7c8f6d
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
