### PR TITLE
feat(library): Adds a new component to be included in dashboard to load plug-ins

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
       "extensions/*",
       "plugins/*",
       "generator",
-      "tools/automation"
+      "tools/*"
     ]
   },
   "prettier": {

--- a/tools/devworkspace-handler/.gitignore
+++ b/tools/devworkspace-handler/.gitignore
@@ -1,0 +1,2 @@
+coverage
+lib

--- a/tools/devworkspace-handler/package.json
+++ b/tools/devworkspace-handler/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@eclipse-che/che-theia-devworkspace-handler",
+  "version": "0.0.1",
+  "private": false,
+  "description": "Handle management of che-theia-plugins and devWorkspace templates",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "prepare": "yarn run clean && yarn run build",
+    "clean": "rimraf lib",
+    "build": "yarn run format && yarn run compile && yarn run lint",
+    "compile": "tsc --project .",
+    "format": "if-env SKIP_FORMAT=true && echo 'skip format check' || prettier --check '{src,tests}/**/*.ts' package.json",
+    "format:fix": "prettier --write '{src,tests}/**/*.ts' package.json",
+    "lint": "if-env SKIP_LINT=true && echo 'skip lint check' || eslint --cache=true --no-error-on-unmatched-pattern=true '{src,tests}/(!model|**)/*.ts'",
+    "lint:fix": "eslint --fix --cache=true --no-error-on-unmatched-pattern=true \"{src,tests}/(!model|**)/*.{ts,tsx}\"",
+    "test": "if-env SKIP_TEST=true && echo 'skip test' || jest --forceExit",
+    "watch": "tsc -w"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/eclipse-che/che-theia.git"
+  },
+  "author": "",
+  "license": "EPL-2.0",
+  "bugs": {
+    "url": "https://github.com/eclipse/che/issues"
+  },
+  "homepage": "https://github.com/eclipse/che-theia/blob/master/tools/devworkspace-handler/README.md",
+  "dependencies": {
+    "@devfile/api": "latest",
+    "axios": "0.21.1",
+    "inversify": "^5.0.1",
+    "js-yaml": "^4.0.0",
+    "jsonc-parser": "^3.0.0",
+    "reflect-metadata": "^0.1.13"
+  },
+  "devDependencies": {
+    "rollup": "^2.44.0"
+  },
+  "jest": {
+    "clearMocks": true,
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx}"
+    ],
+    "coverageDirectory": "coverage",
+    "modulePathIgnorePatterns": [
+      "<rootDir>/lib"
+    ],
+    "preset": "ts-jest"
+  }
+}

--- a/tools/devworkspace-handler/src/api/devfile-che-theia-plugins-resolver.ts
+++ b/tools/devworkspace-handler/src/api/devfile-che-theia-plugins-resolver.ts
@@ -1,0 +1,19 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { DevfileContext } from './devfile-context';
+
+/**
+ * Entry point of the service.
+ * Need to update templates based on the given devfile and repository files
+ */
+export interface DevfileResolver {
+  handle(devfileContext: DevfileContext): Promise<void>;
+}

--- a/tools/devworkspace-handler/src/api/devfile-context.ts
+++ b/tools/devworkspace-handler/src/api/devfile-context.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import { V1alpha2DevWorkspace, V1alpha2DevWorkspaceTemplate } from '@devfile/api';
+
+export enum SidecarPolicy {
+  MERGE_IMAGE = 'mergeImage',
+  USE_DEV_CONTAINER = 'useDevContainer',
+}
+
+/**
+ * Context used on every call to this service to resolve VSIX components to add with their optional sidecar and the vsix installer
+ */
+export interface DevfileContext {
+  // link to the devfile
+  devfileUrl: string;
+
+  // devfile Content
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  devfile: any;
+
+  // .che/che-theia-plugins.yaml content
+  cheTheiaPluginsContent?: string;
+
+  // .vscode/extensions.json content
+  vscodeExtensionsJsonContent?: string;
+
+  // devWorkspace
+  devWorkspace: V1alpha2DevWorkspace;
+
+  // devWorkspace templates
+  devWorkspaceTemplates: V1alpha2DevWorkspaceTemplate[];
+
+  // merge into dev Container
+  sidecarPolicy: SidecarPolicy;
+
+  // suffix to append on generated names
+  suffix: string;
+}

--- a/tools/devworkspace-handler/src/api/vscode-extension-entry.ts
+++ b/tools/devworkspace-handler/src/api/vscode-extension-entry.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainer } from '@devfile/api';
+
+/**
+ * Defines the entry of VS code extension with its extra information like if there is a need for a sidecar image, memory information, etc.
+ */
+export interface VSCodeExtensionEntry {
+  // identifier of the VS Code extension like the one we can have on market place
+  id: string;
+
+  // resolved is set to true only when we have the full definition
+  // for example if there is only the id, then plug-in registry needs to be reached to grab the content
+  resolved: boolean;
+
+  // if the plug-in is not found, we can skip it
+  optional?: boolean;
+
+  // optional preferences for this VS Code extension
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  preferences?: { [key: string]: any };
+
+  // optional dependencies for this VS Code extension
+  dependencies?: string[];
+
+  // optional sidecar information
+  sidecarName?: string;
+  sidecar?: V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainer;
+
+  // URL of vsix files to be installed
+  extensions: string[];
+}
+
+export interface VSCodeExtensionEntryWithSidecar extends VSCodeExtensionEntry {
+  // sidecar is mandatory
+  sidecar: V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainer;
+}

--- a/tools/devworkspace-handler/src/devfile/che-theia-component-finder.ts
+++ b/tools/devworkspace-handler/src/devfile/che-theia-component-finder.ts
@@ -1,0 +1,43 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { DevfileContext } from '../api/devfile-context';
+import { V1alpha2DevWorkspaceSpecTemplateComponents } from '@devfile/api';
+import { injectable } from 'inversify';
+
+/**
+ * Need to find che theia component from main dev workspace or from a template
+ */
+@injectable()
+export class CheTheiaComponentFinder {
+  async find(devfileContext: DevfileContext): Promise<V1alpha2DevWorkspaceSpecTemplateComponents> {
+    // need to find definition
+
+    // first, search in all templates
+    for (const template of devfileContext.devWorkspaceTemplates) {
+      const theiaComponent = template.spec?.components?.find(component => component.name === 'theia-ide');
+      // got one
+      if (theiaComponent) {
+        return theiaComponent;
+      }
+    }
+
+    // then search in main devWorkspace
+    const theiaComponent = devfileContext.devWorkspace.spec?.template?.components?.find(
+      component => component.name === 'theia-ide'
+    );
+    // got one
+    if (theiaComponent) {
+      return theiaComponent;
+    }
+
+    throw new Error('Not able to find theia-ide component in DevWorkspace and its templates');
+  }
+}

--- a/tools/devworkspace-handler/src/devfile/che-theia-component-updater.ts
+++ b/tools/devworkspace-handler/src/devfile/che-theia-component-updater.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+
+import { CheTheiaComponentFinder } from './che-theia-component-finder';
+import { DevfileContext } from '../api/devfile-context';
+import { VSCodeExtensionEntry } from '../api/vscode-extension-entry';
+
+@injectable()
+export class CheTheiaComponentUpdater {
+  @inject(CheTheiaComponentFinder)
+  private cheTheiaComponentFinder: CheTheiaComponentFinder;
+
+  async insert(devfileContext: DevfileContext, cheTheiaExtensions: VSCodeExtensionEntry[]): Promise<void> {
+    // skip stuff if no extensions need to be installed in che-theia component
+    if (cheTheiaExtensions.length === 0) {
+      return;
+    }
+    const theiaComponent = await this.cheTheiaComponentFinder.find(devfileContext);
+
+    // add attributes
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let attributes: any = theiaComponent.attributes;
+    if (!attributes) {
+      attributes = {};
+      theiaComponent.attributes = attributes;
+    }
+
+    // grab list of extensions
+    const cheTheiaVsix = cheTheiaExtensions
+      .map(extension => extension.extensions)
+      .reduce((acc, val) => acc.concat(val), []);
+
+    // grab list of extensions
+    const cheTheiaPreferencesArray = cheTheiaExtensions.map(extension => extension.preferences);
+    const cheTheiaPreferences = Object.assign({}, ...cheTheiaPreferencesArray);
+
+    attributes['che-theia.eclipse.org/vscode-extensions'] = cheTheiaVsix;
+
+    // add preferences only if there are one
+    if (cheTheiaPreferences && Object.keys(cheTheiaPreferences).length > 0) {
+      attributes['che-theia.eclipse.org/vscode-preferences'] = cheTheiaPreferences;
+    }
+  }
+}

--- a/tools/devworkspace-handler/src/devfile/che-theia-plugin-devcontainer-merger.ts
+++ b/tools/devworkspace-handler/src/devfile/che-theia-plugin-devcontainer-merger.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { VSCodeExtensionDevContainer } from './vscode-extension-dev-container';
+import { VSCodeExtensionEntryWithSidecar } from '../api/vscode-extension-entry';
+import { injectable } from 'inversify';
+
+/**
+ * When extensions will run in the dev container, need to aggregate all settings of all extensions like extensions, preferences, volume mounts and endpoints
+ */
+@injectable()
+export class CheTheiaPluginDevContainerMerger {
+  merge(extensionsWithSidecars: VSCodeExtensionEntryWithSidecar[]): VSCodeExtensionDevContainer {
+    const extensions = [
+      ...new Set(
+        extensionsWithSidecars
+          .map(extension => extension.extensions)
+          // flatten the array of array
+          .reduce((acc, val) => acc.concat(val), [])
+      ),
+    ];
+
+    // merge preferences
+    const allPreferences = extensionsWithSidecars
+      .map(extension => extension.preferences || {})
+      .reduce((acc, val) => acc.concat(val), []);
+    const preferences = Object.assign({}, ...allPreferences);
+
+    // all volume mounts
+    const volumeMounts = extensionsWithSidecars
+      .map(extension => extension.sidecar.volumeMounts || [])
+      .reduce((acc, val) => acc.concat(val), []);
+
+    // all endpoints
+    const endpoints = extensionsWithSidecars
+      .map(extension => extension.sidecar.endpoints || [])
+      .reduce((acc, val) => acc.concat(val), []);
+
+    return {
+      extensions,
+      preferences,
+      volumeMounts,
+      endpoints,
+    };
+  }
+}

--- a/tools/devworkspace-handler/src/devfile/che-theia-plugin-sidecar-merger.ts
+++ b/tools/devworkspace-handler/src/devfile/che-theia-plugin-sidecar-merger.ts
@@ -1,0 +1,62 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { VSCodeExtensionEntryWithSidecar } from '../api/vscode-extension-entry';
+import { injectable } from 'inversify';
+
+/**
+ * Reduce the given array of extensions by merging the extensions sharing the same image
+ * For example vscode-java and vscode-java-test have java:latest image, at the end we have an entry with two extensions (java + tests) in a single image (java:latest)
+ */
+
+@injectable()
+export class CheTheiaPluginSidecarMerger {
+  merge(extensionsWithSidecars: VSCodeExtensionEntryWithSidecar[]): VSCodeExtensionEntryWithSidecar[] {
+    // need to merge sidecar if they have the same image
+    // get unique name of images
+    const uniqueImages = [...new Set(extensionsWithSidecars.map(extension => extension.sidecar.image))];
+
+    return uniqueImages.map(imageName => {
+      // get all entires for this image
+      const matchingExtensions = extensionsWithSidecars.filter(extension => extension.sidecar.image === imageName);
+
+      // take sidecar information
+      const sidecar = matchingExtensions[0].sidecar;
+      const sidecarName = matchingExtensions[0].sidecarName;
+
+      const vsixExtensions = matchingExtensions
+        .map(extension => extension.extensions)
+        // flatten the array of array
+        .reduce((acc, val) => acc.concat(val), []);
+
+      const allPreferences = matchingExtensions
+        .map(extension => extension.preferences || {})
+        .reduce((acc, val) => acc.concat(val), []);
+
+      // merge preferences
+      const preferences = Object.assign({}, ...allPreferences);
+
+      const dependencies = matchingExtensions
+        .map(extension => extension.dependencies || [])
+        .reduce((acc, val) => acc.concat(val), []);
+
+      return {
+        id: `merged-${imageName}`,
+        resolved: true,
+        optional: false,
+        preferences,
+        dependencies,
+        sidecarName,
+        sidecar,
+        extensions: vsixExtensions,
+      };
+    });
+  }
+}

--- a/tools/devworkspace-handler/src/devfile/che-theia-plugins-analyzer.ts
+++ b/tools/devworkspace-handler/src/devfile/che-theia-plugins-analyzer.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as jsYaml from 'js-yaml';
+
+import { VSCodeExtensionEntry } from '../api/vscode-extension-entry';
+import { injectable } from 'inversify';
+
+/**
+ * This class needs to analyze the content of a local .che/che-theia-plugins.yaml file and grab different ids and optional parameters
+ */
+@injectable()
+export class CheTheiaPluginsAnalyzer {
+  async extractPlugins(cheTheiaPluginsYamlContent: string): Promise<VSCodeExtensionEntry[]> {
+    // it's a yaml so convert it !
+    const cheTheiaPluginsYamlInRepository = jsYaml.load(cheTheiaPluginsYamlContent);
+
+    // only format supported right now is list of ids as for example:
+    // - id: redhat/java8/latest
+
+    if (cheTheiaPluginsYamlInRepository && Array.isArray(cheTheiaPluginsYamlInRepository)) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return cheTheiaPluginsYamlInRepository.map(entry => ({
+        id: entry.id,
+        resolved: false,
+        extensions: [],
+      }));
+    }
+
+    // not able to really see the content, return something empty
+    return [];
+  }
+}

--- a/tools/devworkspace-handler/src/devfile/che-theia-plugins-devfile-resolver.ts
+++ b/tools/devworkspace-handler/src/devfile/che-theia-plugins-devfile-resolver.ts
@@ -1,0 +1,129 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { VSCodeExtensionEntry, VSCodeExtensionEntryWithSidecar } from '../api/vscode-extension-entry';
+import { inject, injectable } from 'inversify';
+
+import { CheTheiaPluginDevContainerMerger } from './che-theia-plugin-devcontainer-merger';
+import { CheTheiaPluginSidecarMerger } from './che-theia-plugin-sidecar-merger';
+import { CheTheiaPluginsAnalyzer } from './che-theia-plugins-analyzer';
+import { DevWorkspaceUpdater } from './devworkspace-updater';
+import { DevfileContext } from '../api/devfile-context';
+import { DevfileResolver } from '../api/devfile-che-theia-plugins-resolver';
+import { PluginRegistryResolver } from '../plugin-registry/plugin-registry-resolver';
+import { VSCodeExtensionDevContainer } from './vscode-extension-dev-container';
+import { VscodeExtensionJsonAnalyzer } from './vscode-extension-json-analyzer';
+
+/**
+ * This class handle the che-theia-plugins attribute from within a devfile.
+ * It will provide a set of set of DevWorkspace Templates and a map of attributes to add on some components.
+ * New templates will be the optional 'sidecar' components, vsix downloader and extra map will contain for example the vscode extensions to add on che-theia IDE
+ */
+@injectable()
+export class CheTheiaPluginsDevfileResolver implements DevfileResolver {
+  @inject(VscodeExtensionJsonAnalyzer)
+  private vscodeExtensionJsonAnalyzer: VscodeExtensionJsonAnalyzer;
+
+  @inject(CheTheiaPluginsAnalyzer)
+  private cheTheiaPluginsAnalyzer: CheTheiaPluginsAnalyzer;
+
+  @inject(PluginRegistryResolver)
+  private pluginRegistryResolver: PluginRegistryResolver;
+
+  @inject(DevWorkspaceUpdater)
+  private devWorkspaceUpdater: DevWorkspaceUpdater;
+
+  @inject(CheTheiaPluginSidecarMerger)
+  private cheTheiaPluginSidecarMerger: CheTheiaPluginSidecarMerger;
+
+  @inject(CheTheiaPluginDevContainerMerger)
+  private cheTheiaPluginDevContainerMerger: CheTheiaPluginDevContainerMerger;
+
+  async handle(devfileContext: DevfileContext): Promise<void> {
+    let cheTheiaPluginsYamlContent = devfileContext.cheTheiaPluginsContent;
+    let vscodeExtensionJsonContent = devfileContext.vscodeExtensionsJsonContent;
+
+    if (!vscodeExtensionJsonContent) {
+      vscodeExtensionJsonContent = devfileContext.devfile.attributes?.['.vscode/extensions.json'];
+    }
+
+    if (!cheTheiaPluginsYamlContent) {
+      cheTheiaPluginsYamlContent = devfileContext.devfile.attributes?.['.che/che-theia-plugins.yaml'];
+    }
+
+    // no content, skip
+    if (!cheTheiaPluginsYamlContent && !vscodeExtensionJsonContent) {
+      return;
+    }
+
+    // we do have '.vscode/extensions.json' file, grab plug-ins from there.
+    let vscodeExtensions: VSCodeExtensionEntry[] = [];
+    if (vscodeExtensionJsonContent) {
+      vscodeExtensions = await this.vscodeExtensionJsonAnalyzer.extractPlugins(vscodeExtensionJsonContent);
+    }
+
+    let cheTheiaPlugins: VSCodeExtensionEntry[] = [];
+    if (cheTheiaPluginsYamlContent) {
+      cheTheiaPlugins = await this.cheTheiaPluginsAnalyzer.extractPlugins(cheTheiaPluginsYamlContent);
+    }
+
+    // now, need to merge
+    // if defined in both vscode/extensions.json and che-theia-plugins.yaml file, che-theia-plugins.yaml is winning
+    // if not defined, add definition from where it is defined
+
+    // filter out extensions already defined in che-theia-plugins.yaml files
+    const allExtensions = cheTheiaPlugins.concat(
+      vscodeExtensions.filter(extension => !cheTheiaPlugins.find(cheTheiaPlugin => cheTheiaPlugin.id === extension.id))
+    );
+
+    // unique extensions
+    const uniqueExtensions = [...new Set(allExtensions)];
+
+    // resolve the given set of extensions (if needed) by grabbing definition using plug-in registry
+    await this.pluginRegistryResolver.resolve(uniqueExtensions);
+
+    // now we do have definition of all extensions that we want to add into Theia and their optional sidecars for these plug-ins.
+
+    // grab a list of VS Code extensions to install on main che-theia instance (no sidecar)
+    const cheTheiaExtensions = uniqueExtensions
+      // get only extensions without sidecars
+      .filter(entry => !entry.sidecar);
+
+    // grab a list of extensions with sidecars
+    const allExtensionsWithSidecars = uniqueExtensions
+      .filter(entry => entry.sidecar)
+      .map(entry => entry as VSCodeExtensionEntryWithSidecar);
+
+    // do we need to change the sidecar and use a dev container instead ?
+    // if need to use user container, we'll need to update an existing component with the following data
+
+    let extensionsWithSidecars: VSCodeExtensionEntryWithSidecar[] = [];
+
+    // for dev container merge, we unify all extensions into a single sidecar and then we'll apply all settings except the image
+    let extensionsForDevContainer: VSCodeExtensionDevContainer | undefined;
+
+    switch (devfileContext.sidecarPolicy) {
+      case 'mergeImage':
+        extensionsWithSidecars = this.cheTheiaPluginSidecarMerger.merge(allExtensionsWithSidecars);
+        break;
+      case 'useDevContainer':
+        extensionsForDevContainer = this.cheTheiaPluginDevContainerMerger.merge(allExtensionsWithSidecars);
+        break;
+    }
+
+    // ok now we're ready to add the vsix on che-theia component, add component sidecars(if any) and vsix installer component, etc.
+    await this.devWorkspaceUpdater.update(
+      devfileContext,
+      cheTheiaExtensions,
+      extensionsWithSidecars,
+      extensionsForDevContainer
+    );
+  }
+}

