### PR TITLE
Make Che Theia to rely on main endpoint type

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-telemetry-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-telemetry-main.ts
@@ -16,7 +16,7 @@ import { ClientAddressInfo } from '@eclipse-che/plugin';
 import { CommandRegistry } from '@theia/core';
 import { EndpointService } from '@eclipse-che/theia-remote-api/lib/common/endpoint-service';
 import { RPCProtocol } from '@theia/plugin-ext/lib/common/rpc-protocol';
-import { SERVER_IDE_ATTR_VALUE } from '../common/che-server-common';
+import { SERVER_MAIN_ATTR_VALUE } from '../common/che-server-common';
 import { TelemetryService } from '@eclipse-che/theia-remote-api/lib/common/telemetry-service';
 import URI from '@theia/core/lib/common/uri';
 import { interfaces } from 'inversify';
@@ -64,7 +64,7 @@ export class CheTelemetryMainImpl implements CheTelemetryMain {
   }
 
   async getClientAddressInfo(): Promise<ClientAddressInfo> {
-    const ideEndpoints = await this.endpointService.getEndpointsByType(SERVER_IDE_ATTR_VALUE);
+    const ideEndpoints = await this.endpointService.getEndpointsByType(SERVER_MAIN_ATTR_VALUE);
 
     if (ideEndpoints.length === 1) {
       const ipServiceURL = new URI(ideEndpoints[0].url).resolve('che/client-ip').toString();

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-server-common.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-server-common.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-export const SERVER_IDE_ATTR_VALUE = 'ide';
+export const SERVER_MAIN_ATTR_VALUE = 'main';
 export const SERVER_WEBVIEWS_ATTR_VALUE = 'webview';
 export const SERVER_MINI_BROWSER_ATTR_VALUE = 'mini-browser';
 export const SERVER_IDE_DEV_ATTR_VALUE = 'ide-dev';

--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-devfile-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-devfile-service-impl.ts
@@ -94,6 +94,11 @@ export class CheServerDevfileServiceImpl implements DevfileService {
         }
         if (endpointV1.attributes) {
           endpoint.attributes = endpointV1.attributes;
+
+          if (endpoint.attributes['type'] == 'ide') {
+            endpoint.attributes['type'] = 'main';
+          }
+
           if (endpointV1.attributes['public'] !== undefined && endpointV1.attributes['public'] === 'false') {
             endpoint.exposure = 'internal';
           }

--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-devfile-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-devfile-service-impl.ts
@@ -95,7 +95,7 @@ export class CheServerDevfileServiceImpl implements DevfileService {
         if (endpointV1.attributes) {
           endpoint.attributes = endpointV1.attributes;
 
-          if (endpoint.attributes['type'] == 'ide') {
+          if (endpoint.attributes['type'] === 'ide') {
             endpoint.attributes['type'] = 'main';
           }
 

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-endpoint-service-impl.spec.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-endpoint-service-impl.spec.ts
@@ -66,7 +66,7 @@ describe('Test CheServerEndpointServiceImpl', () => {
     const theiaEndpoint = endpoints[0];
     expect(theiaEndpoint.url).toBe('https://route4if6ve1d-che.8a09.starter-us-east-2.openshiftapps.com');
     expect(theiaEndpoint.attributes).toBeDefined();
-    expect(theiaEndpoint.attributes!['type']).toBe('main');
+    expect(theiaEndpoint.attributes!['type']).toBe('ide');
     expect(theiaEndpoint.name).toBe('theia');
     expect(theiaEndpoint.component).toBe('theia-ide9fa');
 

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-endpoint-service-impl.spec.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/node/che-server-endpoint-service-impl.spec.ts
@@ -66,7 +66,7 @@ describe('Test CheServerEndpointServiceImpl', () => {
     const theiaEndpoint = endpoints[0];
     expect(theiaEndpoint.url).toBe('https://route4if6ve1d-che.8a09.starter-us-east-2.openshiftapps.com');
     expect(theiaEndpoint.attributes).toBeDefined();
-    expect(theiaEndpoint.attributes!['type']).toBe('ide');
+    expect(theiaEndpoint.attributes!['type']).toBe('main');
     expect(theiaEndpoint.name).toBe('theia');
     expect(theiaEndpoint.component).toBe('theia-ide9fa');
 

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-devfile-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-devfile-service-impl.ts
@@ -106,7 +106,7 @@ export class K8sDevfileServiceImpl implements DevfileService {
         // endpoint contains something like:
         // - attributes:
         //     controller.devfile.io/endpoint-url: http://workspace1105c7bcbe794da5-theia-3100.192.168.64.53.nip.io
-        //     type: ide
+        //     type: main
         //   exposure: public
         //   name: theia
         //   protocol: http

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/flattened-devfile.yaml
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/flattened-devfile.yaml
@@ -15,7 +15,7 @@ components:
     endpoints:
     - attributes:
         controller.devfile.io/endpoint-url: http://workspace1105c7bcbe794da5-theia-3100.192.168.64.53.nip.io
-        type: ide
+        type: main
       exposure: public
       name: theia
       protocol: http

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/node/k8s-endpoint-service-impl.spec.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/node/k8s-endpoint-service-impl.spec.ts
@@ -43,7 +43,7 @@ describe.only('Test K8sEndpointServiceImpl', () => {
   });
 
   test('getEndpointsByType', async () => {
-    const ideEndpoints = await k8sEndpointServiceImpl.getEndpointsByType('ide');
+    const ideEndpoints = await k8sEndpointServiceImpl.getEndpointsByType('main');
 
     expect(ideEndpoints).toBeDefined();
     expect(ideEndpoints.length).toBe(1);

--- a/extensions/eclipse-che-theia-terminal/src/browser/contribution/exec-terminal-contribution.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/contribution/exec-terminal-contribution.ts
@@ -218,7 +218,7 @@ export class ExecTerminalFrontendContribution extends TerminalFrontendContributi
 
   async getEditorContainerName(): Promise<string | undefined> {
     if (!this.editorContainerName) {
-      const ideComponents = await this.endpointService.getEndpointsByType('ide');
+      const ideComponents = await this.endpointService.getEndpointsByType('main');
       if (ideComponents.length !== 1) {
         throw new Error('Only one endpoint should be of ide type.');
       }


### PR DESCRIPTION
### What does this PR do?
This PR makes Che Theia rely on the main endpoint type instead of deprecated ide.
Ide is still respected since Che Server uses it.

### Screenshot/screencast of this PR
![Screenshot_20210521_180917](https://user-images.githubusercontent.com/5887312/119159193-ace0b880-ba5f-11eb-9144-d62e18e5a82b.png)

### What issues does this PR fix or reference?
it's one piece of many for https://github.com/devfile/devworkspace-operator/issues/399

It should be merged in sync with https://github.com/devfile/devworkspace-operator/issues/399 and https://github.com/eclipse-che/che-plugin-registry/pull/963

### How to test this PR?
1. deploy Che with DevWorkspace enabled.
Note that custom plugin registry and DWO should be deployed from the referenced PRs.
2. Make sure that Theia works without issues, like from master branch.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
