### PR TITLE
Update ubi8 images to the latest nodejs and minimal base images from RHEL8.4

### DIFF
--- a/dockerfiles/theia-dev/docker/ubi8/builder-image-from.dockerfile
+++ b/dockerfiles/theia-dev/docker/ubi8/builder-image-from.dockerfile
@@ -1,2 +1,2 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-12
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-70.1614929178
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-87

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/runtime-from.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/runtime-from.dockerfile
@@ -1,2 +1,2 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.3-291 as runtime
+FROM registry.access.redhat.com/ubi8-minimal:8.4-200 as runtime

--- a/dockerfiles/theia-vsix-installer/docker/ubi8/from.dockerfile
+++ b/dockerfiles/theia-vsix-installer/docker/ubi8/from.dockerfile
@@ -1,2 +1,2 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.3-291 as runtime
+FROM registry.access.redhat.com/ubi8-minimal:8.4-200 as runtime

--- a/dockerfiles/theia/docker/ubi8/build-result-from.dockerfile
+++ b/dockerfiles/theia/docker/ubi8/build-result-from.dockerfile
@@ -1,3 +1,3 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-12
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-70.1614929178 as build-result
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-87 as build-result
 USER root

--- a/dockerfiles/theia/docker/ubi8/runtime-from.dockerfile
+++ b/dockerfiles/theia/docker/ubi8/runtime-from.dockerfile
@@ -1,2 +1,2 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-12
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-70.1614929178 as runtime
+FROM registry.access.redhat.com/ubi8/nodejs-12:1-87 as runtime


### PR DESCRIPTION
This simple PR updates a bunch of base images used for building on RHEL.
Related to https://issues.redhat.com/browse/CRW-1844
![image](https://user-images.githubusercontent.com/227597/119144610-d3c6cc80-ba16-11eb-9de0-c1e07502b2ac.png)