--- a/tools/devworkspace-handler/src/devfile/container-plugin-remote-updater.ts
+++ b/tools/devworkspace-handler/src/devfile/container-plugin-remote-updater.ts
@@ -1,0 +1,46 @@
+/**********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainer } from '@devfile/api';
+import { injectable } from 'inversify';
+
+@injectable()
+export class ContainerPluginRemoteUpdater {
+  update(componentName: string, container: V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainer): void {
+    let env = container.env;
+    if (!env) {
+      env = [];
+      container.env = env;
+    }
+    env.push({
+      name: 'PLUGIN_REMOTE_ENDPOINT_EXECUTABLE',
+      value: '/remote-endpoint/plugin-remote-endpoint',
+    });
+    env.push({
+      name: 'THEIA_PLUGINS',
+      value: `local-dir:///plugins/sidecars/${componentName}`,
+    });
+
+    // next, the volumes
+    let volumeMounts = container.volumeMounts;
+    if (!volumeMounts) {
+      volumeMounts = [];
+      container.volumeMounts = volumeMounts;
+    }
+    volumeMounts.push({
+      path: '/remote-endpoint',
+      name: 'remote-endpoint',
+    });
+    volumeMounts.push({
+      path: '/plugins',
+      name: 'plugins',
+    });
+  }
+}

--- a/tools/devworkspace-handler/src/devfile/dev-container-component-finder.ts
+++ b/tools/devworkspace-handler/src/devfile/dev-container-component-finder.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { DevfileContext } from '../api/devfile-context';
+import { V1alpha2DevWorkspaceSpecTemplateComponents } from '@devfile/api';
+import { injectable } from 'inversify';
+
+/**
+ * Need to find dev container from main dev workspace or from a template
+ */
+@injectable()
+export class DevContainerComponentFinder {
+  async find(devfileContext: DevfileContext): Promise<V1alpha2DevWorkspaceSpecTemplateComponents> {
+    // need to find definition
+
+    // search in main devWorkspace (exclude theia as component name)
+    const devComponents = devfileContext.devWorkspace.spec?.template?.components?.filter(
+      component => component.container && component.name !== 'theia-ide'
+    );
+    // only one, fine, else error
+    if (!devComponents || devComponents.length === 0) {
+      throw new Error('Not able to find any dev container component in DevWorkspace');
+    } else if (devComponents.length === 1) {
+      return devComponents[0];
+    } else {
+      throw new Error(
+        `Too many components have been found that could be considered as dev container. There should be only one to merge sidecars. Found component names: ${devComponents.map(
+          component => component.name
+        )}`
+      );
+    }
+  }
+}

--- a/tools/devworkspace-handler/src/devfile/dev-container-component-updater.ts
+++ b/tools/devworkspace-handler/src/devfile/dev-container-component-updater.ts
@@ -1,0 +1,95 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+
+import { ContainerPluginRemoteUpdater } from './container-plugin-remote-updater';
+import { DevContainerComponentFinder } from './dev-container-component-finder';
+import { DevfileContext } from '../api/devfile-context';
+import { VSCodeExtensionDevContainer } from './vscode-extension-dev-container';
+
+/**
+ * Apply to the DevWorkspace component the information specified in a given DevContainer struct like preferences/extensions/endpoints, etc.
+ */
+@injectable()
+export class DevContainerComponentUpdater {
+  @inject(DevContainerComponentFinder)
+  private devContainerComponentFinder: DevContainerComponentFinder;
+
+  @inject(ContainerPluginRemoteUpdater)
+  private containerPluginRemoteUpdater: ContainerPluginRemoteUpdater;
+
+  async insert(
+    devfileContext: DevfileContext,
+    vSCodeExtensionDevContainer: VSCodeExtensionDevContainer
+  ): Promise<void> {
+    const devContainerComponent = await this.devContainerComponentFinder.find(devfileContext);
+
+    const devContainer = devContainerComponent.container;
+    if (!devContainer) {
+      throw new Error('The dev container should be a component with type "container".');
+    }
+
+    // add attributes
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let attributes: any = devContainerComponent.attributes;
+    if (!attributes) {
+      attributes = {};
+      devContainerComponent.attributes = attributes;
+    }
+
+    // extensions
+    attributes['che-theia.eclipse.org/vscode-extensions'] = vSCodeExtensionDevContainer.extensions;
+
+    // add preferences only if there are one
+    if (vSCodeExtensionDevContainer.preferences && Object.keys(vSCodeExtensionDevContainer.preferences).length > 0) {
+      attributes['che-theia.eclipse.org/vscode-preferences'] = vSCodeExtensionDevContainer.preferences;
+    }
+
+    attributes['app.kubernetes.io/name'] = devContainerComponent.name;
+    // no endpoints ? initialize empty array
+    if (!devContainer.endpoints) {
+      devContainer.endpoints = [];
+    }
+    const toInsertEndpoints = vSCodeExtensionDevContainer.endpoints || [];
+    devContainer.endpoints.push(...toInsertEndpoints);
+
+    // no env ? initialize empty array
+    if (!devContainer.env) {
+      devContainer.env = [];
+    }
+    const toInsertEnvs = vSCodeExtensionDevContainer.env || [];
+    devContainer.env.push(...toInsertEnvs);
+
+    // no volumeMounts ? initialize empty array
+    const devContainerVolumes = devContainer.volumeMounts || [];
+    devContainer.volumeMounts = devContainerVolumes;
+
+    // pick up only volumes that are not already defined
+    const toInsertVolumeMounts = (vSCodeExtensionDevContainer.volumeMounts || []).filter(
+      volume => !devContainerVolumes.some(containerVolume => containerVolume.name === volume.name)
+    );
+    devContainer.volumeMounts.push(...toInsertVolumeMounts);
+
+    // need to tweak the entrypoint to call the ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
+    devContainer.args = ['sh', '-c', '${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}'];
+
+    // now, need to add the common stuff
+    this.containerPluginRemoteUpdater.update(devContainerComponent.name, devContainer);
+
+    if (devContainer.endpoints.length === 0) {
+      delete devContainer.endpoints;
+    }
+
+    if (devContainer.volumeMounts.length === 0) {
+      delete devContainer.volumeMounts;
+    }
+  }
+}

--- a/tools/devworkspace-handler/src/devfile/devfile-module.ts
+++ b/tools/devworkspace-handler/src/devfile/devfile-module.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import { ContainerModule, interfaces } from 'inversify';
+
+import { CheTheiaComponentFinder } from './che-theia-component-finder';
+import { CheTheiaComponentUpdater } from './che-theia-component-updater';
+import { CheTheiaPluginDevContainerMerger } from './che-theia-plugin-devcontainer-merger';
+import { CheTheiaPluginSidecarMerger } from './che-theia-plugin-sidecar-merger';
+import { CheTheiaPluginsAnalyzer } from './che-theia-plugins-analyzer';
+import { CheTheiaPluginsDevfileResolver } from './che-theia-plugins-devfile-resolver';
+import { ContainerPluginRemoteUpdater } from './container-plugin-remote-updater';
+import { DevContainerComponentFinder } from './dev-container-component-finder';
+import { DevContainerComponentUpdater } from './dev-container-component-updater';
+import { DevWorkspaceUpdater } from './devworkspace-updater';
+import { SidecarComponentsCreator } from './sidecar-components-creator';
+import { VscodeExtensionJsonAnalyzer } from './vscode-extension-json-analyzer';
+
+const devfileModule = new ContainerModule((bind: interfaces.Bind) => {
+  bind(CheTheiaComponentFinder).toSelf().inSingletonScope();
+  bind(CheTheiaComponentUpdater).toSelf().inSingletonScope();
+  bind(CheTheiaPluginDevContainerMerger).toSelf().inSingletonScope();
+  bind(CheTheiaPluginSidecarMerger).toSelf().inSingletonScope();
+  bind(ContainerPluginRemoteUpdater).toSelf().inSingletonScope();
+  bind(DevContainerComponentFinder).toSelf().inSingletonScope();
+  bind(DevContainerComponentUpdater).toSelf().inSingletonScope();
+  bind(CheTheiaPluginsDevfileResolver).toSelf().inSingletonScope();
+  bind(DevWorkspaceUpdater).toSelf().inSingletonScope();
+  bind(SidecarComponentsCreator).toSelf().inSingletonScope();
+  bind(CheTheiaPluginsAnalyzer).toSelf().inSingletonScope();
+  bind(VscodeExtensionJsonAnalyzer).toSelf().inSingletonScope();
+});
+
+export { devfileModule };

--- a/tools/devworkspace-handler/src/devfile/devworkspace-updater.ts
+++ b/tools/devworkspace-handler/src/devfile/devworkspace-updater.ts
@@ -1,0 +1,96 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { VSCodeExtensionEntry, VSCodeExtensionEntryWithSidecar } from '../api/vscode-extension-entry';
+import { inject, injectable, named } from 'inversify';
+
+import { CheTheiaComponentUpdater } from './che-theia-component-updater';
+import { DevContainerComponentUpdater } from './dev-container-component-updater';
+import { DevfileContext } from '../api/devfile-context';
+import { SidecarComponentsCreator } from './sidecar-components-creator';
+import { VSCodeExtensionDevContainer } from './vscode-extension-dev-container';
+import { VsixInstallerComponentUpdater } from '../vsix-installer/vsix-installer-component-updater';
+
+/**
+ * This class is responsible to:
+ *  - add annotations about vsix files to add on che-theia component
+ *  - add sidecar components + their vsix files
+ *  - add vsix installer component
+ */
+@injectable()
+export class DevWorkspaceUpdater {
+  @inject(SidecarComponentsCreator)
+  private sidecarComponentsCreator: SidecarComponentsCreator;
+
+  @inject(CheTheiaComponentUpdater)
+  private cheTheiaComponentUpdater: CheTheiaComponentUpdater;
+
+  @inject(DevContainerComponentUpdater)
+  private devContainerComponentUpdater: DevContainerComponentUpdater;
+
+  @inject(VsixInstallerComponentUpdater)
+  private vsixInstallerComponentUpdater: VsixInstallerComponentUpdater;
+
+  @inject('boolean')
+  @named('INSERT_TEMPLATES')
+  private insertTemplates: boolean;
+
+  async update(
+    devfileContext: DevfileContext,
+    cheTheiaExtensions: VSCodeExtensionEntry[],
+    extensionsWithSidecars: VSCodeExtensionEntryWithSidecar[],
+    extensionsForDevContainer: VSCodeExtensionDevContainer | undefined
+  ): Promise<void> {
+    if (!devfileContext.devWorkspace.spec?.template) {
+      throw new Error('Can update a dev workspace only if there is a template in spec object');
+    }
+
+    const components = devfileContext.devWorkspace.spec.template.components || [];
+    if (!devfileContext.devWorkspace.spec.template.components) {
+      devfileContext.devWorkspace.spec.template.components = components;
+    }
+
+    // add the vsix installer
+    await this.vsixInstallerComponentUpdater.add(devfileContext);
+
+    // need to add the kubernetes plug-in in the devWorkspace object
+    if (this.insertTemplates) {
+      devfileContext.devWorkspaceTemplates.map(template => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const name = (template.metadata as any)?.name;
+        if (!name) {
+          throw new Error(`No name found for the template ${JSON.stringify(template, undefined, 2)}.`);
+        }
+        components.push({
+          name,
+          plugin: {
+            kubernetes: {
+              name,
+            },
+          },
+        });
+      });
+    }
+
+    // first, update theia component to add the vsix URLS, preferences, etc
+    this.cheTheiaComponentUpdater.insert(devfileContext, cheTheiaExtensions);
+
+    // then, generate sidecar components to add (if any)
+    const componentsToAdd = await this.sidecarComponentsCreator.create(extensionsWithSidecars);
+
+    // finally, update dev container component with extensions to be deployed there
+    if (extensionsForDevContainer) {
+      this.devContainerComponentUpdater.insert(devfileContext, extensionsForDevContainer);
+    }
+
+    // and add them
+    devfileContext.devWorkspace.spec.template.components.push(...componentsToAdd);
+  }
+}

--- a/tools/devworkspace-handler/src/devfile/sidecar-components-creator.ts
+++ b/tools/devworkspace-handler/src/devfile/sidecar-components-creator.ts
@@ -1,0 +1,54 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+
+import { ContainerPluginRemoteUpdater } from './container-plugin-remote-updater';
+import { V1alpha2DevWorkspaceSpecTemplateComponents } from '@devfile/api';
+import { VSCodeExtensionEntryWithSidecar } from '../api/vscode-extension-entry';
+
+/**
+ * Generate spec template components for every sidecar of plug-ins
+ */
+@injectable()
+export class SidecarComponentsCreator {
+  @inject(ContainerPluginRemoteUpdater)
+  private containerPluginRemoteUpdater: ContainerPluginRemoteUpdater;
+
+  async create(
+    extensionsWithSidecars: VSCodeExtensionEntryWithSidecar[]
+  ): Promise<V1alpha2DevWorkspaceSpecTemplateComponents[]> {
+    // ok now add sidecar components
+    return extensionsWithSidecars.map(entry => {
+      const sidecarName = entry.sidecarName || `sidecar-${entry.id.replace(/[^\w\s]/gi, '-')}`;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const attributes: { [key: string]: any } = {
+        'app.kubernetes.io/part-of': 'che-theia.eclipse.org',
+        'app.kubernetes.io/component': 'vscode-extension',
+        'che-theia.eclipse.org/vscode-extensions': entry.extensions,
+      };
+
+      // add preferences only if there are one
+      if (entry.preferences && Object.keys(entry.preferences).length > 0) {
+        attributes['che-theia.eclipse.org/vscode-preferences'] = entry.preferences;
+      }
+
+      const component = {
+        name: sidecarName,
+        attributes,
+        container: entry.sidecar,
+      };
+
+      // add extra stuff
+      this.containerPluginRemoteUpdater.update(sidecarName, component.container);
+      return component as V1alpha2DevWorkspaceSpecTemplateComponents;
+    });
+  }
+}

--- a/tools/devworkspace-handler/src/devfile/vscode-extension-dev-container.ts
+++ b/tools/devworkspace-handler/src/devfile/vscode-extension-dev-container.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import {
+  V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainerEndpoints,
+  V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainerEnv,
+  V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainerVolumeMounts,
+} from '@devfile/api';
+
+/**
+ * Information to add in a dev container.
+ */
+export interface VSCodeExtensionDevContainer {
+  // optional preferences for this VS Code extension
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  preferences?: { [key: string]: any };
+
+  // extra volume mounts to add
+  volumeMounts?: Array<V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainerVolumeMounts>;
+
+  endpoints?: Array<V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainerEndpoints>;
+
+  // extra volume mounts to add
+  env?: Array<V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainerEnv>;
+
+  // extensions
+  extensions: string[];
+}

