### PR TITLE
fix(convert): When converting devfile v1 to v2, registryUrl attribute is forgotten

### DIFF
--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-devfile-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-devfile-service-impl.ts
@@ -321,6 +321,10 @@ export class CheServerDevfileServiceImpl implements DevfileService {
       if (componentV1.reference) {
         devfileV2Component.plugin.url = componentV1.reference;
       }
+      if (componentV1.registryUrl) {
+        devfileV2Component.plugin.registryUrl = componentV1.registryUrl;
+      }
+
       if (componentV1.cpuLimit) {
         devfileV2Component.plugin.cpuLimit = componentV1.cpuLimit;
       }

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-go-v1.yaml
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-go-v1.yaml
@@ -17,6 +17,7 @@ projects:
 components:
   - type: chePlugin
     id: golang/go/latest
+    registryUrl: https://my-registry.fake
     alias: go-plugin
     memoryLimit: 512Mi
     env:


### PR DESCRIPTION
### What does this PR do?
Devfile v1 is converted internally to devfile V2 to expose new API to plug-ins/extensions but `registryUrl` field was not handled.
Thus, if the editor needs to write the file at some point, this information is removed

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/19829


### How to test this PR?
Look at the unit test (now the field is preserved)

Another manual way : Add a custom component using `registryUrl` field, then starts the workspace, install another plug-in and now look at the updated devfile. New plug-in should be there but also the `registryUrl` should be still there

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next



Change-Id: Ia7dd9aec31f0c6b5326c4d645bfbf4f87ac8e69e
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
