### PR TITLE
fix: Icon path must be relative to plugin registry root (#1118)

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
@@ -13,6 +13,7 @@ import { CommandContribution, CommandRegistry } from '@theia/core/lib/common';
 import { inject, injectable } from 'inversify';
 
 import { ChePluginManager } from './che-plugin-manager';
+import { ChePluginRegistry } from '../../common/che-plugin-protocol';
 import { MonacoQuickOpenService } from '@theia/monaco/lib/browser/monaco-quick-open-service';
 import { QuickInputService } from '@theia/core/lib/browser';
 
@@ -77,9 +78,10 @@ export class ChePluginCommandContribution implements CommandContribution {
       return;
     }
 
-    const registry = {
+    const registry: ChePluginRegistry = {
       name,
       uri,
+      publicUri: uri,
     };
 
     this.chePluginManager.addRegistry(registry);

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
@@ -99,7 +99,7 @@ export class ChePluginManager {
       const newPrefs = event.newValue;
       if (newPrefs) {
         for (const repoName of Object.keys(newPrefs)) {
-          this.registryList.push({ name: repoName, uri: newPrefs[repoName] });
+          this.registryList.push({ name: repoName, uri: newPrefs[repoName], publicUri: newPrefs[repoName] });
         }
       }
       // notify that plugin registry list has been changed
@@ -155,6 +155,7 @@ export class ChePluginManager {
           this.registryList.push({
             name: repoName,
             uri: uri,
+            publicUri: uri,
           });
         }
       });

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-plugin-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-plugin-protocol.ts
@@ -17,8 +17,7 @@ export interface ChePluginRegistry {
   // For default registry it's internal URI, taken from workspace settings
   uri: string;
   // Public URI to access the registry resources from browser
-  // If publicUri is not defined, internal ChePluginRegistry:uri is used
-  publicUri?: string;
+  publicUri: string;
 }
 
 export interface ChePlugin {


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Applies https://github.com/eclipse-che/che-theia/pull/1118 to 7.30.x branch

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19771

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
See original PR https://github.com/eclipse-che/che-theia/pull/1118

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