--- a/tools/devworkspace-handler/src/devfile/vscode-extension-json-analyzer.ts
+++ b/tools/devworkspace-handler/src/devfile/vscode-extension-json-analyzer.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as jsoncparser from 'jsonc-parser';
+
+import { VSCodeExtensionEntry } from '../api/vscode-extension-entry';
+import { injectable } from 'inversify';
+
+/**
+ * This class manages extraction of VS Code extensions id from the .vscode/extensions.json file content
+ * All extensions are optional, meaning that if the plug-in registry does not contain them, it won't fail
+ */
+@injectable()
+export class VscodeExtensionJsonAnalyzer {
+  async extractPlugins(vscodeExtensionsJsonContent: string): Promise<VSCodeExtensionEntry[]> {
+    // use of JSONC parser as we have comments in the VS code json file
+    const strippedContent = jsoncparser.stripComments(vscodeExtensionsJsonContent);
+    const vscodeExtensionsJson = jsoncparser.parse(strippedContent);
+    // no recommendations or invalid entry
+    if (!vscodeExtensionsJson?.recommendations) {
+      return [];
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return vscodeExtensionsJson.recommendations.map((recommendation: string) => ({
+      id: `${recommendation.replace(/\./g, '/')}/latest`.toLocaleLowerCase(),
+      resolved: false,
+      optional: true,
+      extensions: [],
+    }));
+  }
+}

--- a/tools/devworkspace-handler/src/entrypoint.ts
+++ b/tools/devworkspace-handler/src/entrypoint.ts
@@ -1,0 +1,21 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import 'reflect-metadata';
+
+import { Main } from './main';
+
+(async (): Promise<void> => {
+  const main = new Main();
+  const success = await main.start();
+  if (!success) {
+    process.exit(1);
+  }
+})();

--- a/tools/devworkspace-handler/src/fetch/fetch-module.ts
+++ b/tools/devworkspace-handler/src/fetch/fetch-module.ts
@@ -1,0 +1,18 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import { ContainerModule, interfaces } from 'inversify';
+
+import { UrlFetcher } from './url-fetcher';
+
+const fetchModule = new ContainerModule((bind: interfaces.Bind) => {
+  bind(UrlFetcher).toSelf().inSingletonScope();
+});
+
+export { fetchModule };

--- a/tools/devworkspace-handler/src/fetch/url-fetcher.ts
+++ b/tools/devworkspace-handler/src/fetch/url-fetcher.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import { inject, injectable } from 'inversify';
+
+import { AxiosInstance } from 'axios';
+
+/**
+ * Allow to grab external content
+ * if browser support is enabled, it will update URLs to make them work on browser side.
+ */
+@injectable()
+export class UrlFetcher {
+  // Can't use AxiosInstance interface there
+  @inject(Symbol.for('AxiosInstance'))
+  private axiosInstance: AxiosInstance;
+
+  // fetch content optionally, if the URL is not found, we return undefined without throwing errors
+  async fetchTextOptionalContent(url: string): Promise<string | undefined> {
+    try {
+      const response = await this.axiosInstance.get<string>(url, {
+        responseType: 'text',
+      });
+      return response.data;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      // not found then we return undefined
+      if (error.response && error.response.status === 404) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  // fetch content
+  async fetchText(url: string): Promise<string> {
+    const response = await this.axiosInstance.get<string>(url, {
+      responseType: 'text',
+    });
+    return response.data;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }
+}

--- a/tools/devworkspace-handler/src/generate.ts
+++ b/tools/devworkspace-handler/src/generate.ts
@@ -1,0 +1,114 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import 'reflect-metadata';
+
+import * as fs from 'fs-extra';
+import * as jsYaml from 'js-yaml';
+
+import { V1alpha2DevWorkspace, V1alpha2DevWorkspaceTemplate, V1alpha2DevWorkspaceTemplateSpec } from '@devfile/api';
+import { inject, injectable } from 'inversify';
+
+import { CheTheiaPluginsDevfileResolver } from './devfile/che-theia-plugins-devfile-resolver';
+import { GithubResolver } from './github/github-resolver';
+import { PluginRegistryResolver } from './plugin-registry/plugin-registry-resolver';
+import { SidecarPolicy } from './api/devfile-context';
+import { UrlFetcher } from './fetch/url-fetcher';
+
+@injectable()
+export class Generate {
+  @inject(UrlFetcher)
+  private urlFetcher: UrlFetcher;
+
+  @inject(CheTheiaPluginsDevfileResolver)
+  private cheTheiaPluginsDevfileResolver: CheTheiaPluginsDevfileResolver;
+
+  @inject(PluginRegistryResolver)
+  private pluginRegistryResolver: PluginRegistryResolver;
+
+  @inject(GithubResolver)
+  private githubResolver: GithubResolver;
+
+  async generate(
+    devfileUrl: string,
+    editorEntry: string,
+    sidecarPolicy: SidecarPolicy,
+    outputFile: string
+  ): Promise<void> {
+    // gets the github URL
+    const githubUrl = this.githubResolver.resolve(devfileUrl);
+
+    // user devfile
+    const userDevfileContent = await this.urlFetcher.fetchText(githubUrl.getContentUrl('devfile.yaml'));
+    const devfile = jsYaml.load(userDevfileContent);
+    // sets the suffix to the devfile name
+    const suffix = devfile.metadata.name || '';
+
+    // devfile of the editor
+    const editorDevfile = await this.pluginRegistryResolver.loadDevfilePlugin(editorEntry);
+
+    // transform it into a devWorkspace template
+    const metadata = editorDevfile.metadata;
+    // add sufix
+    metadata.name = `${metadata.name}-${suffix}`;
+    delete editorDevfile.metadata;
+    delete editorDevfile.schemaVersion;
+    const editorDevWorkspaceTemplate: V1alpha2DevWorkspaceTemplate = {
+      apiVersion: 'workspace.devfile.io/v1alpha2',
+      kind: 'DevWorkspaceTemplate',
+      metadata,
+      spec: editorDevfile as V1alpha2DevWorkspaceTemplateSpec,
+    };
+
+    // grab the content of the .vscode/extensions.json and .che/che-theia-plugins.yaml files
+    const vscodeExtensionsJsonContent = await this.urlFetcher.fetchTextOptionalContent(
+      githubUrl.getContentUrl('.vscode/extensions.json')
+    );
+    const cheTheiaPluginsContent = await this.urlFetcher.fetchTextOptionalContent(
+      githubUrl.getContentUrl('.che/che-theia-plugins.yaml')
+    );
+
+    // transform it into a devWorkspace
+    const devfileMetadata = devfile.metadata;
+
+    delete devfile.schemaVersion;
+    delete devfile.metadata;
+    const devWorkspace: V1alpha2DevWorkspace = {
+      apiVersion: 'workspace.devfile.io/v1alpha2',
+      kind: 'DevWorkspace',
+      metadata: devfileMetadata,
+      spec: {
+        started: true,
+        template: devfile,
+      },
+    };
+
+    // for now the list of devWorkspace templates is only the editor template
+    const devWorkspaceTemplates = [editorDevWorkspaceTemplate];
+
+    await this.cheTheiaPluginsDevfileResolver.handle({
+      devfileUrl,
+      devfile: userDevfileContent,
+      vscodeExtensionsJsonContent,
+      cheTheiaPluginsContent,
+      devWorkspace,
+      devWorkspaceTemplates,
+      sidecarPolicy,
+      suffix,
+    });
+
+    // write templates and then DevWorkspace in a single file
+    const allContentArray = devWorkspaceTemplates.map(template => jsYaml.dump(template));
+    allContentArray.push(jsYaml.dump(devWorkspace));
+
+    const generatedContent = allContentArray.join('---\n');
+
+    await fs.writeFile(outputFile, generatedContent, 'utf-8');
+  }
+}

--- a/tools/devworkspace-handler/src/github/github-module.ts
+++ b/tools/devworkspace-handler/src/github/github-module.ts
@@ -1,0 +1,18 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import { ContainerModule, interfaces } from 'inversify';
+
+import { GithubResolver } from './github-resolver';
+
+const githubModule = new ContainerModule((bind: interfaces.Bind) => {
+  bind(GithubResolver).toSelf().inSingletonScope();
+});
+
+export { githubModule };

--- a/tools/devworkspace-handler/src/github/github-resolver.ts
+++ b/tools/devworkspace-handler/src/github/github-resolver.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { GithubUrl } from './github-url';
+import { injectable } from 'inversify';
+
+/**
+ * Providing a github URL it provides a github URL object allowing to interact
+ */
+@injectable()
+export class GithubResolver {
+  // eslint-disable-next-line max-len
+  static readonly GITHUB_URL_PATTERN = /^(?:http)(?:s)?(?:\:\/\/)github\.com\/(?<repoUser>[^\/]+)\/(?<repoName>[^\/]+)((\/)|(?:\/(blob|tree)\/(?<branchName>[^\/]+)(?:\/(?<subFolder>.*))?))?$/;
+
+  resolve(link: string): GithubUrl {
+    const match = GithubResolver.GITHUB_URL_PATTERN.exec(link);
+    if (!match) {
+      throw new Error(`Invalid github URL: ${link}`);
+    }
+    const repoUser = this.getGroup(match, 'repoUser');
+    const repoName = this.getGroup(match, 'repoName');
+    const branchName = this.getGroup(match, 'branchName', 'HEAD');
+    const subFolder = this.getGroup(match, 'subFolder');
+    return new GithubUrl(repoUser, repoName, branchName, subFolder);
+  }
+
+  getGroup(match: RegExpExecArray, groupName: string, defaultValue?: string) {
+    if (match.groups && match.groups[groupName]) {
+      return match.groups[groupName];
+    }
+    return defaultValue || '';
+  }
+}

--- a/tools/devworkspace-handler/src/github/github-url.ts
+++ b/tools/devworkspace-handler/src/github/github-url.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/**
+ * Provides helper methods on top of github URL to get for example raw content of get relative links
+ */
+export class GithubUrl {
+  // raw link
+  static readonly RAW_LINK = 'https://raw.githubusercontent.com';
+
+  constructor(
+    private readonly repoUser: string,
+    private readonly repoName: string,
+    private readonly branchName: string,
+    private readonly subFolder: string
+  ) {}
+
+  /**
+   * Provides the raw link to the given path based on the current repository information
+   */
+  getContentUrl(path: string): string {
+    return `${GithubUrl.RAW_LINK}/${this.repoUser}/${this.repoName}/${this.branchName}/${path}`;
+  }
+
+  getUrl(): string {
+    return `https://github.com/${this.repoUser}/${this.repoName}/tree/${this.branchName}/${this.subFolder}`;
+  }
+}

--- a/tools/devworkspace-handler/src/inversify/inversify-binding.ts
+++ b/tools/devworkspace-handler/src/inversify/inversify-binding.ts
@@ -1,0 +1,45 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import 'reflect-metadata';
+
+import { AxiosInstance } from 'axios';
+import { Container } from 'inversify';
+import { devfileModule } from '../devfile/devfile-module';
+import { fetchModule } from '../fetch/fetch-module';
+import { githubModule } from '../github/github-module';
+import { pluginRegistryModule } from '../plugin-registry/plugin-registry-module';
+import { vsixInstallerModule } from '../vsix-installer/vsix-installer-module';
+
+export interface InversifyBindingOptions {
+  pluginRegistryUrl: string;
+  axiosInstance: AxiosInstance;
+  insertTemplates: boolean;
+}
+/**
+ * Manage all bindings for inversify
+ */
+export class InversifyBinding {
+  private container: Container;
+
+  public async initBindings(options: InversifyBindingOptions): Promise<Container> {
+    this.container = new Container();
+    this.container.load(devfileModule);
+    this.container.load(fetchModule);
+    this.container.load(githubModule);
+    this.container.load(pluginRegistryModule);
+    this.container.load(vsixInstallerModule);
+
+    this.container.bind(Symbol.for('AxiosInstance')).toConstantValue(options.axiosInstance);
+    this.container.bind('string').toConstantValue(options.pluginRegistryUrl).whenTargetNamed('PLUGIN_REGISTRY_URL');
+    this.container.bind('boolean').toConstantValue(options.insertTemplates).whenTargetNamed('INSERT_TEMPLATES');
+
+    return this.container;
+  }
+}

--- a/tools/devworkspace-handler/src/main.ts
+++ b/tools/devworkspace-handler/src/main.ts
@@ -1,0 +1,93 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as axios from 'axios';
+
+import { Generate } from './generate';
+import { InversifyBinding } from './inversify/inversify-binding';
+import { SidecarPolicy } from './api/devfile-context';
+
+export class Main {
+  protected async doStart(): Promise<void> {
+    let devfileUrl: string | undefined;
+    let outputFile: string | undefined;
+    let pluginRegistryUrl: string | undefined;
+    let editor: string | undefined;
+    let sidecarPolicy: SidecarPolicy | undefined;
+    const args = process.argv.slice(2);
+    args.forEach(arg => {
+      if (arg.startsWith('--devfile-url:')) {
+        devfileUrl = arg.substring('--devfile-url:'.length);
+      }
+      if (arg.startsWith('--plugin-registry-url:')) {
+        pluginRegistryUrl = arg.substring('--plugin-registry-url:'.length);
+      }
+      if (arg.startsWith('--editor:')) {
+        editor = arg.substring('--editor:'.length);
+      }
+      if (arg.startsWith('--output-file:')) {
+        outputFile = arg.substring('--output-file:'.length);
+      }
+      if (arg.startsWith('--sidecar-policy:')) {
+        const policy = arg.substring('--sidecar-policy:'.length);
+        if (policy === SidecarPolicy.MERGE_IMAGE.toString()) {
+          sidecarPolicy = SidecarPolicy.MERGE_IMAGE;
+        } else if (policy === SidecarPolicy.USE_DEV_CONTAINER.toString()) {
+          sidecarPolicy = SidecarPolicy.USE_DEV_CONTAINER;
+        } else {
+          throw new Error(
+            `${policy} is not a valid sidecar policy. Available values are ${Object.values(SidecarPolicy)}`
+          );
+        }
+      }
+    });
+    if (!pluginRegistryUrl) {
+      pluginRegistryUrl = 'https://eclipse-che.github.io/che-plugin-registry/main/v3';
+      console.log(`No plug-in registry url. Setting to ${pluginRegistryUrl}`);
+    }
+    if (!editor) {
+      editor = 'eclipse/che-theia/next';
+      console.log(`No editor. Setting to ${editor}`);
+    }
+    if (!sidecarPolicy) {
+      sidecarPolicy = SidecarPolicy.USE_DEV_CONTAINER;
+      console.log(`No sidecar policy. Setting to ${sidecarPolicy}`);
+    }
+    if (!devfileUrl) {
+      throw new Error('missing --devfile-url: parameter');
+    }
+    if (!outputFile) {
+      throw new Error('missing --output-file: parameter');
+    }
+
+    const axiosInstance = axios.default;
+    const inversifyBinbding = new InversifyBinding();
+    const container = await inversifyBinbding.initBindings({
+      pluginRegistryUrl,
+      insertTemplates: true,
+      axiosInstance,
+    });
+    container.bind(Generate).toSelf().inSingletonScope();
+
+    const generate = container.get(Generate);
+    return generate.generate(devfileUrl, editor, sidecarPolicy, outputFile);
+  }
+
+  async start(): Promise<boolean> {
+    try {
+      await this.doStart();
+      return true;
+    } catch (error) {
+      console.error('stack=' + error.stack);
+      console.error('Unable to start', error);
+      return false;
+    }
+  }
+}

--- a/tools/devworkspace-handler/src/plugin-registry/plugin-registry-module.ts
+++ b/tools/devworkspace-handler/src/plugin-registry/plugin-registry-module.ts
@@ -1,0 +1,18 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import { ContainerModule, interfaces } from 'inversify';
+
+import { PluginRegistryResolver } from './plugin-registry-resolver';
+
+const pluginRegistryModule = new ContainerModule((bind: interfaces.Bind) => {
+  bind(PluginRegistryResolver).toSelf().inSingletonScope();
+});
+
+export { pluginRegistryModule };

--- a/tools/devworkspace-handler/src/plugin-registry/plugin-registry-resolver.ts
+++ b/tools/devworkspace-handler/src/plugin-registry/plugin-registry-resolver.ts
@@ -1,0 +1,141 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as jsYaml from 'js-yaml';
+
+import { inject, injectable, named } from 'inversify';
+
+import { UrlFetcher } from '../fetch/url-fetcher';
+import { VSCodeExtensionEntry } from '../api/vscode-extension-entry';
+
+/**
+ * Definition of the theia plug-in
+ */
+interface CheTheiaPluginYaml {
+  metadata: {
+    id: string;
+    name: string;
+    publisher: string;
+  };
+  sidecar: {
+    name?: string;
+    image: string;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  preferences?: { [key: string]: any };
+  dependencies?: string[];
+  extensions: string[];
+}
+
+/**
+ * Resolve plug-ins by grabbing the definition from the plug-in registry.
+ */
+@injectable()
+export class PluginRegistryResolver {
+  @inject('string')
+  @named('PLUGIN_REGISTRY_URL')
+  private pluginRegistryUrl: string;
+
+  @inject(UrlFetcher)
+  private urlFetcher: UrlFetcher;
+
+  async resolve(vSCodeExtensionEntries: VSCodeExtensionEntry[]): Promise<void> {
+    // resolve extensions references
+    await Promise.all(vSCodeExtensionEntries.map(entry => this.resolveEntry(entry)));
+
+    // now resolved dependencies
+    await this.resolveDependencies(vSCodeExtensionEntries);
+  }
+
+  // Iterate on dependencies
+  async resolveDependencies(vSCodeExtensionEntries: VSCodeExtensionEntry[]): Promise<void> {
+    // list of all dependencies
+    const allDependencies = vSCodeExtensionEntries
+      .map(extension => extension.dependencies || [])
+      // flatten the array of array
+      .reduce((acc, val) => acc.concat(val), []);
+
+    const uniqueDependencies = [...new Set(allDependencies)];
+
+    // list of all dependencies not yet analyzed (because not yet in the list)
+    const toAnalyzeDependenciesIds = uniqueDependencies.filter(
+      dependency => !vSCodeExtensionEntries.some(entry => entry.id === `${dependency.replace(/\./g, '/')}/latest`)
+    );
+
+    // map new dependencies
+    const toAnalyzeDependencies = toAnalyzeDependenciesIds.map(name => ({
+      id: `${name.replace(/\./g, '/')}/latest`,
+      resolved: false,
+      optional: true,
+      extensions: [],
+    }));
+
+    // resolve these new dependencies
+    await Promise.all(toAnalyzeDependencies.map(entry => this.resolveEntry(entry)));
+
+    // add new extensions being resolved
+    vSCodeExtensionEntries.push(...toAnalyzeDependencies);
+
+    // new dependencies, check again if new dependencies are there
+    if (toAnalyzeDependencies.length > 0) {
+      await this.resolveDependencies(vSCodeExtensionEntries);
+    }
+  }
+
+  // FQN id (like eclipse/che-theia/next)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async loadDevfilePlugin(devfileId: string): Promise<any> {
+    const devfileUrl = `${this.pluginRegistryUrl}/plugins/${devfileId}/devfile.yaml`;
+    const devfileContent = await this.urlFetcher.fetchText(devfileUrl);
+    return jsYaml.load(devfileContent);
+  }
+
+  // check if extension is not resolved
+  // if not, reach plugin-registry
+  async resolveEntry(vSCodeExtensionEntry: VSCodeExtensionEntry): Promise<void> {
+    // skip already resolved
+    if (vSCodeExtensionEntry.resolved === true) {
+      return;
+    }
+
+    // grab the content from the plugin registry
+    // plugin registry url is with the format "https://plugin-registry.com/v3"
+    const url = `${this.pluginRegistryUrl}/plugins/${vSCodeExtensionEntry.id}/che-theia-plugin.yaml`;
+
+    // let's propagate the error if the plugin definition does not exist
+    const cheTheiaPluginYamlContent = await this.urlFetcher.fetchTextOptionalContent(url);
+    if (!cheTheiaPluginYamlContent) {
+      if (vSCodeExtensionEntry.optional === true) {
+        console.error(
+          `${vSCodeExtensionEntry.id} is missing on the plug-in registry but it is flagged as optional, skipping it`
+        );
+        return;
+      } else {
+        throw new Error(
+          `${vSCodeExtensionEntry.id} is a mandatory plug-in but definition is not found on the plug-in registry. Aborting !`
+        );
+      }
+    }
+    const cheTheiaPluginYaml: CheTheiaPluginYaml = jsYaml.load(cheTheiaPluginYamlContent);
+
+    // resolve now the extension
+    vSCodeExtensionEntry.resolved = true;
+
+    vSCodeExtensionEntry.extensions = cheTheiaPluginYaml.extensions;
+    const sidecar = cheTheiaPluginYaml.sidecar;
+    if (sidecar) {
+      vSCodeExtensionEntry.sidecarName = sidecar.name;
+      delete sidecar.name;
+    }
+    vSCodeExtensionEntry.sidecar = sidecar;
+    vSCodeExtensionEntry.preferences = cheTheiaPluginYaml.preferences;
+    vSCodeExtensionEntry.dependencies = cheTheiaPluginYaml.dependencies;
+  }
+}

--- a/tools/devworkspace-handler/src/vsix-installer/vsix-installer-component-updater.ts
+++ b/tools/devworkspace-handler/src/vsix-installer/vsix-installer-component-updater.ts
@@ -1,0 +1,77 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { V1alpha2DevWorkspaceTemplate, V1alpha2DevWorkspaceTemplateSpec } from '@devfile/api';
+
+import { DevfileContext } from '../api/devfile-context';
+import { injectable } from 'inversify';
+
+/* eslint-disable max-len */
+
+/**
+ * Manage the registration of the vsix installer component by adding a new devWorkspace template
+ * it will be added as a new DevWorkspaceTemplate
+ */
+@injectable()
+export class VsixInstallerComponentUpdater {
+  static readonly TEMPLATE_CONTENT: V1alpha2DevWorkspaceTemplateSpec = {
+    components: [
+      {
+        name: 'vsix-installer',
+        attributes: {
+          'app.kubernetes.io/part-of': 'che-theia.eclipse.org',
+          'app.kubernetes.io/component': 'vsix-installer',
+        },
+        container: {
+          image: 'quay.io/eclipse/che-theia-vsix-installer:next',
+          volumeMounts: [
+            {
+              path: '/plugins',
+              name: 'plugins',
+            },
+          ],
+        },
+      },
+    ],
+    events: {
+      preStart: ['copy-vsix'],
+    },
+    commands: [
+      {
+        id: 'copy-vsix',
+        apply: {
+          component: 'vsix-installer',
+        },
+      },
+    ],
+  };
+
+  async add(devfileContext: DevfileContext): Promise<void> {
+    // pre-requisites: to have existing components in devWorkspace
+    if (!devfileContext.devWorkspace.spec?.template?.components) {
+      throw new Error('No components in the devworkspace templates');
+    }
+
+    // append the suffix
+    const name = `che-theia-vsix-installer-${devfileContext.suffix}`;
+
+    // create a new DevWorkspaceTemplate
+    const vsixInstallerDevWorkspaceTemplate: V1alpha2DevWorkspaceTemplate = {
+      apiVersion: 'workspace.devfile.io/v1alpha2',
+      kind: 'DevWorkspaceTemplate',
+      metadata: {
+        name,
+      },
+      spec: VsixInstallerComponentUpdater.TEMPLATE_CONTENT,
+    };
+    // add the template
+    devfileContext.devWorkspaceTemplates.push(vsixInstallerDevWorkspaceTemplate);
+  }
+}

--- a/tools/devworkspace-handler/src/vsix-installer/vsix-installer-module.ts
+++ b/tools/devworkspace-handler/src/vsix-installer/vsix-installer-module.ts
@@ -1,0 +1,18 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import { ContainerModule, interfaces } from 'inversify';
+
+import { VsixInstallerComponentUpdater } from './vsix-installer-component-updater';
+
+const vsixInstallerModule = new ContainerModule((bind: interfaces.Bind) => {
+  bind(VsixInstallerComponentUpdater).toSelf().inSingletonScope();
+});
+
+export { vsixInstallerModule };

--- a/tools/devworkspace-handler/tests/_data/che-theia/che-theia-plugins-id.yaml
+++ b/tools/devworkspace-handler/tests/_data/che-theia/che-theia-plugins-id.yaml
@@ -1,0 +1,1 @@
+- id: redhat/java/latest

--- a/tools/devworkspace-handler/tests/_data/vscode/vscode-extensions.json
+++ b/tools/devworkspace-handler/tests/_data/vscode/vscode-extensions.json
@@ -1,0 +1,8 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"dbaeumer.vscode-eslint",
+		"EditorConfig.EditorConfig"
+	]
+}

--- a/tools/devworkspace-handler/tests/devfile/che-theia-component-finder.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/che-theia-component-finder.spec.ts
@@ -1,0 +1,79 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { CheTheiaComponentFinder } from '../../src/devfile/che-theia-component-finder';
+import { Container } from 'inversify';
+import { DevfileContext } from '../../src/api/devfile-context';
+
+describe('Test CheTheiaComponentFinder', () => {
+  let container: Container;
+
+  let cheTheiaComponentFinder: CheTheiaComponentFinder;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(CheTheiaComponentFinder).toSelf().inSingletonScope();
+    cheTheiaComponentFinder = container.get(CheTheiaComponentFinder);
+  });
+
+  test('in a template', async () => {
+    const devfileContext = {
+      devWorkspaceTemplates: [
+        {},
+        {
+          spec: {
+            components: [
+              { name: 'foo' },
+              {
+                name: 'theia-ide',
+              },
+            ],
+          },
+        },
+      ],
+    } as DevfileContext;
+    const devWorkspaceSpectTemplateComponents = await cheTheiaComponentFinder.find(devfileContext);
+    expect(devWorkspaceSpectTemplateComponents.name).toBe('theia-ide');
+  });
+
+  test('in the main devWorkspace', async () => {
+    const devfileContext = ({
+      devWorkspaceTemplates: [],
+      devWorkspace: {
+        spec: {
+          template: {
+            components: [
+              { name: 'foo' },
+              {
+                name: 'theia-ide',
+              },
+            ],
+          },
+        },
+      },
+    } as any) as DevfileContext;
+    const devWorkspaceSpectTemplateComponents = await cheTheiaComponentFinder.find(devfileContext);
+    expect(devWorkspaceSpectTemplateComponents.name).toBe('theia-ide');
+  });
+
+  test('missing', async () => {
+    const devfileContext = ({
+      devWorkspaceTemplates: [],
+      devWorkspace: {},
+    } as any) as DevfileContext;
+    await expect(cheTheiaComponentFinder.find(devfileContext)).rejects.toThrow(
+      'Not able to find theia-ide component in DevWorkspace and its templates'
+    );
+  });
+});

