### PR TITLE
feat(explorer): Display Welcome panel when there are no projects in a devfile

### DIFF
--- a/extensions/eclipse-che-theia-workspace/src/browser/che-navigator-widget.tsx
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-navigator-widget.tsx
@@ -10,17 +10,111 @@
 
 import * as React from 'react';
 
-import { injectable } from 'inversify';
+import { Devfile, DevfileService } from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
 
 import { FileNavigatorWidget } from '@theia/navigator/lib/browser/navigator-widget';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import URI from '@theia/core/lib/common/uri';
+import { WorkspaceInputDialog } from '@theia/workspace/lib/browser/workspace-input-dialog';
+import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
+import { inject } from '@theia/core/shared/inversify';
+import { injectable } from 'inversify';
 
 @injectable()
 export class CheFileNavigatorWidget extends FileNavigatorWidget {
+  @inject(FileService) protected readonly fileService: FileService;
+  @inject(DevfileService) protected readonly devfileService: DevfileService;
+  @inject(WorkspaceService) protected readonly cheWorkspaceService: WorkspaceService;
+
+  protected devfile: Devfile | undefined;
+  protected projectsRootDirectory: string | undefined;
+
   protected renderEmptyMultiRootWorkspace(): React.ReactNode {
+    if (this.devfile) {
+      const projects = this.devfile.projects;
+      if (projects && projects.length > 0) {
+        return this.renderNoProjectsPanel();
+      } else {
+        return this.renderWelcomePanel();
+      }
+    } else {
+      this.initialize().then(() => this.restartRendering());
+
+      return this.renderNoProjectsPanel();
+    }
+  }
+
+  protected renderNoProjectsPanel(): React.ReactNode {
     return (
       <div className="theia-navigator-container">
         <div className="center">No projects in the workspace yet</div>
       </div>
     );
+  }
+
+  protected renderWelcomePanel(): React.ReactNode {
+    return (
+      <div className="theia-navigator-container">
+        <div className="label">No projects in the workspace yet.</div>
+        <div className="label">You can clone a repository from a URL.</div>
+        <div className="open-workspace-button-container">
+          <button
+            className="theia-button open-workspace-button"
+            title="Clone Repository"
+            onClick={this.cloneRepo}
+            onKeyUp={this.keyUpHandler}
+          >
+            Clone Repository
+          </button>
+        </div>
+        <div className="label">You can also add a new folder to the Che workspace.</div>
+        <div className="open-workspace-button-container">
+          <button
+            className="theia-button open-workspace-button"
+            title="Add a new folder to your workspace"
+            onClick={this.newFolderToWorkspace}
+            onKeyUp={this.keyUpHandler}
+          >
+            New Folder
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  protected newFolderToWorkspace = () => {
+    const parent = new URI(this.projectsRootDirectory);
+    const dialog = new WorkspaceInputDialog(
+      {
+        title: 'New Folder',
+        parentUri: new URI(this.projectsRootDirectory),
+        initialValue: 'Untitled',
+      },
+      this.labelProvider
+    );
+    dialog.open().then(async name => {
+      if (name) {
+        const folderUri = parent.resolve(name);
+        await this.fileService.createFolder(folderUri);
+      }
+    });
+  };
+
+  protected cloneRepo = () => {
+    return this.commandService.executeCommand('git.clone');
+  };
+
+  protected async initialize(): Promise<void> {
+    if (!this.devfile) {
+      this.devfile = await this.devfileService.get();
+    }
+
+    if (!this.projectsRootDirectory) {
+      this.projectsRootDirectory = (await this.cheWorkspaceService.getProjectsRootDirectory()) || '/projects';
+    }
+  }
+
+  private async restartRendering(): Promise<void> {
+    super.render();
   }
 }

--- a/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-module.ts
+++ b/extensions/eclipse-che-theia-workspace/src/browser/che-workspace-module.ts
@@ -7,6 +7,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
+
+import '../../src/browser/style/index.css';
+
 import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
 import { Container, ContainerModule, interfaces } from 'inversify';
 import { FileTree, FileTreeModel, FileTreeWidget, createFileTreeContainer } from '@theia/filesystem/lib/browser';

--- a/extensions/eclipse-che-theia-workspace/src/browser/style/index.css
+++ b/extensions/eclipse-che-theia-workspace/src/browser/style/index.css
@@ -1,0 +1,21 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+.theia-navigator-container .label {
+  text-align: center;
+  margin-top: 15px;
+}
+
+.p-Widget .open-workspace-button {
+  padding: 4px 12px;
+  width: calc(100% - var(--theia-ui-padding) * 4);
+  margin-left: 0;
+  margin-bottom: 5px;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4585,7 +4585,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@0.21.1, axios@^0.21.0, axios@^0.21.1:
+axios@0.21.1, axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
   integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Displays `Welcome` panel for the `Explorer` view when there are no projects in a devfile

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![welcome_panel](https://user-images.githubusercontent.com/5676062/123437085-faf55880-d5d7-11eb-9627-1ab0aceb7b5f.png)


https://user-images.githubusercontent.com/5676062/123442491-989f5680-d5dd-11eb-8e3a-f31ba8d3f3e3.mp4



![newFolder](https://user-images.githubusercontent.com/5676062/123438332-40665580-d5d9-11eb-8474-fea88f61c400.gif)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19645

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Start a workspace from a devfile without projects - you should see the `Welcome` panel with `Clone Repository` and `New Folder` buttons in the `Explorer` view.
2. Try to use the buttons.
3. Start a workspace with projects - you shouldn't see the`Welcome` panel. 

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
