### PR TITLE
Remove file watcher related workaround

### DIFF
--- a/plugins/task-plugin/src/export/launch-configs-exporter.ts
+++ b/plugins/task-plugin/src/export/launch-configs-exporter.ts
@@ -12,8 +12,8 @@ import * as che from '@eclipse-che/plugin';
 import * as startPoint from '../task-plugin-backend';
 import * as theia from '@theia/plugin';
 
-import { ensureDirExists, modify, writeFile } from '../utils';
 import { inject, injectable } from 'inversify';
+import { modify, writeFile } from '../utils';
 
 import { ConfigFileLaunchConfigsExtractor } from '../extract/config-file-launch-configs-extractor';
 import { ConfigurationsExporter } from './export-configs-manager';
@@ -120,26 +120,8 @@ export class LaunchConfigurationsExporter implements ConfigurationsExporter {
     content: string,
     configurations: theia.DebugConfiguration[]
   ): Promise<void> {
-    /*
-        There is an issue related to file watchers: the watcher only reports the first directory when creating recursively directories.
-        For example:
-            - we would like to create /projects/someProject/.theia/launch.json recursively
-            - /projects/someProject directory already exists
-            - .theia directory and launch.json file should be created
-            - as result file watcher fires an event that .theia directory was created, there is no an event about launch.json file
-
-        The issue is reproduced not permanently.
-
-        We had to use the workaround to avoid the issue: first we create the directory and then - config file
-    */
-
-    const configDirPath = resolve(workspaceFolderPath, CONFIG_DIR);
-    await ensureDirExists(configDirPath);
-
-    const launchConfigFilePath = resolve(configDirPath, LAUNCH_CONFIG_FILE);
-    await ensureDirExists(launchConfigFilePath);
-
     const result = modify(content, ['configurations'], configurations, formattingOptions);
+    const launchConfigFilePath = resolve(workspaceFolderPath, CONFIG_DIR, LAUNCH_CONFIG_FILE);
     return writeFile(launchConfigFilePath, result);
   }
 

--- a/plugins/task-plugin/src/utils.ts
+++ b/plugins/task-plugin/src/utils.ts
@@ -138,8 +138,5 @@ export function ensureDirExistence(filePath: string): void {
 /** Creates a directory containing the file if they don't exist */
 export async function ensureDirExists(filePath: string): Promise<void> {
   const dirName = path.dirname(filePath);
-  if (await fs.pathExists(dirName)) {
-    return;
-  }
   return fs.mkdirp(dirName);
 }


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

I'm working on CRW-1758.
Within CRW-1758 I tested these changes based on 7.30.x for power related infrastructure.

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- There was an issue related to file watchers: the watcher only reported the first directory when creating recursively directories.
 We had to use a workaround to avoid the issue.
  The issue was fixed in the upstream: https://community.theia-ide.org/t/eclipse-theia-v1-12-1-patch-release/1588
 Now we can remove the workaround.
 
 - I have removed the check from `ensureDirExists(filePath: string)` method:
  ```
  if (await fs.pathExists(dirName))
  ``` 
  as it looks like the check is redundant: `fs.mkdirp(dirName)` should not throw an error if a directory already exists.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19457

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Start a workspace from a devfile which contains a debug configuration. 
2. Go to the debug panel and check that the configuration is available for running.

Please repeat it few times, maybe for different workspaces, maybe use restarting a workspace - as the problem was reproduced not permanently. That's why I restarted the happy path tests multiple times - as far as I know that use case was covered by the tests.  

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