--- a/tools/devworkspace-handler/tests/devfile/che-theia-component-updater.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/che-theia-component-updater.spec.ts
@@ -1,0 +1,125 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { CheTheiaComponentFinder } from '../../src/devfile/che-theia-component-finder';
+import { CheTheiaComponentUpdater } from '../../src/devfile/che-theia-component-updater';
+import { Container } from 'inversify';
+import { DevfileContext } from '../../src/api/devfile-context';
+import { V1alpha2DevWorkspaceSpecTemplateComponents } from '@devfile/api';
+import { VSCodeExtensionEntry } from '../../src/api/vscode-extension-entry';
+
+describe('Test CheTheiaComponentFinder', () => {
+  let container: Container;
+
+  let cheTheiaComponentUpdater: CheTheiaComponentUpdater;
+  const cheTheiaComponentFinderFindMethod = jest.fn();
+  const cheTheiaComponentFinder = {
+    find: cheTheiaComponentFinderFindMethod,
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(CheTheiaComponentUpdater).toSelf().inSingletonScope();
+    container.bind(CheTheiaComponentFinder).toConstantValue(cheTheiaComponentFinder);
+    cheTheiaComponentUpdater = container.get(CheTheiaComponentUpdater);
+  });
+
+  test('basics', async () => {
+    const theiaComponent: V1alpha2DevWorkspaceSpecTemplateComponents = {
+      name: 'theia',
+    };
+    const cheTheiaExtensions: VSCodeExtensionEntry[] = [
+      {
+        id: 'foo',
+        resolved: true,
+        preferences: {
+          myPreference: 'foo-dummy',
+        },
+        extensions: ['http://foo-first.vsix', 'http://foo-second.vsix'],
+      },
+      {
+        id: 'bar',
+        resolved: true,
+        preferences: {
+          barPreference: 'dummy',
+        },
+        extensions: ['http://bar.vsix'],
+      },
+      {
+        id: 'baz',
+        resolved: true,
+        extensions: ['http://baz.vsix'],
+      },
+    ];
+    cheTheiaComponentFinderFindMethod.mockResolvedValue(theiaComponent);
+    const devfileContext = {} as DevfileContext;
+    await cheTheiaComponentUpdater.insert(devfileContext, cheTheiaExtensions);
+    expect(theiaComponent.attributes).toBeDefined();
+    const attributes = theiaComponent.attributes || ({} as any);
+    expect(attributes['che-theia.eclipse.org/vscode-extensions']).toStrictEqual([
+      'http://foo-first.vsix',
+      'http://foo-second.vsix',
+      'http://bar.vsix',
+      'http://baz.vsix',
+    ]);
+    expect(attributes['che-theia.eclipse.org/vscode-preferences']).toStrictEqual({
+      barPreference: 'dummy',
+      myPreference: 'foo-dummy',
+    });
+  });
+
+  test('empty extensions', async () => {
+    const theiaComponent: V1alpha2DevWorkspaceSpecTemplateComponents = {
+      name: 'theia',
+    };
+
+    const devfileContext = {} as DevfileContext;
+    const cheTheiaExtensions: VSCodeExtensionEntry[] = [];
+    await cheTheiaComponentUpdater.insert(devfileContext, cheTheiaExtensions);
+    // do not add any attributes
+    expect(theiaComponent.attributes).toBeUndefined();
+  });
+
+  test('existing attributes and no preferences', async () => {
+    const theiaComponent: V1alpha2DevWorkspaceSpecTemplateComponents = {
+      name: 'theia',
+      attributes: {
+        myItem: 'foo',
+      },
+    };
+    const cheTheiaExtensions: VSCodeExtensionEntry[] = [
+      {
+        id: 'foo',
+        resolved: true,
+        extensions: ['http://foo.vsix'],
+      },
+      {
+        id: 'bar',
+        resolved: true,
+        extensions: ['http://bar.vsix'],
+      },
+    ];
+    cheTheiaComponentFinderFindMethod.mockResolvedValue(theiaComponent);
+    const devfileContext = {} as DevfileContext;
+    await cheTheiaComponentUpdater.insert(devfileContext, cheTheiaExtensions);
+    expect(theiaComponent.attributes).toBeDefined();
+    const attributes = theiaComponent.attributes || ({} as any);
+    expect(attributes['che-theia.eclipse.org/vscode-extensions']).toStrictEqual(['http://foo.vsix', 'http://bar.vsix']);
+    // no preferences
+    expect(attributes['che-theia.eclipse.org/vscode-preferences']).toBeUndefined();
+
+    // existing attribute is kept
+    expect(attributes.myItem).toBe('foo');
+  });
+});

--- a/tools/devworkspace-handler/tests/devfile/che-theia-plugin-devcontainer-merger.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/che-theia-plugin-devcontainer-merger.spec.ts
@@ -1,0 +1,94 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { CheTheiaPluginDevContainerMerger } from '../../src/devfile/che-theia-plugin-devcontainer-merger';
+import { Container } from 'inversify';
+import { VSCodeExtensionEntryWithSidecar } from '../../src/api/vscode-extension-entry';
+
+describe('Test CheTheiaPluginDevContainerMerger', () => {
+  let container: Container;
+
+  let cheTheiaPluginDevContainerMerger: CheTheiaPluginDevContainerMerger;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(CheTheiaPluginDevContainerMerger).toSelf().inSingletonScope();
+    cheTheiaPluginDevContainerMerger = container.get(CheTheiaPluginDevContainerMerger);
+  });
+
+  test('basics', async () => {
+    const entries: VSCodeExtensionEntryWithSidecar[] = [
+      {
+        id: 'foo',
+        resolved: true,
+        preferences: {
+          myPreference: 'foo-dummy',
+        },
+        extensions: ['http://foo-first.vsix', 'http://foo-second.vsix'],
+        sidecar: {
+          image: 'foo',
+          volumeMounts: [
+            { name: 'fooVolume', path: '/fooPath' },
+            { name: 'm2Volume', path: '/m2Path' },
+          ],
+          endpoints: [{ name: 'fooEndpoint', targetPort: 1 }],
+        },
+      },
+      {
+        id: 'bar',
+        resolved: true,
+        preferences: {
+          barPreference: 'dummy',
+        },
+        extensions: ['http://bar.vsix'],
+        sidecar: {
+          image: 'foo',
+
+          volumeMounts: [],
+        },
+      },
+      {
+        id: 'baz',
+        resolved: true,
+        extensions: ['http://baz.vsix'],
+        sidecar: {
+          image: 'foo',
+          endpoints: [{ name: 'bazEndpoint', targetPort: 1 }],
+        },
+      },
+    ];
+
+    const devContainer = await cheTheiaPluginDevContainerMerger.merge(entries);
+    // merge of preferences
+    expect(devContainer.preferences).toStrictEqual({ barPreference: 'dummy', myPreference: 'foo-dummy' });
+
+    // merge of endpoints
+    expect(devContainer.endpoints).toStrictEqual([
+      { name: 'fooEndpoint', targetPort: 1 },
+      { name: 'bazEndpoint', targetPort: 1 },
+    ]);
+
+    // merge of volume mounts
+    expect(devContainer.volumeMounts).toStrictEqual([
+      {
+        name: 'fooVolume',
+        path: '/fooPath',
+      },
+      {
+        name: 'm2Volume',
+        path: '/m2Path',
+      },
+    ]);
+  });
+});

--- a/tools/devworkspace-handler/tests/devfile/che-theia-plugin-sidecar-merger.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/che-theia-plugin-sidecar-merger.spec.ts
@@ -1,0 +1,87 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { CheTheiaPluginSidecarMerger } from '../../src/devfile/che-theia-plugin-sidecar-merger';
+import { Container } from 'inversify';
+import { VSCodeExtensionEntryWithSidecar } from '../../src/api/vscode-extension-entry';
+
+describe('Test CheTheiaPluginSidecarMerger', () => {
+  let container: Container;
+
+  let cheTheiaPluginSidecarMerger: CheTheiaPluginSidecarMerger;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(CheTheiaPluginSidecarMerger).toSelf().inSingletonScope();
+    cheTheiaPluginSidecarMerger = container.get(CheTheiaPluginSidecarMerger);
+  });
+
+  test('basics', async () => {
+    const entries: VSCodeExtensionEntryWithSidecar[] = [
+      {
+        id: 'foo',
+        resolved: true,
+        preferences: {
+          myPreference: 'foo-dummy',
+        },
+        extensions: ['http://foo-first.vsix', 'http://foo-second.vsix'],
+        sidecarName: 'fooName',
+        sidecar: {
+          image: 'shared-image:123',
+          volumeMounts: [
+            { name: 'fooVolume', path: '/fooPath' },
+            { name: 'm2Volume', path: '/m2Path' },
+          ],
+          endpoints: [{ name: 'fooEndpoint', targetPort: 1 }],
+        },
+      },
+      {
+        id: 'bar',
+        resolved: true,
+        extensions: ['http://bar.vsix'],
+        sidecar: {
+          image: 'foo',
+
+          volumeMounts: [],
+        },
+      },
+      {
+        id: 'baz',
+        resolved: true,
+        extensions: ['http://baz.vsix'],
+        preferences: {
+          bazPreference: 'dummyBaz',
+        },
+        sidecarName: 'bazName',
+        sidecar: {
+          image: 'shared-image:123',
+          endpoints: [{ name: 'bazEndpoint', targetPort: 1 }],
+        },
+      },
+    ];
+
+    const mergedEntries = await cheTheiaPluginSidecarMerger.merge(entries);
+    // merged occured, less entries
+    expect(mergedEntries.length).toBe(entries.length - 1);
+
+    const firstEntry = mergedEntries[0];
+    expect(firstEntry.resolved).toBeTruthy();
+    expect(firstEntry.optional).toBeFalsy();
+
+    expect(firstEntry.id).toBe('merged-shared-image:123');
+    expect(firstEntry.extensions).toStrictEqual(['http://foo-first.vsix', 'http://foo-second.vsix', 'http://baz.vsix']);
+    expect(firstEntry.preferences).toStrictEqual({ myPreference: 'foo-dummy', bazPreference: 'dummyBaz' });
+    expect(firstEntry.sidecarName).toBe('fooName');
+  });
+});

--- a/tools/devworkspace-handler/tests/devfile/che-theia-plugins-analyzer.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/che-theia-plugins-analyzer.spec.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+import { CheTheiaPluginsAnalyzer } from '../../src/devfile/che-theia-plugins-analyzer';
+import { Container } from 'inversify';
+
+describe('Test CheTheiaPluginsAnalyzer', () => {
+  let container: Container;
+
+  let cheTheiaPluginsAnalyzer: CheTheiaPluginsAnalyzer;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(CheTheiaPluginsAnalyzer).toSelf().inSingletonScope();
+    cheTheiaPluginsAnalyzer = container.get(CheTheiaPluginsAnalyzer);
+  });
+
+  test('basic', async () => {
+    const cheTheiaPluginsYamlPath = path.resolve(__dirname, '..', '_data', 'che-theia', 'che-theia-plugins-id.yaml');
+    const cheTheiaPluginsYamlContent = await fs.readFile(cheTheiaPluginsYamlPath, 'utf-8');
+
+    const entries = await cheTheiaPluginsAnalyzer.extractPlugins(cheTheiaPluginsYamlContent);
+    expect(entries.length).toBe(1);
+    expect(entries[0]).toStrictEqual({
+      id: 'redhat/java/latest',
+      resolved: false,
+      extensions: [],
+    });
+  });
+
+  test('invalid yaml / empty', async () => {
+    const entries = await cheTheiaPluginsAnalyzer.extractPlugins('foo');
+    expect(entries.length).toBe(0);
+  });
+});

--- a/tools/devworkspace-handler/tests/devfile/che-theia-plugins-devfile-resolver.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/che-theia-plugins-devfile-resolver.spec.ts
@@ -1,0 +1,332 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { CheTheiaPluginDevContainerMerger } from '../../src/devfile/che-theia-plugin-devcontainer-merger';
+import { CheTheiaPluginSidecarMerger } from '../../src/devfile/che-theia-plugin-sidecar-merger';
+import { CheTheiaPluginsAnalyzer } from '../../src/devfile/che-theia-plugins-analyzer';
+import { CheTheiaPluginsDevfileResolver } from '../../src/devfile/che-theia-plugins-devfile-resolver';
+import { Container } from 'inversify';
+import { DevWorkspaceUpdater } from '../../src/devfile/devworkspace-updater';
+import { DevfileContext } from '../../src/api/devfile-context';
+import { PluginRegistryResolver } from '../../src/plugin-registry/plugin-registry-resolver';
+import { UrlFetcher } from '../../src/fetch/url-fetcher';
+import { VscodeExtensionJsonAnalyzer } from '../../src/devfile/vscode-extension-json-analyzer';
+
+// import { VSCodeExtensionEntry, VSCodeExtensionEntryWithSidecar } from '../../src/api/vscode-extension-entry';
+
+describe('Test CheTheiaPluginsDevfileResolver', () => {
+  let container: Container;
+
+  let cheTheiaPluginsDevfileResolver: CheTheiaPluginsDevfileResolver;
+
+  const urlFetcherFetchTextOptionalContentMethod = jest.fn();
+  const urlFetcher = {
+    fetchTextOptionalContent: urlFetcherFetchTextOptionalContentMethod,
+  } as any;
+
+  let cheTheiaPluginsAnalyzer: CheTheiaPluginsAnalyzer;
+  let vscodeExtensionJsonAnalyzer: VscodeExtensionJsonAnalyzer;
+  let cheTheiaPluginSidecarMerger: CheTheiaPluginSidecarMerger;
+  let cheTheiaPluginDevContainerMerger: CheTheiaPluginDevContainerMerger;
+
+  const pluginRegistryResolverResolveMethod = jest.fn();
+  const pluginRegistryResolver = {
+    resolve: pluginRegistryResolverResolveMethod,
+  } as any;
+
+  const devWorkspaceUpdaterUpdateMethod = jest.fn();
+  const devWorkspaceUpdater = {
+    update: devWorkspaceUpdaterUpdateMethod,
+  } as any;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(CheTheiaPluginsDevfileResolver).toSelf().inSingletonScope();
+
+    // use real implementation
+    container.bind(CheTheiaPluginsAnalyzer).toSelf().inSingletonScope();
+    container.bind(VscodeExtensionJsonAnalyzer).toSelf().inSingletonScope();
+    container.bind(CheTheiaPluginSidecarMerger).toSelf().inSingletonScope();
+    container.bind(CheTheiaPluginDevContainerMerger).toSelf().inSingletonScope();
+
+    // mock
+    container.bind(UrlFetcher).toConstantValue(urlFetcher);
+    container.bind(PluginRegistryResolver).toConstantValue(pluginRegistryResolver);
+    container.bind(DevWorkspaceUpdater).toConstantValue(devWorkspaceUpdater);
+
+    cheTheiaPluginsDevfileResolver = container.get(CheTheiaPluginsDevfileResolver);
+    cheTheiaPluginsAnalyzer = container.get(CheTheiaPluginsAnalyzer);
+    vscodeExtensionJsonAnalyzer = container.get(VscodeExtensionJsonAnalyzer);
+    cheTheiaPluginSidecarMerger = container.get(CheTheiaPluginSidecarMerger);
+    cheTheiaPluginDevContainerMerger = container.get(CheTheiaPluginDevContainerMerger);
+  });
+
+  test('basics with mergeImage', async () => {
+    const cheTheiaPluginsAnalyzerExtractPluginsSpy = jest.spyOn(cheTheiaPluginsAnalyzer, 'extractPlugins');
+    const vscodeExtensionJsonAnalyzerExtractPluginsSpy = jest.spyOn(vscodeExtensionJsonAnalyzer, 'extractPlugins');
+    const cheTheiaPluginSidecarMergerMergeSpy = jest.spyOn(cheTheiaPluginSidecarMerger, 'merge');
+    const cheTheiaPluginDevContainerMergerMergeSpy = jest.spyOn(cheTheiaPluginDevContainerMerger, 'merge');
+
+    const devfileContext = {
+      sidecarPolicy: 'mergeImage',
+      devfile: {},
+      cheTheiaPluginsContent: '- id: my/first-plugin/latest',
+      vscodeExtensionsJsonContent: JSON.stringify({
+        recommendations: ['redhat.java', 'foo.java', 'foo.node'],
+      }),
+    } as DevfileContext;
+
+    pluginRegistryResolverResolveMethod.mockImplementation(array => {
+      array[0].resolved = true;
+      array[0].extensions = ['http://first-plugin.vsix'];
+
+      array[1].resolved = true;
+      (array[1].sidecar = {
+        image: 'foo-image',
+      }),
+        (array[1].extensions = ['http://redhat-java.vsix']);
+
+      array[2].resolved = true;
+      (array[2].sidecar = {
+        image: 'foo-image',
+      }),
+        (array[2].extensions = ['http://foo-java.vsix']);
+
+      array[3].resolved = true;
+      (array[3].sidecar = {
+        image: 'foo-node',
+      }),
+        (array[3].extensions = ['http://foo-node.vsix']);
+    });
+
+    await cheTheiaPluginsDevfileResolver.handle(devfileContext);
+
+    // analyze yaml or extension.json
+    expect(vscodeExtensionJsonAnalyzerExtractPluginsSpy).toBeCalled();
+    expect(cheTheiaPluginsAnalyzerExtractPluginsSpy).toBeCalled();
+
+    // plug-ins will be fetched on the registry
+    expect(pluginRegistryResolverResolveMethod).toBeCalled();
+
+    // mergeImage
+    expect(cheTheiaPluginSidecarMergerMergeSpy).toBeCalled();
+    // but not useDevContainer
+    expect(cheTheiaPluginDevContainerMergerMergeSpy).toBeCalledTimes(0);
+
+    // devWorkspace updated
+    expect(devWorkspaceUpdaterUpdateMethod).toBeCalled();
+    const updateCall = devWorkspaceUpdaterUpdateMethod.mock.calls[0];
+    expect(updateCall[0].sidecarPolicy).toBe('mergeImage');
+
+    // extensions without sidecar:
+    expect(updateCall[1].length).toBe(1);
+    expect(updateCall[1][0].extensions).toStrictEqual(['http://first-plugin.vsix']);
+
+    // extensions with same sidecar should have been merged
+    expect(updateCall[2].length).toBe(2);
+    expect(updateCall[2][0].extensions).toStrictEqual(['http://redhat-java.vsix', 'http://foo-java.vsix']);
+    expect(updateCall[2][0].sidecar.image).toBe('foo-image');
+
+    expect(updateCall[2][1].extensions).toStrictEqual(['http://foo-node.vsix']);
+    expect(updateCall[2][1].sidecar.image).toBe('foo-node');
+
+    // nothing for dev container
+    expect(updateCall[3]).toBeUndefined();
+  });
+
+  test('basics mergeImage only extensionJson attribute', async () => {
+    const cheTheiaPluginsAnalyzerExtractPluginsSpy = jest.spyOn(cheTheiaPluginsAnalyzer, 'extractPlugins');
+    const vscodeExtensionJsonAnalyzerExtractPluginsSpy = jest.spyOn(vscodeExtensionJsonAnalyzer, 'extractPlugins');
+    const cheTheiaPluginSidecarMergerMergeSpy = jest.spyOn(cheTheiaPluginSidecarMerger, 'merge');
+    const cheTheiaPluginDevContainerMergerMergeSpy = jest.spyOn(cheTheiaPluginDevContainerMerger, 'merge');
+
+    const devfileContext = {
+      sidecarPolicy: 'mergeImage',
+      devfile: {
+        attributes: {
+          '.vscode/extensions.json': JSON.stringify({
+            recommendations: ['first.plugin'],
+          }),
+        },
+      },
+    } as DevfileContext;
+
+    pluginRegistryResolverResolveMethod.mockImplementation(array => {
+      array[0].resolved = true;
+      array[0].extensions = ['http://first-plugin.vsix'];
+    });
+
+    await cheTheiaPluginsDevfileResolver.handle(devfileContext);
+
+    // no yaml
+    expect(cheTheiaPluginsAnalyzerExtractPluginsSpy).toBeCalledTimes(0);
+    // but extension.json
+    expect(vscodeExtensionJsonAnalyzerExtractPluginsSpy).toBeCalled();
+
+    // plug-ins will be fetched on the registry
+    expect(pluginRegistryResolverResolveMethod).toBeCalled();
+
+    // mergeImage
+    expect(cheTheiaPluginSidecarMergerMergeSpy).toBeCalled();
+    // but not useDevContainer
+    expect(cheTheiaPluginDevContainerMergerMergeSpy).toBeCalledTimes(0);
+
+    // devWorkspace updated
+    expect(devWorkspaceUpdaterUpdateMethod).toBeCalled();
+    const updateCall = devWorkspaceUpdaterUpdateMethod.mock.calls[0];
+    expect(updateCall[0].sidecarPolicy).toBe('mergeImage');
+
+    // extensions without sidecar:
+    expect(updateCall[1].length).toBe(1);
+    expect(updateCall[1][0].extensions).toStrictEqual(['http://first-plugin.vsix']);
+
+    // extensions with same sidecar should have been merged
+    expect(updateCall[2].length).toBe(0);
+
+    // nothing for dev container
+    expect(updateCall[3]).toBeUndefined();
+  });
+
+  test('basics mergeImage only cheTheiaPlugins attribute', async () => {
+    const cheTheiaPluginsAnalyzerExtractPluginsSpy = jest.spyOn(cheTheiaPluginsAnalyzer, 'extractPlugins');
+    const vscodeExtensionJsonAnalyzerExtractPluginsSpy = jest.spyOn(vscodeExtensionJsonAnalyzer, 'extractPlugins');
+    const cheTheiaPluginSidecarMergerMergeSpy = jest.spyOn(cheTheiaPluginSidecarMerger, 'merge');
+    const cheTheiaPluginDevContainerMergerMergeSpy = jest.spyOn(cheTheiaPluginDevContainerMerger, 'merge');
+
+    const devfileContext = {
+      sidecarPolicy: 'mergeImage',
+      devfile: {
+        attributes: {
+          '.che/che-theia-plugins.yaml': '- id: my/first-plugin/latest',
+        },
+      },
+    } as DevfileContext;
+
+    pluginRegistryResolverResolveMethod.mockImplementation(array => {
+      array[0].resolved = true;
+      array[0].extensions = ['http://first-plugin.vsix'];
+    });
+
+    await cheTheiaPluginsDevfileResolver.handle(devfileContext);
+
+    // no extension.json
+    expect(vscodeExtensionJsonAnalyzerExtractPluginsSpy).toBeCalledTimes(0);
+    // but yaml
+    expect(cheTheiaPluginsAnalyzerExtractPluginsSpy).toBeCalled();
+
+    // plug-ins will be fetched on the registry
+    expect(pluginRegistryResolverResolveMethod).toBeCalled();
+
+    // mergeImage
+    expect(cheTheiaPluginSidecarMergerMergeSpy).toBeCalled();
+    // but not useDevContainer
+    expect(cheTheiaPluginDevContainerMergerMergeSpy).toBeCalledTimes(0);
+
+    // devWorkspace updated
+    expect(devWorkspaceUpdaterUpdateMethod).toBeCalled();
+    const updateCall = devWorkspaceUpdaterUpdateMethod.mock.calls[0];
+    expect(updateCall[0].sidecarPolicy).toBe('mergeImage');
+
+    // extensions without sidecar:
+    expect(updateCall[1].length).toBe(1);
+    expect(updateCall[1][0].extensions).toStrictEqual(['http://first-plugin.vsix']);
+
+    // extensions with same sidecar should have been merged
+    expect(updateCall[2].length).toBe(0);
+
+    // nothing for dev container
+    expect(updateCall[3]).toBeUndefined();
+  });
+
+  test('basics with useDevContainer', async () => {
+    const cheTheiaPluginsAnalyzerExtractPluginsSpy = jest.spyOn(cheTheiaPluginsAnalyzer, 'extractPlugins');
+    const vscodeExtensionJsonAnalyzerExtractPluginsSpy = jest.spyOn(vscodeExtensionJsonAnalyzer, 'extractPlugins');
+    const cheTheiaPluginSidecarMergerMergeSpy = jest.spyOn(cheTheiaPluginSidecarMerger, 'merge');
+    const cheTheiaPluginDevContainerMergerMergeSpy = jest.spyOn(cheTheiaPluginDevContainerMerger, 'merge');
+
+    const devfileContext = {
+      sidecarPolicy: 'useDevContainer',
+      devfile: {},
+      cheTheiaPluginsContent: '- id: my/first-plugin/latest',
+      vscodeExtensionsJsonContent: JSON.stringify({
+        recommendations: ['redhat.java'],
+      }),
+    } as DevfileContext;
+
+    pluginRegistryResolverResolveMethod.mockImplementation(array => {
+      array[0].resolved = true;
+      array[0].extensions = ['http://first-plugin.vsix'];
+
+      array[1].resolved = true;
+      (array[1].sidecar = {
+        image: 'foo-image',
+      }),
+        (array[1].extensions = ['http://redhat-java.vsix']);
+    });
+
+    await cheTheiaPluginsDevfileResolver.handle(devfileContext);
+
+    // analyze yaml or extension.json
+    expect(vscodeExtensionJsonAnalyzerExtractPluginsSpy).toBeCalled();
+    expect(cheTheiaPluginsAnalyzerExtractPluginsSpy).toBeCalled();
+
+    // plug-ins will be fetched on the registry
+    expect(pluginRegistryResolverResolveMethod).toBeCalled();
+
+    // useDevContainer
+    expect(cheTheiaPluginDevContainerMergerMergeSpy).toBeCalled();
+    // but not mergeImage
+    expect(cheTheiaPluginSidecarMergerMergeSpy).toBeCalledTimes(0);
+
+    // devWorkspace updated
+    expect(devWorkspaceUpdaterUpdateMethod).toBeCalled();
+    const updateCall = devWorkspaceUpdaterUpdateMethod.mock.calls[0];
+    expect(updateCall[0].sidecarPolicy).toBe('useDevContainer');
+
+    // extensions without sidecar:
+    expect(updateCall[1].length).toBe(1);
+    expect(updateCall[1][0].extensions).toStrictEqual(['http://first-plugin.vsix']);
+
+    // no extensions with sidecar
+    expect(updateCall[2].length).toBe(0);
+
+    // dev container will deploy redhat-java.vsix
+    expect(updateCall[3].extensions).toStrictEqual(['http://redhat-java.vsix']);
+  });
+
+  test('basics no content', async () => {
+    const cheTheiaPluginsAnalyzerExtractPluginsSpy = jest.spyOn(cheTheiaPluginsAnalyzer, 'extractPlugins');
+    const vscodeExtensionJsonAnalyzerExtractPluginsSpy = jest.spyOn(vscodeExtensionJsonAnalyzer, 'extractPlugins');
+    const cheTheiaPluginSidecarMergerMergeSpy = jest.spyOn(cheTheiaPluginSidecarMerger, 'merge');
+    const cheTheiaPluginDevContainerMergerMergeSpy = jest.spyOn(cheTheiaPluginDevContainerMerger, 'merge');
+
+    const devfileContext = {
+      devfile: {},
+    } as DevfileContext;
+
+    await cheTheiaPluginsDevfileResolver.handle(devfileContext);
+
+    // we never analyze yaml or extension.json as it's not there
+    expect(vscodeExtensionJsonAnalyzerExtractPluginsSpy).toBeCalledTimes(0);
+    expect(cheTheiaPluginsAnalyzerExtractPluginsSpy).toBeCalledTimes(0);
+    expect(pluginRegistryResolverResolveMethod).toBeCalledTimes(0);
+
+    // no merge
+    expect(cheTheiaPluginSidecarMergerMergeSpy).toBeCalledTimes(0);
+    expect(cheTheiaPluginDevContainerMergerMergeSpy).toBeCalledTimes(0);
+
+    // no update
+    expect(devWorkspaceUpdaterUpdateMethod).toBeCalledTimes(0);
+  });
+});

--- a/tools/devworkspace-handler/tests/devfile/container-plugin-remote-updater.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/container-plugin-remote-updater.spec.ts
@@ -1,0 +1,80 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { ContainerPluginRemoteUpdater } from '../../src/devfile/container-plugin-remote-updater';
+import { V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainer } from '@devfile/api';
+
+describe('Test ContainerPluginRemoteUpdater', () => {
+  let container: Container;
+
+  let containerPluginRemoteUpdater: ContainerPluginRemoteUpdater;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(ContainerPluginRemoteUpdater).toSelf().inSingletonScope();
+    containerPluginRemoteUpdater = container.get(ContainerPluginRemoteUpdater);
+  });
+
+  test('basics', async () => {
+    const container: V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainer = {
+      image: 'fake-image',
+    };
+    const componentName = 'myComponent';
+    await containerPluginRemoteUpdater.update(componentName, container);
+    expect(container.env?.find(entry => entry.name === 'PLUGIN_REMOTE_ENDPOINT_EXECUTABLE')).toBeDefined();
+    const theiaPluginEnv = container.env?.find(entry => entry.name === 'THEIA_PLUGINS');
+    expect(theiaPluginEnv).toBeDefined();
+    expect(theiaPluginEnv?.value).toBe(`local-dir:///plugins/sidecars/${componentName}`);
+
+    const volumeMountEndpoint = container.volumeMounts?.find(entry => entry.name === 'remote-endpoint');
+    expect(volumeMountEndpoint).toBeDefined();
+    expect(volumeMountEndpoint?.path).toBe('/remote-endpoint');
+
+    const volumeMountPlugins = container.volumeMounts?.find(entry => entry.name === 'plugins');
+    expect(volumeMountPlugins).toBeDefined();
+    expect(volumeMountPlugins?.path).toBe('/plugins');
+  });
+
+  test('basics', async () => {
+    const container: V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainer = {
+      image: 'fake-image',
+      env: [{ name: 'FOO', value: 'BAR' }],
+      volumeMounts: [{ name: 'FOO', path: '/BAR' }],
+    };
+    const componentName = 'myComponent';
+    await containerPluginRemoteUpdater.update(componentName, container);
+    expect(container.env?.find(entry => entry.name === 'PLUGIN_REMOTE_ENDPOINT_EXECUTABLE')).toBeDefined();
+
+    const existingEnv = container.env?.find(entry => entry.name === 'FOO');
+    expect(existingEnv).toBeDefined();
+    expect(existingEnv?.value).toBe('BAR');
+
+    const theiaPluginEnv = container.env?.find(entry => entry.name === 'THEIA_PLUGINS');
+    expect(theiaPluginEnv).toBeDefined();
+    expect(theiaPluginEnv?.value).toBe(`local-dir:///plugins/sidecars/${componentName}`);
+
+    const volumeMountExisting = container.volumeMounts?.find(entry => entry.name === 'FOO');
+    expect(volumeMountExisting).toBeDefined();
+    expect(volumeMountExisting?.path).toBe('/BAR');
+
+    const volumeMountEndpoint = container.volumeMounts?.find(entry => entry.name === 'remote-endpoint');
+    expect(volumeMountEndpoint).toBeDefined();
+    expect(volumeMountEndpoint?.path).toBe('/remote-endpoint');
+
+    const volumeMountPlugins = container.volumeMounts?.find(entry => entry.name === 'plugins');
+    expect(volumeMountPlugins).toBeDefined();
+    expect(volumeMountPlugins?.path).toBe('/plugins');
+  });
+});

--- a/tools/devworkspace-handler/tests/devfile/dev-container-component-finder.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/dev-container-component-finder.spec.ts
@@ -1,0 +1,115 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { DevContainerComponentFinder } from '../../src/devfile/dev-container-component-finder';
+import { DevfileContext } from '../../src/api/devfile-context';
+
+describe('Test DevContainerComponentFinder', () => {
+  let container: Container;
+
+  let devContainerComponentFinder: DevContainerComponentFinder;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(DevContainerComponentFinder).toSelf().inSingletonScope();
+    devContainerComponentFinder = container.get(DevContainerComponentFinder);
+  });
+
+  test('basics', async () => {
+    const devfileContext = {
+      devWorkspace: {
+        spec: {
+          template: {
+            components: [
+              { name: 'foo' },
+              {
+                name: 'theia-ide',
+              },
+              {
+                name: 'my-container',
+                container: {
+                  image: 'user-image:123',
+                },
+              },
+            ],
+          },
+        },
+      },
+    } as DevfileContext;
+    const devWorkspaceSpecTemplateComponents = await devContainerComponentFinder.find(devfileContext);
+    expect(devWorkspaceSpecTemplateComponents.name).toBe('my-container');
+  });
+
+  test('missing dev container', async () => {
+    const devfileContext = {
+      devWorkspace: {
+        spec: {
+          template: {
+            components: [
+              { name: 'foo' },
+              {
+                name: 'theia-ide',
+              },
+            ],
+          },
+        },
+      },
+    } as DevfileContext;
+    await expect(devContainerComponentFinder.find(devfileContext)).rejects.toThrow(
+      'Not able to find any dev container component in DevWorkspace'
+    );
+  });
+
+  test('missing dev container (no components)', async () => {
+    const devfileContext = {
+      devWorkspace: {},
+    } as DevfileContext;
+    await expect(devContainerComponentFinder.find(devfileContext)).rejects.toThrow(
+      'Not able to find any dev container component in DevWorkspace'
+    );
+  });
+
+  test('too many dev container', async () => {
+    const devfileContext = {
+      devWorkspace: {
+        spec: {
+          template: {
+            components: [
+              { name: 'foo' },
+              {
+                name: 'theia-ide',
+              },
+              {
+                name: 'my-container-1',
+                container: {
+                  image: 'user-image:123',
+                },
+              },
+              {
+                name: 'my-container-2',
+                container: {
+                  image: 'user-image:123',
+                },
+              },
+            ],
+          },
+        },
+      },
+    } as DevfileContext;
+    await expect(devContainerComponentFinder.find(devfileContext)).rejects.toThrow(
+      'Too many components have been found that could be considered as dev container'
+    );
+  });
+});

--- a/tools/devworkspace-handler/tests/devfile/dev-container-component-updater.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/dev-container-component-updater.spec.ts
@@ -1,0 +1,172 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { ContainerPluginRemoteUpdater } from '../../src/devfile/container-plugin-remote-updater';
+import { DevContainerComponentFinder } from '../../src/devfile/dev-container-component-finder';
+import { DevContainerComponentUpdater } from '../../src/devfile/dev-container-component-updater';
+import { DevfileContext } from '../../src/api/devfile-context';
+import { V1alpha2DevWorkspaceSpecTemplateComponents } from '@devfile/api';
+import { VSCodeExtensionDevContainer } from '../../src/devfile/vscode-extension-dev-container';
+
+describe('Test DevContainerComponentUpdater', () => {
+  let container: Container;
+
+  let devContainerComponentUpdater: DevContainerComponentUpdater;
+  const devContainerComponentFinderFindMethod = jest.fn();
+  const devContainerComponentFinder = {
+    find: devContainerComponentFinderFindMethod,
+  } as DevContainerComponentFinder;
+
+  const containerPluginRemoteUpdaterUpdateMethod = jest.fn();
+  const containerPluginRemoteUpdater = {
+    update: containerPluginRemoteUpdaterUpdateMethod,
+  } as ContainerPluginRemoteUpdater;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(DevContainerComponentUpdater).toSelf().inSingletonScope();
+    container.bind(DevContainerComponentFinder).toConstantValue(devContainerComponentFinder);
+    container.bind(ContainerPluginRemoteUpdater).toConstantValue(containerPluginRemoteUpdater);
+
+    devContainerComponentUpdater = container.get(DevContainerComponentUpdater);
+  });
+
+  test('basics', async () => {
+    const devfileContext = {} as DevfileContext;
+
+    const devContainerComponent: V1alpha2DevWorkspaceSpecTemplateComponents = {
+      name: 'foo',
+      attributes: {},
+      container: {
+        image: 'foo',
+        env: [
+          {
+            name: 'EXISTING',
+            value: 'EXISTING_VALUE',
+          },
+        ],
+        endpoints: [{ name: 'existing', targetPort: 2 }],
+
+        volumeMounts: [
+          {
+            name: 'existing',
+            path: '/existing',
+          },
+        ],
+      },
+    };
+    devContainerComponentFinderFindMethod.mockResolvedValue(devContainerComponent);
+
+    const vSCodeExtensionDevContainer: VSCodeExtensionDevContainer = {
+      preferences: {
+        foo: 'foo',
+        bar: 'bar',
+      },
+      env: [
+        {
+          name: 'FOO_ENV',
+          value: 'FOO_VALUE',
+        },
+      ],
+      volumeMounts: [
+        {
+          name: 'foo',
+          path: '/bar',
+        },
+        {
+          name: 'existing',
+          path: '/existing',
+        },
+      ],
+      endpoints: [
+        {
+          name: 'endpoint1',
+          targetPort: 1,
+        },
+      ],
+      extensions: ['http://first.vsix', 'http://second.vsix'],
+    };
+    await devContainerComponentUpdater.insert(devfileContext, vSCodeExtensionDevContainer);
+
+    // check that inside the devContainer we have stuff being added
+    const attributes = devContainerComponent.attributes || ({} as any);
+    expect(attributes['che-theia.eclipse.org/vscode-extensions']).toStrictEqual(vSCodeExtensionDevContainer.extensions);
+    expect(attributes['che-theia.eclipse.org/vscode-preferences']).toStrictEqual({ bar: 'bar', foo: 'foo' });
+    expect(attributes['app.kubernetes.io/name']).toBe('foo');
+    expect(devContainerComponent?.container?.env).toStrictEqual([
+      { name: 'EXISTING', value: 'EXISTING_VALUE' },
+      { name: 'FOO_ENV', value: 'FOO_VALUE' },
+    ]);
+    expect(devContainerComponent?.container?.endpoints).toStrictEqual([
+      { name: 'existing', targetPort: 2 },
+      { name: 'endpoint1', targetPort: 1 },
+    ]);
+    expect(devContainerComponent?.container?.volumeMounts).toStrictEqual([
+      {
+        name: 'existing',
+        path: '/existing',
+      },
+      {
+        name: 'foo',
+        path: '/bar',
+      },
+    ]);
+    // args updated
+    expect(devContainerComponent?.container?.args).toStrictEqual(['sh', '-c', '${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}']);
+  });
+
+  test('basics without existing', async () => {
+    const devfileContext = {} as DevfileContext;
+
+    const devContainerComponent: V1alpha2DevWorkspaceSpecTemplateComponents = {
+      name: 'foo',
+      container: {
+        image: 'foo',
+      },
+    };
+    devContainerComponentFinderFindMethod.mockResolvedValue(devContainerComponent);
+
+    const vSCodeExtensionDevContainer: VSCodeExtensionDevContainer = {
+      extensions: ['http://first.vsix', 'http://second.vsix'],
+    };
+    await devContainerComponentUpdater.insert(devfileContext, vSCodeExtensionDevContainer);
+
+    // check that inside the devContainer we have stuff being added
+    const attributes = devContainerComponent.attributes || ({} as any);
+    expect(attributes['che-theia.eclipse.org/vscode-extensions']).toStrictEqual(vSCodeExtensionDevContainer.extensions);
+    expect(attributes['che-theia.eclipse.org/vscode-preferences']).toBeUndefined();
+    expect(attributes['app.kubernetes.io/name']).toBe('foo');
+    expect(devContainerComponent?.container?.endpoints).toBeUndefined();
+    expect(devContainerComponent?.container?.volumeMounts).toBeUndefined();
+    // args updated
+    expect(devContainerComponent?.container?.args).toStrictEqual(['sh', '-c', '${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}']);
+  });
+
+  test('not a dev container', async () => {
+    const devfileContext = {} as DevfileContext;
+
+    const devContainerComponent: V1alpha2DevWorkspaceSpecTemplateComponents = {
+      name: 'foo',
+    };
+    const vSCodeExtensionDevContainer: VSCodeExtensionDevContainer = {
+      extensions: [],
+    };
+    devContainerComponentFinderFindMethod.mockResolvedValue(devContainerComponent);
+
+    await expect(devContainerComponentUpdater.insert(devfileContext, vSCodeExtensionDevContainer)).rejects.toThrow(
+      'The dev container should be a component'
+    );
+  });
+});

--- a/tools/devworkspace-handler/tests/devfile/devworkspace-updater.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/devworkspace-updater.spec.ts
@@ -1,0 +1,211 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { VSCodeExtensionEntry, VSCodeExtensionEntryWithSidecar } from '../../src/api/vscode-extension-entry';
+
+import { CheTheiaComponentUpdater } from '../../src/devfile/che-theia-component-updater';
+import { Container } from 'inversify';
+import { DevContainerComponentUpdater } from '../../src/devfile/dev-container-component-updater';
+import { DevWorkspaceUpdater } from '../../src/devfile/devworkspace-updater';
+import { DevfileContext } from '../../src/api/devfile-context';
+import { SidecarComponentsCreator } from '../../src/devfile/sidecar-components-creator';
+import { V1alpha2DevWorkspaceSpecTemplateComponents } from '@devfile/api';
+import { VSCodeExtensionDevContainer } from '../../src/devfile/vscode-extension-dev-container';
+import { VsixInstallerComponentUpdater } from '../../src/vsix-installer/vsix-installer-component-updater';
+
+describe('Test DevWorkspaceUpdater', () => {
+  let container: Container;
+
+  let devWorkspaceUpdater: DevWorkspaceUpdater;
+
+  const sidecarComponentsCreatorCreateMethod = jest.fn();
+  const sidecarComponentsCreator = {
+    create: sidecarComponentsCreatorCreateMethod,
+  } as any;
+
+  const cheTheiaComponentUpdaterInsertMethod = jest.fn();
+  const cheTheiaComponentUpdater = {
+    insert: cheTheiaComponentUpdaterInsertMethod,
+  } as any;
+
+  const devContainerComponentUpdaterInsertMethod = jest.fn();
+  const devContainerComponentUpdater = {
+    insert: devContainerComponentUpdaterInsertMethod,
+  } as any;
+
+  const vsixInstallerComponentUpdaterAddMethod = jest.fn();
+  const vsixInstallerComponentUpdater = {
+    add: vsixInstallerComponentUpdaterAddMethod,
+  } as any;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(DevWorkspaceUpdater).toSelf().inSingletonScope();
+    container.bind(SidecarComponentsCreator).toConstantValue(sidecarComponentsCreator);
+    container.bind(CheTheiaComponentUpdater).toConstantValue(cheTheiaComponentUpdater);
+    container.bind(DevContainerComponentUpdater).toConstantValue(devContainerComponentUpdater);
+    container.bind(VsixInstallerComponentUpdater).toConstantValue(vsixInstallerComponentUpdater);
+  });
+
+  test('basics', async () => {
+    container.bind('boolean').toConstantValue(true).whenTargetNamed('INSERT_TEMPLATES');
+    devWorkspaceUpdater = container.get(DevWorkspaceUpdater);
+
+    const devfileContext = {
+      devWorkspace: {
+        spec: {
+          template: {
+            components: [
+              {
+                name: 'bar',
+              },
+            ],
+          },
+        },
+      },
+      devWorkspaceTemplates: [
+        {
+          metadata: {
+            name: 'foo',
+          },
+        },
+      ],
+    } as DevfileContext;
+
+    const componentsToAdd: V1alpha2DevWorkspaceSpecTemplateComponents[] = [
+      {
+        name: 'component-added-1',
+      },
+    ];
+    sidecarComponentsCreatorCreateMethod.mockResolvedValue(componentsToAdd);
+
+    const cheTheiaExtensions: VSCodeExtensionEntry[] = [];
+    const extensionsWithSidecars: VSCodeExtensionEntryWithSidecar[] = [];
+    const extensionsForDevContainer: VSCodeExtensionDevContainer = {
+      extensions: [],
+    };
+    await devWorkspaceUpdater.update(
+      devfileContext,
+      cheTheiaExtensions,
+      extensionsWithSidecars,
+      extensionsForDevContainer
+    );
+
+    // check components have been added
+    expect(devfileContext.devWorkspace.spec?.template?.components).toStrictEqual([
+      {
+        name: 'bar',
+      },
+      {
+        name: 'foo',
+        plugin: {
+          kubernetes: {
+            name: 'foo',
+          },
+        },
+      },
+      {
+        name: 'component-added-1',
+      },
+    ]);
+    expect(devContainerComponentUpdaterInsertMethod).toBeCalledWith(devfileContext, extensionsForDevContainer);
+  });
+
+  test('basics without insert', async () => {
+    container.bind('boolean').toConstantValue(false).whenTargetNamed('INSERT_TEMPLATES');
+    devWorkspaceUpdater = container.get(DevWorkspaceUpdater);
+
+    const devfileContext = {
+      devWorkspace: {
+        spec: {
+          template: {},
+        },
+      },
+      devWorkspaceTemplates: [{}],
+    } as DevfileContext;
+
+    const componentsToAdd: V1alpha2DevWorkspaceSpecTemplateComponents[] = [
+      {
+        name: 'component-added-1',
+      },
+    ];
+    sidecarComponentsCreatorCreateMethod.mockResolvedValue(componentsToAdd);
+
+    const cheTheiaExtensions: VSCodeExtensionEntry[] = [];
+    const extensionsWithSidecars: VSCodeExtensionEntryWithSidecar[] = [];
+    const extensionsForDevContainer = undefined;
+    await devWorkspaceUpdater.update(
+      devfileContext,
+      cheTheiaExtensions,
+      extensionsWithSidecars,
+      extensionsForDevContainer
+    );
+    expect(devContainerComponentUpdaterInsertMethod).toBeCalledTimes(0);
+
+    // check components have been added
+    expect(devfileContext.devWorkspace.spec?.template?.components).toStrictEqual([
+      {
+        name: 'component-added-1',
+      },
+    ]);
+  });
+
+  test('error insert no name', async () => {
+    container.bind('boolean').toConstantValue(true).whenTargetNamed('INSERT_TEMPLATES');
+    devWorkspaceUpdater = container.get(DevWorkspaceUpdater);
+
+    const devfileContext = {
+      devWorkspace: {
+        spec: {
+          template: {},
+        },
+      },
+      devWorkspaceTemplates: [{}],
+    } as DevfileContext;
+
+    const componentsToAdd: V1alpha2DevWorkspaceSpecTemplateComponents[] = [
+      {
+        name: 'component-added-1',
+      },
+    ];
+    sidecarComponentsCreatorCreateMethod.mockResolvedValue(componentsToAdd);
+
+    const cheTheiaExtensions: VSCodeExtensionEntry[] = [];
+    const extensionsWithSidecars: VSCodeExtensionEntryWithSidecar[] = [];
+    const extensionsForDevContainer: VSCodeExtensionDevContainer = {
+      extensions: [],
+    };
+    await expect(
+      devWorkspaceUpdater.update(devfileContext, cheTheiaExtensions, extensionsWithSidecars, extensionsForDevContainer)
+    ).rejects.toThrow('No name found for the template');
+  });
+
+  test('error no template insert no name', async () => {
+    container.bind('boolean').toConstantValue(true).whenTargetNamed('INSERT_TEMPLATES');
+    devWorkspaceUpdater = container.get(DevWorkspaceUpdater);
+
+    const devfileContext = {
+      devWorkspace: {},
+    } as DevfileContext;
+
+    const cheTheiaExtensions: VSCodeExtensionEntry[] = [];
+    const extensionsWithSidecars: VSCodeExtensionEntryWithSidecar[] = [];
+    const extensionsForDevContainer: VSCodeExtensionDevContainer = {
+      extensions: [],
+    };
+    await expect(
+      devWorkspaceUpdater.update(devfileContext, cheTheiaExtensions, extensionsWithSidecars, extensionsForDevContainer)
+    ).rejects.toThrow('Can update a dev workspace only if there is a template in spec object');
+  });
+});

--- a/tools/devworkspace-handler/tests/devfile/sidecar-components-creator.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/sidecar-components-creator.spec.ts
@@ -1,0 +1,85 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { ContainerPluginRemoteUpdater } from '../../src/devfile/container-plugin-remote-updater';
+import { SidecarComponentsCreator } from '../../src/devfile/sidecar-components-creator';
+import { VSCodeExtensionEntryWithSidecar } from '../../src/api/vscode-extension-entry';
+
+describe('Test SidecarComponentsCreator', () => {
+  let container: Container;
+
+  let sidecarComponentsCreator: SidecarComponentsCreator;
+
+  const containerPluginRemoteUpdaterUpdateMethod = jest.fn();
+  const containerPluginRemoteUpdater = {
+    update: containerPluginRemoteUpdaterUpdateMethod,
+  } as ContainerPluginRemoteUpdater;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(SidecarComponentsCreator).toSelf().inSingletonScope();
+    container.bind(ContainerPluginRemoteUpdater).toConstantValue(containerPluginRemoteUpdater);
+
+    sidecarComponentsCreator = container.get(SidecarComponentsCreator);
+  });
+
+  test('basics', async () => {
+    const entry: VSCodeExtensionEntryWithSidecar = {
+      id: 'plugin',
+      sidecarName: 'my-sidecar',
+      resolved: true,
+      extensions: ['http://first.vsix'],
+      preferences: {
+        foo: 'bar',
+      },
+      sidecar: {
+        image: 'my-image',
+      },
+    };
+    const components = await sidecarComponentsCreator.create([entry]);
+    expect(containerPluginRemoteUpdaterUpdateMethod).toBeCalledWith('my-sidecar', entry.sidecar);
+    expect(components.length).toBe(1);
+    const component = components[0];
+    expect(component.name).toBe(entry.sidecarName);
+    expect(component.container).toBe(entry.sidecar);
+    const componentAttributes = component.attributes || ({} as any);
+    expect(componentAttributes['app.kubernetes.io/part-of']).toBe('che-theia.eclipse.org');
+    expect(componentAttributes['app.kubernetes.io/component']).toBe('vscode-extension');
+    expect(componentAttributes['che-theia.eclipse.org/vscode-extensions']).toStrictEqual(['http://first.vsix']);
+    expect(componentAttributes['che-theia.eclipse.org/vscode-preferences']).toStrictEqual({ foo: 'bar' });
+  });
+
+  test('basics no sidecarname and preferences', async () => {
+    const entry: VSCodeExtensionEntryWithSidecar = {
+      id: 'plugin',
+      resolved: true,
+      extensions: ['http://first.vsix'],
+      sidecar: {
+        image: 'my-image',
+      },
+    };
+    const components = await sidecarComponentsCreator.create([entry]);
+    expect(containerPluginRemoteUpdaterUpdateMethod).toBeCalledWith(`sidecar-${entry.id}`, entry.sidecar);
+    expect(components.length).toBe(1);
+    const component = components[0];
+    expect(component.name).toBe(`sidecar-${entry.id}`);
+    expect(component.container).toBe(entry.sidecar);
+    const componentAttributes = component.attributes || ({} as any);
+    expect(componentAttributes['app.kubernetes.io/part-of']).toBe('che-theia.eclipse.org');
+    expect(componentAttributes['app.kubernetes.io/component']).toBe('vscode-extension');
+    expect(componentAttributes['che-theia.eclipse.org/vscode-extensions']).toStrictEqual(['http://first.vsix']);
+    expect(componentAttributes['che-theia.eclipse.org/vscode-preferences']).toBeUndefined();
+  });
+});

--- a/tools/devworkspace-handler/tests/devfile/vscode-extension-json-analyzer.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/vscode-extension-json-analyzer.spec.ts
@@ -1,0 +1,56 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+import { Container } from 'inversify';
+import { VscodeExtensionJsonAnalyzer } from '../../src/devfile/vscode-extension-json-analyzer';
+
+describe('Test VscodeExtensionJsonAnalyzer', () => {
+  let container: Container;
+
+  let vscodeExtensionJsonAnalyzer: VscodeExtensionJsonAnalyzer;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(VscodeExtensionJsonAnalyzer).toSelf().inSingletonScope();
+    vscodeExtensionJsonAnalyzer = container.get(VscodeExtensionJsonAnalyzer);
+  });
+
+  test('basic', async () => {
+    const vscodeExtensionJsonPath = path.resolve(__dirname, '..', '_data', 'vscode', 'vscode-extensions.json');
+    const vscodeExtensionJsonContent = await fs.readFile(vscodeExtensionJsonPath, 'utf-8');
+
+    const entries = await vscodeExtensionJsonAnalyzer.extractPlugins(vscodeExtensionJsonContent);
+    expect(entries.length).toBe(2);
+    expect(entries[0]).toStrictEqual({
+      id: 'dbaeumer/vscode-eslint/latest',
+      resolved: false,
+      optional: true,
+      extensions: [],
+    });
+    expect(entries[1]).toStrictEqual({
+      id: 'editorconfig/editorconfig/latest',
+      resolved: false,
+      optional: true,
+      extensions: [],
+    });
+  });
+
+  test('invalid json / empty', async () => {
+    const entries = await vscodeExtensionJsonAnalyzer.extractPlugins('foo');
+    expect(entries.length).toBe(0);
+  });
+});

--- a/tools/devworkspace-handler/tests/entrypoint.spec.ts
+++ b/tools/devworkspace-handler/tests/entrypoint.spec.ts
@@ -1,0 +1,53 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import 'reflect-metadata';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const startMethodMock = jest.fn();
+
+jest.mock('../src/main', () => ({
+  Main: function () {
+    return { start: startMethodMock };
+  },
+}));
+
+describe('Test Entrypoint', () => {
+  const originalProcessExitCode = process.exitCode;
+  const originalConsoleError = console.error;
+  const mockedConsoleError = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+    jest.resetModules();
+    console.error = mockedConsoleError;
+  });
+  afterEach(() => {
+    console.error = originalConsoleError;
+    process.exitCode = originalProcessExitCode;
+  });
+
+  test('entrypoint', async () => {
+    startMethodMock.mockResolvedValue(true);
+    await require('../src/entrypoint');
+    expect(startMethodMock).toBeCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  test('entrypoint fail to start', async () => {
+    const spyExit = jest.spyOn(process, 'exit');
+    const value: never = {} as never;
+    spyExit.mockReturnValue(value);
+    await require('../src/entrypoint');
+    startMethodMock.mockResolvedValue(false);
+    expect(spyExit).toBeCalled();
+    expect(startMethodMock).toBeCalled();
+  });
+});

--- a/tools/devworkspace-handler/tests/fetch/url-fetcher.spec.ts
+++ b/tools/devworkspace-handler/tests/fetch/url-fetcher.spec.ts
@@ -1,0 +1,75 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { UrlFetcher } from '../../src/fetch/url-fetcher';
+
+class Custom404Error extends Error {
+  public response = {
+    status: 404,
+  };
+}
+
+class Custom500Error extends Error {
+  public response = {
+    status: 500,
+  };
+}
+
+describe('Test UrlFetcher', () => {
+  let container: Container;
+
+  const axiosGetMock = jest.fn();
+  const axiosMock = {
+    get: axiosGetMock,
+  } as any;
+
+  let urlFetcher: UrlFetcher;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(UrlFetcher).toSelf().inSingletonScope();
+    container.bind(Symbol.for('AxiosInstance')).toConstantValue(axiosMock);
+    urlFetcher = container.get(UrlFetcher);
+  });
+
+  test('basic fetchTextOptionalContent', async () => {
+    const content = 'abcd';
+    axiosGetMock.mockResolvedValue({ data: content });
+    const value = await urlFetcher.fetchTextOptionalContent('http://fake-entry');
+    expect(axiosGetMock).toBeCalledWith('http://fake-entry', { responseType: 'text' });
+    expect(value).toBe(content);
+  });
+
+  test('basic 404 error empty fetchTextOptionalContent', async () => {
+    axiosGetMock.mockImplementation(() => Promise.reject(new Custom404Error()));
+    const value = await urlFetcher.fetchTextOptionalContent('http://fake-entry');
+    expect(axiosGetMock).toBeCalledWith('http://fake-entry', { responseType: 'text' });
+    expect(value).toBeUndefined();
+  });
+
+  test('basic 500 error empty fetchTextOptionalContent', async () => {
+    axiosGetMock.mockImplementation(() => Promise.reject(new Custom500Error()));
+    await expect(urlFetcher.fetchTextOptionalContent('http://fake-entry')).rejects.toThrow();
+    expect(axiosGetMock).toBeCalledWith('http://fake-entry', { responseType: 'text' });
+  });
+
+  test('basic fetchText', async () => {
+    const content = 'abcd';
+    axiosGetMock.mockResolvedValue({ data: content });
+    const value = await urlFetcher.fetchText('http://fake-entry');
+    expect(axiosGetMock).toBeCalledWith('http://fake-entry', { responseType: 'text' });
+    expect(value).toBe(content);
+  });
+});

--- a/tools/devworkspace-handler/tests/generate.spec.ts
+++ b/tools/devworkspace-handler/tests/generate.spec.ts
@@ -1,0 +1,97 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import * as fs from 'fs-extra';
+import * as jsYaml from 'js-yaml';
+
+import { CheTheiaPluginsDevfileResolver } from '../src/devfile/che-theia-plugins-devfile-resolver';
+import { Container } from 'inversify';
+import { Generate } from '../src/generate';
+import { GithubResolver } from '../src/github/github-resolver';
+import { PluginRegistryResolver } from '../src/plugin-registry/plugin-registry-resolver';
+import { SidecarPolicy } from '../src/api/devfile-context';
+import { UrlFetcher } from '../src/fetch/url-fetcher';
+
+describe('Test Generate', () => {
+  let container: Container;
+
+  let generate: Generate;
+
+  const getContentUrlMethod = jest.fn();
+  const githubUrlMock = {
+    getContentUrl: getContentUrlMethod,
+  };
+
+  const urlFetcherFetchTextMethod = jest.fn();
+  const urlFetcherFetchTextOptionalContentMethod = jest.fn();
+  const urlFetcher = {
+    fetchText: urlFetcherFetchTextMethod,
+    fetchTextOptionalContent: urlFetcherFetchTextOptionalContentMethod,
+  } as any;
+
+  const githubResolverResolveMethod = jest.fn();
+  const githubResolver = {
+    resolve: githubResolverResolveMethod,
+  } as any;
+
+  const cheTheiaPluginsDevfileResolverHandleMethod = jest.fn();
+  const cheTheiaPluginsDevfileResolver = {
+    handle: cheTheiaPluginsDevfileResolverHandleMethod,
+  } as any;
+
+  const pluginRegistryResolverLoadDevfilePluginMethod = jest.fn();
+  const pluginRegistryResolver = {
+    loadDevfilePlugin: pluginRegistryResolverLoadDevfilePluginMethod,
+  } as any;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(Generate).toSelf().inSingletonScope();
+    container.bind(UrlFetcher).toConstantValue(urlFetcher);
+    container.bind(CheTheiaPluginsDevfileResolver).toConstantValue(cheTheiaPluginsDevfileResolver);
+    container.bind(PluginRegistryResolver).toConstantValue(pluginRegistryResolver);
+    container.bind(GithubResolver).toConstantValue(githubResolver);
+    githubResolverResolveMethod.mockReturnValue(githubUrlMock);
+
+    generate = container.get(Generate);
+  });
+
+  test('basics', async () => {
+    pluginRegistryResolverLoadDevfilePluginMethod.mockResolvedValue({
+      schemaVersion: '2.1.0',
+      metadata: {
+        name: 'theia-ide',
+      },
+      commands: [],
+    });
+
+    const devfileUrl = 'http://my-devfile-url';
+    const fakeoutputDir = '/fake-output';
+    const editor = 'my/editor/latest';
+
+    const fsWriteFileSpy = jest.spyOn(fs, 'writeFile');
+    fsWriteFileSpy.mockReturnValue();
+
+    const rawDevfileUrl = 'https://content-of-devfile.url';
+    getContentUrlMethod.mockReturnValue(rawDevfileUrl);
+
+    urlFetcherFetchTextMethod.mockResolvedValue(jsYaml.dump({ metadata: {} }));
+
+    await generate.generate(devfileUrl, editor, SidecarPolicy.USE_DEV_CONTAINER, fakeoutputDir);
+    expect(urlFetcherFetchTextMethod).toBeCalledWith(rawDevfileUrl);
+
+    // expect to write the file
+    expect(fsWriteFileSpy).toBeCalled();
+  });
+});

--- a/tools/devworkspace-handler/tests/github/github-resolver.spec.ts
+++ b/tools/devworkspace-handler/tests/github/github-resolver.spec.ts
@@ -1,0 +1,47 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { GithubResolver } from '../../src/github/github-resolver';
+
+describe('Test PluginRegistryResolver', () => {
+  let container: Container;
+
+  let githubResolver: GithubResolver;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(GithubResolver).toSelf().inSingletonScope();
+    githubResolver = container.get(GithubResolver);
+  });
+
+  test('basic resolve', async () => {
+    expect(githubResolver.resolve('http://github.com/eclipse/che').getUrl()).toBe(
+      'https://github.com/eclipse/che/tree/HEAD/'
+    );
+    expect(githubResolver.resolve('https://github.com/eclipse/che/tree/7.30.x').getUrl()).toBe(
+      'https://github.com/eclipse/che/tree/7.30.x/'
+    );
+
+    expect(githubResolver.resolve('http://github.com/eclipse/che').getContentUrl('README.md')).toBe(
+      'https://raw.githubusercontent.com/eclipse/che/HEAD/README.md'
+    );
+  });
+
+  test('error', async () => {
+    expect(() => {
+      githubResolver.resolve('http://unknown/che');
+    }).toThrow('Invalid github URL:');
+  });
+});

--- a/tools/devworkspace-handler/tests/inversify/inversify-binding.spec.ts
+++ b/tools/devworkspace-handler/tests/inversify/inversify-binding.spec.ts
@@ -1,0 +1,93 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import 'reflect-metadata';
+
+import * as axios from 'axios';
+import * as fs from 'fs-extra';
+
+import { InversifyBinding, InversifyBindingOptions } from '../../src/inversify/inversify-binding';
+
+import { CheTheiaComponentFinder } from '../../src/devfile/che-theia-component-finder';
+import { CheTheiaComponentUpdater } from '../../src/devfile/che-theia-component-updater';
+import { CheTheiaPluginDevContainerMerger } from '../../src/devfile/che-theia-plugin-devcontainer-merger';
+import { CheTheiaPluginSidecarMerger } from '../../src/devfile/che-theia-plugin-sidecar-merger';
+import { CheTheiaPluginsAnalyzer } from '../../src/devfile/che-theia-plugins-analyzer';
+import { CheTheiaPluginsDevfileResolver } from '../../src/devfile/che-theia-plugins-devfile-resolver';
+import { Container } from 'inversify';
+import { ContainerPluginRemoteUpdater } from '../../src/devfile/container-plugin-remote-updater';
+import { DevContainerComponentFinder } from '../../src/devfile/dev-container-component-finder';
+import { DevContainerComponentUpdater } from '../../src/devfile/dev-container-component-updater';
+import { DevWorkspaceUpdater } from '../../src/devfile/devworkspace-updater';
+import { Generate } from '../../src/generate';
+import { GithubResolver } from '../../src/github/github-resolver';
+import { PluginRegistryResolver } from '../../src/plugin-registry/plugin-registry-resolver';
+import { SidecarComponentsCreator } from '../../src/devfile/sidecar-components-creator';
+import { UrlFetcher } from '../../src/fetch/url-fetcher';
+import { VscodeExtensionJsonAnalyzer } from '../../src/devfile/vscode-extension-json-analyzer';
+import { VsixInstallerComponentUpdater } from '../../src/vsix-installer/vsix-installer-component-updater';
+
+describe('Test InversifyBinding', () => {
+  const mockedArgv: string[] = ['dummy', 'dummy'];
+  const originalProcessArgv = process.argv;
+
+  beforeEach(() => {
+    mockedArgv.length = 2;
+    process.argv = mockedArgv;
+    const fsMkdirsSpy = jest.spyOn(fs, 'mkdirs');
+    fsMkdirsSpy.mockReturnValue();
+  });
+  afterEach(() => (process.argv = originalProcessArgv));
+
+  test('default', async () => {
+    const inversifyBinding = new InversifyBinding();
+
+    const axiosInstance = axios.default;
+    const options: InversifyBindingOptions = {
+      pluginRegistryUrl: 'http://fake-registry',
+      axiosInstance,
+      insertTemplates: false,
+    };
+
+    const container: Container = await inversifyBinding.initBindings(options);
+    container.bind(Generate).toSelf().inSingletonScope();
+
+    expect(inversifyBinding).toBeDefined();
+
+    // check devfile module
+    expect(container.get(CheTheiaComponentFinder)).toBeDefined();
+    expect(container.get(CheTheiaComponentUpdater)).toBeDefined();
+    expect(container.get(CheTheiaPluginDevContainerMerger)).toBeDefined();
+    expect(container.get(CheTheiaPluginSidecarMerger)).toBeDefined();
+    expect(container.get(CheTheiaPluginsAnalyzer)).toBeDefined();
+    expect(container.get(CheTheiaPluginsDevfileResolver)).toBeDefined();
+    expect(container.get(ContainerPluginRemoteUpdater)).toBeDefined();
+    expect(container.get(DevContainerComponentFinder)).toBeDefined();
+    expect(container.get(DevContainerComponentUpdater)).toBeDefined();
+    expect(container.get(DevWorkspaceUpdater)).toBeDefined();
+    expect(container.get(SidecarComponentsCreator)).toBeDefined();
+    expect(container.get(VscodeExtensionJsonAnalyzer)).toBeDefined();
+
+    // check fetch module
+    expect(container.get(UrlFetcher)).toBeDefined();
+
+    // check github module
+    expect(container.get(GithubResolver)).toBeDefined();
+
+    // check plugin-registry module
+    expect(container.get(PluginRegistryResolver)).toBeDefined();
+
+    // check vsix-installer module
+    expect(container.get(VsixInstallerComponentUpdater)).toBeDefined();
+
+    // check main module
+    expect(container.get(Generate)).toBeDefined();
+  });
+});

--- a/tools/devworkspace-handler/tests/main.spec.ts
+++ b/tools/devworkspace-handler/tests/main.spec.ts
@@ -1,0 +1,170 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { InversifyBinding } from '../src/inversify/inversify-binding';
+import { Main } from '../src/main';
+import { SidecarPolicy } from '../src/api/devfile-context';
+
+describe('Test Main with stubs', () => {
+  const FAKE_DEVFILE_URL = 'http://fake-devfile-url';
+  const FAKE_OUTPUT_FILE = '/fake-output';
+  const FAKE_PLUGIN_REGISTRY_URL = 'http://fake-plugin-registry-url';
+  const FAKE_EDITOR = 'fake/editor';
+  const SIDECAR_POLICY = SidecarPolicy.MERGE_IMAGE.toString();
+
+  const originalConsoleError = console.error;
+  const mockedConsoleError = jest.fn();
+
+  const originalConsoleLog = console.log;
+  const mockedConsoleLog = jest.fn();
+
+  const generateMethod = jest.fn();
+  const originalArgs = process.argv;
+  const selfMock = {
+    inSingletonScope: jest.fn(),
+  };
+  const toSelfMethod = jest.fn();
+  const bindMock = {
+    toSelf: toSelfMethod,
+  };
+  const generateMock = {
+    generate: generateMethod as any,
+  };
+
+  const containerBindMethod = jest.fn();
+  const containerGetMethod = jest.fn();
+  const container = {
+    bind: containerBindMethod,
+    get: containerGetMethod,
+  } as any;
+  let spyInitBindings;
+
+  function initArgs(
+    devfileUrl: string | undefined,
+    outputFile: string | undefined,
+    pluginRegistryUrl: string | undefined,
+    editor: string | undefined,
+    sidecarPolicy: string | undefined
+  ) {
+    // empty args
+    process.argv = ['', ''];
+    if (devfileUrl) {
+      process.argv.push(`--devfile-url:${devfileUrl}`);
+    }
+    if (outputFile) {
+      process.argv.push(`--output-file:${outputFile}`);
+    }
+    if (pluginRegistryUrl) {
+      process.argv.push(`--plugin-registry-url:${pluginRegistryUrl}`);
+    }
+    if (editor) {
+      process.argv.push(`--editor:${editor}`);
+    }
+    if (sidecarPolicy) {
+      process.argv.push(`--sidecar-policy:${sidecarPolicy}`);
+    }
+  }
+
+  beforeEach(() => {
+    initArgs(FAKE_DEVFILE_URL, FAKE_OUTPUT_FILE, FAKE_PLUGIN_REGISTRY_URL, FAKE_EDITOR, SIDECAR_POLICY);
+    spyInitBindings = jest.spyOn(InversifyBinding.prototype, 'initBindings');
+    spyInitBindings.mockImplementation(() => Promise.resolve(container));
+    toSelfMethod.mockReturnValue(selfMock), containerBindMethod.mockReturnValue(bindMock);
+    containerGetMethod.mockReturnValue(generateMock);
+  });
+
+  afterEach(() => {
+    process.argv = originalArgs;
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+  });
+
+  beforeEach(() => {
+    console.error = mockedConsoleError;
+    console.log = mockedConsoleLog;
+  });
+  afterEach(() => {
+    console.error = originalConsoleError;
+    console.log = originalConsoleLog;
+  });
+
+  test('success with mergeImage', async () => {
+    const main = new Main();
+    const returnCode = await main.start();
+    expect(returnCode).toBeTruthy();
+    expect(generateMethod).toBeCalledWith(FAKE_DEVFILE_URL, FAKE_EDITOR, SIDECAR_POLICY, FAKE_OUTPUT_FILE);
+    expect(mockedConsoleError).toBeCalledTimes(0);
+  });
+
+  test('success with devContainer merge', async () => {
+    const main = new Main();
+    initArgs(
+      FAKE_DEVFILE_URL,
+      FAKE_OUTPUT_FILE,
+      FAKE_PLUGIN_REGISTRY_URL,
+      FAKE_EDITOR,
+      SidecarPolicy.USE_DEV_CONTAINER.toString()
+    );
+    const returnCode = await main.start();
+    expect(returnCode).toBeTruthy();
+    expect(generateMethod).toBeCalledWith(
+      FAKE_DEVFILE_URL,
+      FAKE_EDITOR,
+      SidecarPolicy.USE_DEV_CONTAINER.toString(),
+      FAKE_OUTPUT_FILE
+    );
+    expect(mockedConsoleError).toBeCalledTimes(0);
+  });
+
+  test('missing devfile', async () => {
+    const main = new Main();
+    initArgs(undefined, FAKE_OUTPUT_FILE, FAKE_PLUGIN_REGISTRY_URL, FAKE_EDITOR, SIDECAR_POLICY);
+    const returnCode = await main.start();
+    expect(mockedConsoleError).toBeCalled();
+    expect(mockedConsoleError.mock.calls[1][1].toString()).toContain('missing --devfile-url: parameter');
+    expect(returnCode).toBeFalsy();
+    expect(generateMethod).toBeCalledTimes(0);
+  });
+
+  test('missing outputfile', async () => {
+    const main = new Main();
+    initArgs(FAKE_DEVFILE_URL, undefined, undefined, undefined, undefined);
+    const returnCode = await main.start();
+    expect(mockedConsoleError).toBeCalled();
+    expect(mockedConsoleError.mock.calls[1][1].toString()).toContain('missing --output-file: parameter');
+    expect(returnCode).toBeFalsy();
+    expect(generateMethod).toBeCalledTimes(0);
+  });
+
+  test('invalid sidecar policy', async () => {
+    const main = new Main();
+    initArgs(FAKE_DEVFILE_URL, undefined, undefined, undefined, 'FOO');
+    const returnCode = await main.start();
+    expect(mockedConsoleError).toBeCalled();
+    expect(mockedConsoleError.mock.calls[1][1].toString()).toContain(
+      'FOO is not a valid sidecar policy. Available values are'
+    );
+    expect(returnCode).toBeFalsy();
+    expect(generateMethod).toBeCalledTimes(0);
+  });
+
+  test('error', async () => {
+    jest.spyOn(InversifyBinding.prototype, 'initBindings').mockImplementation(() => {
+      throw new Error('Dummy error');
+    });
+    const main = new Main();
+    const returnCode = await main.start();
+    expect(mockedConsoleError).toBeCalled();
+    expect(returnCode).toBeFalsy();
+    expect(generateMethod).toBeCalledTimes(0);
+  });
+});

--- a/tools/devworkspace-handler/tests/plugin-registry/plugin-registry-resolver.spec.ts
+++ b/tools/devworkspace-handler/tests/plugin-registry/plugin-registry-resolver.spec.ts
@@ -1,0 +1,142 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import * as jsYaml from 'js-yaml';
+
+import { Container } from 'inversify';
+import { PluginRegistryResolver } from '../../src/plugin-registry/plugin-registry-resolver';
+import { UrlFetcher } from '../../src/fetch/url-fetcher';
+import { VSCodeExtensionEntry } from '../../src/api/vscode-extension-entry';
+
+describe('Test PluginRegistryResolver', () => {
+  let container: Container;
+
+  const originalConsoleError = console.error;
+  const mockedConsoleError = jest.fn();
+
+  const urlFetcherFetchTextMock = jest.fn();
+  const urlFetcherFetchTextOptionalMock = jest.fn();
+  const urlFetcher = {
+    fetchText: urlFetcherFetchTextMock,
+    fetchTextOptionalContent: urlFetcherFetchTextOptionalMock,
+  } as any;
+
+  let pluginRegistryResolver: PluginRegistryResolver;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(PluginRegistryResolver).toSelf().inSingletonScope();
+    container.bind(UrlFetcher).toConstantValue(urlFetcher);
+    container.bind('string').toConstantValue('http://fake-plugin-registry').whenTargetNamed('PLUGIN_REGISTRY_URL');
+    pluginRegistryResolver = container.get(PluginRegistryResolver);
+    console.error = mockedConsoleError;
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  test('basic resolve', async () => {
+    const entries: VSCodeExtensionEntry[] = [];
+    const unresolvedOptionalEntry: VSCodeExtensionEntry = {
+      id: 'unresolved',
+      resolved: false,
+      optional: true,
+      extensions: [],
+      dependencies: [],
+    };
+
+    const resolvedEntry: VSCodeExtensionEntry = {
+      id: 'resolved',
+      resolved: true,
+      optional: true,
+      extensions: [],
+      dependencies: [],
+    };
+
+    // first call mock
+    const dummySidecarName = 'dummy-sidecar';
+    const preferences = { hello: 'world' };
+    const extensions = ['http://fake-vsix'];
+    urlFetcherFetchTextOptionalMock.mockResolvedValueOnce(
+      JSON.stringify({
+        preferences,
+        extensions,
+        dependencies: ['dep1'],
+        sidecar: {
+          name: dummySidecarName,
+        },
+      })
+    );
+    // second call mock
+    urlFetcherFetchTextOptionalMock.mockResolvedValueOnce(
+      JSON.stringify({
+        preferences,
+      })
+    );
+    entries.push(unresolvedOptionalEntry, resolvedEntry);
+    await pluginRegistryResolver.resolve(entries);
+    expect(unresolvedOptionalEntry.sidecarName).toBe(dummySidecarName);
+    expect(unresolvedOptionalEntry.preferences).toStrictEqual(preferences);
+    expect(unresolvedOptionalEntry.extensions).toStrictEqual(extensions);
+    expect(unresolvedOptionalEntry.resolved).toBeTruthy();
+
+    // already resolved so we don't have anything being changed
+    expect(resolvedEntry.sidecarName).toBeUndefined();
+    expect(resolvedEntry.preferences).toBeUndefined();
+    expect(resolvedEntry.resolved).toBeTruthy();
+  });
+
+  test('optional and missing in the registry', async () => {
+    const entries: VSCodeExtensionEntry[] = [];
+    const unresolvedOptionalEntry: VSCodeExtensionEntry = {
+      id: 'unresolved',
+      resolved: false,
+      optional: true,
+      extensions: [],
+      dependencies: [],
+    };
+
+    entries.push(unresolvedOptionalEntry);
+    await pluginRegistryResolver.resolve(entries);
+    expect(mockedConsoleError).toBeCalledWith(
+      expect.stringMatching(/is missing on the plug-in registry but it is flagged as optional/)
+    );
+  });
+
+  test('mandatory and missing in the registry', async () => {
+    const entries: VSCodeExtensionEntry[] = [];
+    const unresolvedOptionalEntry: VSCodeExtensionEntry = {
+      id: 'unresolved',
+      resolved: false,
+      optional: false,
+      extensions: [],
+      dependencies: [],
+    };
+
+    entries.push(unresolvedOptionalEntry);
+    await expect(pluginRegistryResolver.resolve(entries)).rejects.toThrow(
+      'is a mandatory plug-in but definition is not found on the plug-in registry'
+    );
+  });
+
+  test('basic loadDevfilePlugin', async () => {
+    const myId = 'foo';
+    const dummy = { dummyContent: 'dummy' };
+    urlFetcherFetchTextMock.mockResolvedValue(jsYaml.dump(dummy));
+    const content = await pluginRegistryResolver.loadDevfilePlugin(myId);
+    expect(urlFetcherFetchTextMock).toBeCalledWith('http://fake-plugin-registry/plugins/foo/devfile.yaml');
+    expect(content).toStrictEqual(dummy);
+  });
+});

--- a/tools/devworkspace-handler/tests/vsix-installer/vsix-installer-component-updater.spec.ts
+++ b/tools/devworkspace-handler/tests/vsix-installer/vsix-installer-component-updater.spec.ts
@@ -1,0 +1,64 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import 'reflect-metadata';
+
+import { Container } from 'inversify';
+import { DevfileContext } from '../../src/api/devfile-context';
+import { V1alpha2DevWorkspaceTemplate } from '@devfile/api';
+import { VsixInstallerComponentUpdater } from '../../src/vsix-installer/vsix-installer-component-updater';
+
+describe('Test VsixInstallerComponentUpdater', () => {
+  let container: Container;
+
+  let vsixInstallerComponentUpdater: VsixInstallerComponentUpdater;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+    container = new Container();
+    container.bind(VsixInstallerComponentUpdater).toSelf().inSingletonScope();
+    vsixInstallerComponentUpdater = container.get(VsixInstallerComponentUpdater);
+  });
+
+  test('basics', async () => {
+    const devWorkspaceTemplates: V1alpha2DevWorkspaceTemplate[] = [];
+    const devWorkspace = {
+      spec: {
+        template: {
+          components: [],
+        },
+      },
+    };
+    const suffix = 'my-suffix';
+    const devfileContext = ({ devWorkspace, devWorkspaceTemplates, suffix } as any) as DevfileContext;
+    await vsixInstallerComponentUpdater.add(devfileContext);
+    // a new template added
+    expect(devWorkspaceTemplates.length).toBe(1);
+    const template = devWorkspaceTemplates[0] as any;
+    expect(template.metadata.name).toBe('che-theia-vsix-installer-my-suffix');
+  });
+
+  test('error if missing spec template components', async () => {
+    const devWorkspace = {
+      spec: {
+        template: {},
+      },
+    };
+    const devfileContext = { devWorkspace } as DevfileContext;
+    await expect(vsixInstallerComponentUpdater.add(devfileContext)).rejects.toThrow('No components');
+  });
+
+  test('error if missing spec components', async () => {
+    const devWorkspace = {};
+    const devfileContext = { devWorkspace } as DevfileContext;
+    await expect(vsixInstallerComponentUpdater.add(devfileContext)).rejects.toThrow('No components');
+  });
+});

--- a/tools/devworkspace-handler/tsconfig.json
+++ b/tools/devworkspace-handler/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "extends": "../../configs/base.tsconfig",
+    "compilerOptions": {
+        "target": "es6",
+        "lib": [
+            "es6",
+        ],
+        "sourceMap": true,
+        "rootDir": "src",
+        "outDir": "lib",
+        "types": [
+            "node", "jest"
+        ]
+    },
+    "include": [
+        "src"
+    ]
+}

--- a/tools/old/github/github-module.ts
+++ b/tools/old/github/github-module.ts
@@ -1,0 +1,18 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import { ContainerModule, interfaces } from 'inversify';
+
+import { GithubResolver } from './github-resolver';
+
+const githubModule = new ContainerModule((bind: interfaces.Bind) => {
+  bind(GithubResolver).toSelf().inSingletonScope();
+});
+
+export { githubModule };

--- a/tools/old/github/github-resolver.ts
+++ b/tools/old/github/github-resolver.ts
@@ -1,0 +1,40 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { GithubUrl } from './github-url';
+import { injectable } from 'inversify';
+
+/**
+ * Providing a github URL it provides a github URL object allowing to interact
+ */
+@injectable()
+export class GithubResolver {
+  // eslint-disable-next-line max-len
+  static readonly GITHUB_URL_PATTERN = /^(?:http)(?:s)?(?:\:\/\/)github\.com\/(?<repoUser>[^\/]+)\/(?<repoName>[^\/]+)((\/)|(?:\/(blob|tree)\/(?<branchName>[^\/]+)(?:\/(?<subFolder>.*))?))?$/;
+
+  resolve(link: string): GithubUrl {
+    const match = GithubResolver.GITHUB_URL_PATTERN.exec(link);
+    if (!match) {
+      throw new Error(`Invalid github URL: ${link}`);
+    }
+    const repoUser = this.getGroup(match, 'repoUser');
+    const repoName = this.getGroup(match, 'repoName');
+    const branchName = this.getGroup(match, 'branchName', 'HEAD');
+    const subFolder = this.getGroup(match, 'subFolder');
+    return new GithubUrl(repoUser, repoName, branchName, subFolder);
+  }
+
+  getGroup(match: RegExpExecArray, groupName: string, defaultValue?: string) {
+    if (match.groups && match.groups[groupName]) {
+      return match.groups[groupName];
+    }
+    return defaultValue || '';
+  }
+}

--- a/tools/old/github/github-url.ts
+++ b/tools/old/github/github-url.ts
@@ -1,0 +1,35 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/**
+ * Provides helper methods on top of github URL to get for example raw content of get relative links
+ */
+export class GithubUrl {
+  // raw link
+  static readonly RAW_LINK = 'https://cdn.jsdelivr.net/gh';
+
+  constructor(
+    private readonly repoUser: string,
+    private readonly repoName: string,
+    private readonly branchName: string,
+    private readonly subFolder: string
+  ) {}
+
+  /**
+   * Provides the raw link to the given path based on the current repository information
+   */
+  getContentUrl(path: string): string {
+    return `${GithubUrl.RAW_LINK}/${this.repoUser}/${this.repoName}@${this.branchName}/${path}`;
+  }
+
+  getUrl(): string {
+    return `https://github.com/${this.repoUser}/${this.repoName}/tree/${this.branchName}/${this.subFolder}`;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -936,6 +936,17 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@devfile/api@latest":
+  version "0.0.1-1620398714"
+  resolved "https://registry.yarnpkg.com/@devfile/api/-/api-0.0.1-1620398714.tgz#1eb97e463e7a12baa0cdf3dc774be45c7035a8ce"
+  integrity sha512-VFUGWgJlwMAJ44f476TNGg6We5DwkjoHRfOyG0ncZ1sSuUfoTIFtnM95Od7R49sX1n5AQWMsExDR3NH+SKoGhQ==
+  dependencies:
+    "@types/bluebird" "*"
+    "@types/request" "*"
+    bluebird "^3.5.0"
+    request "^2.81.0"
+    rewire "^3.0.2"
+
 "@eclipse-che/api@^7.0.0-beta-4.0", "@eclipse-che/api@^7.3.2", "@eclipse-che/api@latest":
   version "7.30.0"
   resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.30.0.tgz#c6fcdd48dad814e0c48063815ca6b2dbb23d6d63"
@@ -2799,6 +2810,11 @@
   resolved "https://registry.yarnpkg.com/@types/base64-arraybuffer/-/base64-arraybuffer-0.1.0.tgz#739eea0a974d13ae831f96d97d882ceb0b187543"
   integrity sha512-oyV0CGER7tX6OlfnLfGze0XbsA7tfRuTtsQ2JbP8K5KBUzc24yoYRD+0XjMRQgOejvZWeIbtkNaHlE8akzj4aQ==
 
+"@types/bluebird@*":
+  version "3.5.34"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.34.tgz#0e9f1f4f5dfab98a421fb973b5f5690d22411893"
+  integrity sha512-QMc57Pf067Rr78l6f4FftvuIXPYxu0VYFRKrZk1Clv+LWy7gN2fTBiAiv68askFHEHZcTLPFd01kNlpKOiSPgQ==
+
 "@types/body-parser@*", "@types/body-parser@^1.16.4", "@types/body-parser@^1.17.0":
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
@@ -3136,7 +3152,7 @@
   dependencies:
     reflect-metadata "*"
 
-"@types/request@^2.0.3", "@types/request@^2.47.1":
+"@types/request@*", "@types/request@^2.0.3", "@types/request@^2.47.1":
   version "2.48.5"
   resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.5.tgz#019b8536b402069f6d11bee1b2c03e7f232937a0"
   integrity sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==
@@ -4201,6 +4217,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -4424,6 +4445,62 @@ axios@0.21.1, axios@^0.21.0, axios@^0.21.1:
   dependencies:
     follow-redirects "^1.10.0"
 
+babel-code-frame@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
+  integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
+  dependencies:
+    chalk "^1.1.3"
+    esutils "^2.0.2"
+    js-tokens "^3.0.2"
+
+babel-core@^6.26.0:
+  version "6.26.3"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
+  integrity sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-generator "^6.26.0"
+    babel-helpers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-register "^6.26.0"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    convert-source-map "^1.5.1"
+    debug "^2.6.9"
+    json5 "^0.5.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    path-is-absolute "^1.0.1"
+    private "^0.1.8"
+    slash "^1.0.0"
+    source-map "^0.5.7"
+
+babel-generator@^6.26.0:
+  version "6.26.1"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
+  integrity sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==
+  dependencies:
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.17.4"
+    source-map "^0.5.7"
+    trim-right "^1.0.1"
+
+babel-helpers@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.24.1.tgz#3471de9caec388e5c850e597e58a26ddf37602b2"
+  integrity sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
 babel-jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
@@ -4447,6 +4524,13 @@ babel-loader@^8.0.4:
     loader-utils "^1.4.0"
     make-dir "^3.1.0"
     schema-utils "^2.6.5"
+
+babel-messages@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
+  integrity sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=
+  dependencies:
+    babel-runtime "^6.22.0"
 
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
@@ -4500,6 +4584,17 @@ babel-plugin-polyfill-regenerator@^0.2.0:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.2.0"
 
+babel-plugin-transform-es2015-block-scoping@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
+  integrity sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
+
 babel-polyfill@^6.2.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
@@ -4535,13 +4630,67 @@ babel-preset-jest@^26.6.2:
     babel-plugin-jest-hoist "^26.6.2"
     babel-preset-current-node-syntax "^1.0.0"
 
-babel-runtime@^6.26.0:
+babel-register@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
+  integrity sha1-btAhFz4vy0htestFxgCahW9kcHE=
+  dependencies:
+    babel-core "^6.26.0"
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    home-or-tmp "^2.0.0"
+    lodash "^4.17.4"
+    mkdirp "^0.5.1"
+    source-map-support "^0.4.15"
+
+babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
+
+babel-template@^6.24.1, babel-template@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+  integrity sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
+
+babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
+babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
+
+babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+  integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
 back@~0.1.5:
   version "0.1.5"
@@ -4645,7 +4794,7 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bluebird@^3.1.1, bluebird@^3.5.5:
+bluebird@^3.1.1, bluebird@^3.5.0, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -5822,7 +5971,7 @@ conventional-recommended-bump@^6.1.0:
     meow "^8.0.0"
     q "^1.5.1"
 
-convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
+convert-source-map@^1.4.0, convert-source-map@^1.5.1, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
@@ -6290,7 +6439,7 @@ deasync@^0.1.19:
     bindings "^1.5.0"
     node-addon-api "^1.7.1"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -6583,6 +6732,13 @@ detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
+
+detect-indent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
+  integrity sha1-920GQ1LN9Docts5hnE7jqUdd4gg=
+  dependencies:
+    repeating "^2.0.0"
 
 detect-indent@^5.0.0:
   version "5.0.0"
@@ -8364,6 +8520,11 @@ globals@^13.6.0:
   dependencies:
     type-fest "^0.20.2"
 
+globals@^9.18.0:
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+  integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
+
 globby@^11.0.1, globby@^11.0.2:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
@@ -8689,6 +8850,14 @@ hogan.js@^3.0.2:
   dependencies:
     mkdirp "0.3.0"
     nopt "1.0.10"
+
+home-or-tmp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
+  integrity sha1-42w/LSyufXRqhX440Y1fMqeILbg=
+  dependencies:
+    os-homedir "^1.0.0"
+    os-tmpdir "^1.0.1"
 
 homedir-polyfill@^1.0.1:
   version "1.0.3"
@@ -9259,6 +9428,13 @@ into-stream@^3.1.0:
   dependencies:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
+
+invariant@^2.2.2:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
 
 inversify@4.14.0:
   version "4.14.0"
@@ -10193,6 +10369,11 @@ jose@^2.0.5:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-tokens@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+  integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
+
 js-yaml@3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
@@ -10208,6 +10389,13 @@ js-yaml@^3.13.0, js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -10250,6 +10438,11 @@ jsdom@^16.4.0:
     whatwg-url "^8.5.0"
     ws "^7.4.4"
     xml-name-validator "^3.0.0"
+
+jsesc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
+  integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -10325,7 +10518,7 @@ json5@2.x, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
-json5@^0.5.0:
+json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
@@ -10341,6 +10534,11 @@ jsonc-parser@^2.0.2, jsonc-parser@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.3.1.tgz#59549150b133f2efacca48fe9ce1ec0659af2342"
   integrity sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==
+
+jsonc-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
+  integrity sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -10724,7 +10922,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.17.5, lodash@^4.5.1, lodash@^4.7.0, lodash@^4.8.0:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.5.1, lodash@^4.7.0, lodash@^4.8.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -10734,7 +10932,7 @@ loglevel@^1.6.8:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -12068,7 +12266,7 @@ os-locale@^3.0.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -12424,7 +12622,7 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-path-is-absolute@^1.0.0:
+path-is-absolute@^1.0.0, path-is-absolute@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
@@ -13035,6 +13233,11 @@ prismjs@^1.13.0:
   integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==
   optionalDependencies:
     clipboard "^2.0.0"
+
+private@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
+  integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -13762,7 +13965,7 @@ request-promise-native@^1.0.9:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.82.0, request@^2.87.0, request@^2.88.0, request@^2.88.2:
+request@^2.81.0, request@^2.82.0, request@^2.87.0, request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -13922,6 +14125,14 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rewire@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rewire/-/rewire-3.0.2.tgz#25e5413c4f1676eb3247d1884198b3a265408bbd"
+  integrity sha512-ejkkt3qYnsQ38ifc9llAAzuHiGM7kR8N5/mL3aHWgmWwet0OMFcmJB8aTsMV2PBHCWxNVTLCeRfBpEa8X2+1fw==
+  dependencies:
+    babel-core "^6.26.0"
+    babel-plugin-transform-es2015-block-scoping "^6.26.0"
+
 rfc4648@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/rfc4648/-/rfc4648-1.4.0.tgz#c75b2856ad2e2d588b6ddb985d556f1f7f2a2abd"
@@ -13965,6 +14176,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rollup@^2.44.0:
+  version "2.47.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.47.0.tgz#9d958aeb2c0f6a383cacc0401dff02b6e252664d"
+  integrity sha512-rqBjgq9hQfW0vRmz+0S062ORRNJXvwRpzxhFXORvar/maZqY6za3rgQ/p1Glg+j1hnc1GtYyQCPiAei95uTElg==
+  optionalDependencies:
+    fsevents "~2.3.1"
 
 route-parser@^0.0.5:
   version "0.0.5"
@@ -14494,6 +14712,13 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.4.15:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+  integrity sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
+  dependencies:
+    source-map "^0.5.6"
+
 source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
@@ -14512,7 +14737,7 @@ source-map@0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
   integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
 
-source-map@^0.5.0, source-map@^0.5.6:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -15299,6 +15524,11 @@ to-factory@^1.0.0:
   resolved "https://registry.yarnpkg.com/to-factory/-/to-factory-1.0.0.tgz#8738af8bd97120ad1d4047972ada5563bf9479b1"
   integrity sha1-hzivi9lxIK0dQEeXKtpVY7+UebE=
 
+to-fast-properties@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+  integrity sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
@@ -15426,6 +15656,11 @@ trim-repeated@^1.0.0:
   integrity sha1-42RqLqTokTEr9+rObPsFOAvAHCE=
   dependencies:
     escape-string-regexp "^1.0.2"
+
+trim-right@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+  integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
 ts-jest@26.4.3:
   version "26.4.3"


### PR DESCRIPTION
### What does this PR do?
devfile v2 does not include anymore IDE plug-ins

Here is the library that will analyze `.che-theia/che-theia-plugins.yaml` + `.vscode/extensions.json` files and add the annotations/components to the DevWorkspace templates.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19230

### How to test this PR?
you may compile the library, then run

```bash
$ node lib/entrypoint.js --sidecar-policy:"useDevContainer" --devfile-url:https://github.com/benoitf/spring-petclinic/tree/5da9e7f80b66b1fc456faa038c40c848dbd4d50e --output-file:/tmp/all-in-one.yaml
```
 
And then, on a Eclipse Che instance having devWorkspace enabled
```yaml
spec:
  devWorkspace:
    enable: true
```

```bash
$ kubectl apply -f <content-of-the-generated-/tmp/all-in-one.yaml>
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next


Change-Id: Ifa1c23002d44ace7e636bd8969de54adac792f87
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

