### PR TITLE
feat(ports-plugin): Handle devworkspaces

### DIFF
--- a/plugins/ports-plugin/__mocks__/@eclipse-che/plugin.ts
+++ b/plugins/ports-plugin/__mocks__/@eclipse-che/plugin.ts
@@ -14,15 +14,25 @@
  */
 const che: any = {};
 let currentWorkspace: any = undefined;
+let currentDevfile: any = undefined;
 
 che.setWorkspaceOutput = (result: string) => {
   currentWorkspace = JSON.parse(result);
 };
 
+che.setDevfile = (result: any) => {
+  currentDevfile = result;
+};
+
 che.workspace = {};
+che.devfile = {};
 
 che.workspace.getCurrentWorkspace = () => {
   return currentWorkspace;
+};
+
+che.devfile.get = () => {
+  return currentDevfile;
 };
 
 module.exports = che;

--- a/plugins/ports-plugin/src/devfile-handler-devworkspace-impl.ts
+++ b/plugins/ports-plugin/src/devfile-handler-devworkspace-impl.ts
@@ -1,0 +1,119 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as che from '@eclipse-che/plugin';
+
+import { DevfileHandler } from './devfile-handler';
+import { Endpoint } from './endpoint';
+import { EndpointCategory } from './endpoint-category';
+import { EndpointExposure } from './endpoint-exposure';
+
+/**
+ * Handle endpoints retrieval for DevWorkspaces.
+ * It filters all container endpoints and then check if there are some attributes to know if it's user or plug-ins side
+ * @author Florent Benoit
+ */
+interface DevfileContainerComponentWithComponentAttributes extends che.devfile.DevfileContainerComponent {
+  componentAttributes: { [attributeName: string]: string };
+}
+
+interface DevfileComponentEndpointWithComponentAttributes extends che.devfile.DevfileComponentEndpoint {
+  componentAttributes: { [attributeName: string]: string };
+}
+
+export class DevWorkspaceDevfileHandlerImpl implements DevfileHandler {
+  async getEndpoints(): Promise<Array<Endpoint>> {
+    const devfile = await che.devfile.get();
+    const containerComponents: DevfileContainerComponentWithComponentAttributes[] =
+      devfile.components
+        ?.filter(component => component.container)
+        .map(
+          component =>
+            ({
+              ...component.container,
+              componentAttributes: component.attributes,
+            } as DevfileContainerComponentWithComponentAttributes)
+        ) || [];
+
+    const devfileEndpoints: DevfileComponentEndpointWithComponentAttributes[] = containerComponents
+      .map(container =>
+        (container.endpoints || []).map(endpoint => ({
+          ...endpoint,
+          componentAttributes: container.componentAttributes,
+        }))
+      )
+      .reduce((acc, val) => acc.concat(val), []);
+
+    const endpoints = devfileEndpoints.map(exposedEndpoint => {
+      let exposure: EndpointExposure;
+      if (exposedEndpoint.exposure === 'public') {
+        exposure = EndpointExposure.FROM_DEVFILE_PUBLIC;
+      } else if (exposedEndpoint.exposure === 'internal') {
+        exposure = EndpointExposure.FROM_DEVFILE_PRIVATE;
+      } else {
+        exposure = EndpointExposure.FROM_DEVFILE_NONE;
+      }
+
+      // category ? is is part of eclipse che-theia
+      let category;
+      const isPartOfCheTheia =
+        exposedEndpoint.componentAttributes?.['app.kubernetes.io/part-of'] === 'che-theia.eclipse.org';
+      if (isPartOfCheTheia) {
+        category = EndpointCategory.PLUGINS;
+      } else {
+        category = EndpointCategory.USER;
+      }
+      return {
+        name: exposedEndpoint.name,
+        category,
+        exposure,
+        protocol: exposedEndpoint.protocol,
+        url: exposedEndpoint.attributes?.['controller.devfile.io/endpoint-url'],
+        targetPort: exposedEndpoint.targetPort,
+      } as Endpoint;
+    });
+
+    // Add private JWT proxy ports
+    const jwtProxyEnv: string[] = Object.keys(process.env).filter(key =>
+      key.includes('_JWTPROXY_SERVICE_PORT_SERVER_')
+    );
+    jwtProxyEnv.forEach((key, index) => {
+      const value = process.env[key]!.toLocaleLowerCase() || '';
+      const port = parseInt(value);
+      if (!isNaN(port)) {
+        const endpoint: Endpoint = {
+          name: `jwt-proxy-${index + 1}`,
+          exposure: EndpointExposure.FROM_DEVFILE_PRIVATE,
+          url: '',
+          targetPort: port,
+          protocol: 'tcp',
+          type: 'jwt-proxy',
+          category: EndpointCategory.PLUGINS,
+        };
+        endpoints.push(endpoint);
+      }
+    });
+
+    // Theia sidecar remote endpoint
+    [2503, 2504].forEach(port => {
+      endpoints.push({
+        name: 'theia-sidecar-endpoint',
+        exposure: EndpointExposure.FROM_DEVFILE_PRIVATE,
+        url: '',
+        targetPort: port,
+        protocol: 'tcp',
+        type: 'theia-endpoint',
+        category: EndpointCategory.PLUGINS,
+      });
+    });
+
+    return endpoints;
+  }
+}

--- a/plugins/ports-plugin/src/ports-plugin.ts
+++ b/plugins/ports-plugin/src/ports-plugin.ts
@@ -11,6 +11,7 @@
 import * as theia from '@theia/plugin';
 
 import { CheServerDevfileHandlerImpl } from './devfile-handler-che-server-impl';
+import { DevWorkspaceDevfileHandlerImpl } from './devfile-handler-devworkspace-impl';
 import { DevfileHandler } from './devfile-handler';
 import { Endpoint } from './endpoint';
 import { EndpointCategory } from './endpoint-category';
@@ -52,7 +53,11 @@ export class PortsPlugin {
   constructor(private context: theia.PluginContext) {
     this.devfileEndpoints = [];
     this.redirectPorts = [];
-    this.devfileHandler = new CheServerDevfileHandlerImpl();
+    if (process.env.DEVWORKSPACE_COMPONENT_NAME) {
+      this.devfileHandler = new DevWorkspaceDevfileHandlerImpl();
+    } else {
+      this.devfileHandler = new CheServerDevfileHandlerImpl();
+    }
     this.portForwards = new Map();
     this.excludedPorts = [];
     this.endpointsTreeDataProvider = new EndpointsTreeDataProvider();
@@ -257,7 +262,6 @@ export class PortsPlugin {
     });
 
     // first, grab ports of workspace
-    this.devfileHandler = new CheServerDevfileHandlerImpl();
     this.devfileEndpoints = await this.devfileHandler.getEndpoints();
 
     this.redirectPorts = this.devfileEndpoints.filter(endpoint =>

--- a/plugins/ports-plugin/tests/devfile-handler/devfile-handler-devworkspace-impl.spec.ts
+++ b/plugins/ports-plugin/tests/devfile-handler/devfile-handler-devworkspace-impl.spec.ts
@@ -1,0 +1,99 @@
+/**********************************************************************
+ * Copyright (c) 2019-2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+
+import * as che from '@eclipse-che/plugin';
+import * as fs from 'fs-extra';
+import * as jsYaml from 'js-yaml';
+
+import { DevWorkspaceDevfileHandlerImpl } from '../../src/devfile-handler-devworkspace-impl';
+import { DevfileHandler } from '../../src/devfile-handler';
+import { EndpointCategory } from '../../src/endpoint-category';
+import { EndpointExposure } from '../../src/endpoint-exposure';
+
+describe('Test Workspace Endpoints', () => {
+  let devfileHandler: DevfileHandler;
+
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    devfileHandler = new DevWorkspaceDevfileHandlerImpl();
+    jest.resetModules();
+    process.env = {};
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  test('test ports opened', async () => {
+    const output = await fs.readFile(__dirname + '/devworkspace-flattened.yaml', 'utf-8');
+    const devfile = jsYaml.load(output);
+    (che as any).setDevfile(devfile);
+
+    // jwt proxy
+    process.env.SERVERU2DZ64P8_JWTPROXY_SERVICE_PORT_SERVER_4401 = '4401';
+    process.env.SERVERU2DZ64P8_JWTPROXY_SERVICE_PORT_SERVER_4400 = '4400';
+    process.env.SERVERU2DZ64P8_JWTPROXY_SERVICE_PORT_SERVER_4402 = '4402';
+    process.env.SERVERU2DZ64P8_JWTPROXY_SERVICE_PORT_SERVER_EMPTY = '';
+    process.env.SERVERU2DZ64P8_JWTPROXY_SERVICE_PORT_SERVER_INVALID = 'invalid';
+
+    const endpoints = await devfileHandler.getEndpoints();
+
+    expect(endpoints).toBeDefined();
+    expect(Array.isArray(endpoints)).toBe(true);
+    expect(endpoints.length).toBe(15);
+
+    expect(endpoints[0].targetPort).toBe(3100);
+    expect(endpoints[0].url).toBe('https://workspace4bdbaf7a58884128-1.apps.cluster-c1dd.c1dd.sandbox85.opentlc.com/');
+    expect(endpoints[0].name).toBe('theia');
+    expect(endpoints[0].exposure).toBe(EndpointExposure.FROM_DEVFILE_PUBLIC);
+    expect(endpoints[0].category).toBe(EndpointCategory.PLUGINS);
+
+    // check we have JTW proxy endpoints
+    const jwtEndpoints = endpoints.filter(endpoint => endpoint.type === 'jwt-proxy');
+    expect(jwtEndpoints.length).toBe(3);
+    jwtEndpoints.forEach(jwtEndpoint => {
+      expect(jwtEndpoint.category).toBe(EndpointCategory.PLUGINS);
+      expect(jwtEndpoint.exposure).toBe(EndpointExposure.FROM_DEVFILE_PRIVATE);
+      expect(jwtEndpoint.url).toBe('');
+      expect(jwtEndpoint.protocol).toBe('tcp');
+      expect(jwtEndpoint.url).toBe('');
+    });
+  });
+
+  test('test quarkus workspace', async () => {
+    const output = await fs.readFile(__dirname + '/devworkspace-flattened.yaml', 'utf-8');
+    const devfile = jsYaml.load(output);
+    (che as any).setDevfile(devfile);
+
+    const endpoints = await devfileHandler.getEndpoints();
+
+    // check that quarkus debug port is private
+    const result = endpoints.filter(endpoint => endpoint.name === 'debug');
+    expect(result).toBeDefined();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result!.length).toBe(1);
+    const quarkusEndpoint = result[0];
+    expect(quarkusEndpoint.targetPort).toBe(5005);
+    expect(quarkusEndpoint.exposure).toBe(EndpointExposure.FROM_DEVFILE_NONE);
+    expect(quarkusEndpoint.category).toBe(EndpointCategory.USER);
+
+    // check user public endpoints are filtered (when multiple endpoints have the same url/targetport, etc)
+    const userPublicEndpoints = endpoints.filter(
+      endpoint =>
+        endpoint.exposure === EndpointExposure.FROM_DEVFILE_PUBLIC && endpoint.category === EndpointCategory.USER
+    );
+    expect(userPublicEndpoints).toBeDefined();
+    expect(userPublicEndpoints!.length).toBe(1);
+  });
+});

--- a/plugins/ports-plugin/tests/devfile-handler/devworkspace-flattened.yaml
+++ b/plugins/ports-plugin/tests/devfile-handler/devworkspace-flattened.yaml
@@ -1,0 +1,231 @@
+commands:
+- apply:
+    component: vsix-installer
+  attributes:
+    controller.devfile.io/imported-by: che-theia-vsix-installer-workspace4bdbaf7a58884128
+  id: copy-vsix
+- apply:
+    component: remote-runtime-injector
+  attributes:
+    controller.devfile.io/imported-by: theia-ide-workspace4bdbaf7a58884128
+  id: init-container-command
+- apply:
+    component: project-clone
+  id: clone-projects
+components:
+- attributes:
+    app.kubernetes.io/component: vsix-installer
+    app.kubernetes.io/part-of: che-theia.eclipse.org
+    controller.devfile.io/imported-by: che-theia-vsix-installer-workspace4bdbaf7a58884128
+  container:
+    image: quay.io/eclipse/che-theia-vsix-installer:next
+    sourceMapping: /projects
+    volumeMounts:
+    - name: plugins
+      path: /plugins
+  name: vsix-installer
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspace4bdbaf7a58884128
+    app.kubernetes.io/part-of: che-theia.eclipse.org
+  container:
+    cpuLimit: 1500m
+    cpuRequest: 100m
+    endpoints:
+    - attributes:
+        controller.devfile.io/endpoint-url: https://workspace4bdbaf7a58884128-1.apps.cluster-c1dd.c1dd.sandbox85.opentlc.com/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: main
+      exposure: public
+      name: theia
+      protocol: https
+      targetPort: 3100
+    - attributes:
+        controller.devfile.io/endpoint-url: https://workspace4bdbaf7a58884128-2.apps.cluster-c1dd.c1dd.sandbox85.opentlc.com/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: webview
+        unique: true
+      exposure: public
+      name: webviews
+      protocol: https
+      targetPort: 3100
+    - attributes:
+        controller.devfile.io/endpoint-url: https://workspace4bdbaf7a58884128-3.apps.cluster-c1dd.c1dd.sandbox85.opentlc.com/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: mini-browser
+        unique: true
+      exposure: public
+      name: mini-browser
+      protocol: https
+      targetPort: 3100
+    - attributes:
+        controller.devfile.io/endpoint-url: http://workspace4bdbaf7a58884128-4.apps.cluster-c1dd.c1dd.sandbox85.opentlc.com/
+        discoverable: false
+        type: ide-dev
+      exposure: public
+      name: theia-dev
+      protocol: http
+      targetPort: 3130
+    - attributes:
+        controller.devfile.io/endpoint-url: http://workspace4bdbaf7a58884128-5.apps.cluster-c1dd.c1dd.sandbox85.opentlc.com/
+        discoverable: false
+      exposure: public
+      name: theia-redirect-1
+      protocol: http
+      targetPort: 13131
+    - attributes:
+        controller.devfile.io/endpoint-url: http://workspace4bdbaf7a58884128-6.apps.cluster-c1dd.c1dd.sandbox85.opentlc.com/
+        discoverable: false
+      exposure: public
+      name: theia-redirect-2
+      protocol: http
+      targetPort: 13132
+    - attributes:
+        controller.devfile.io/endpoint-url: http://workspace4bdbaf7a58884128-7.apps.cluster-c1dd.c1dd.sandbox85.opentlc.com/
+        discoverable: false
+      exposure: public
+      name: theia-redirect-3
+      protocol: http
+      targetPort: 13133
+    - attributes:
+        controller.devfile.io/endpoint-url: wss://workspace4bdbaf7a58884128-8.apps.cluster-c1dd.c1dd.sandbox85.opentlc.com/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: collocated-terminal
+      exposure: public
+      name: terminal
+      protocol: wss
+      targetPort: 3333
+    env:
+    - name: THEIA_PLUGINS
+      value: local-dir:///plugins
+    - name: HOSTED_PLUGIN_HOSTNAME
+      value: 0.0.0.0
+    - name: HOSTED_PLUGIN_PORT
+      value: "3130"
+    - name: THEIA_HOST
+      value: 0.0.0.0
+    image: quay.io/crw_pr/che-theia:1129
+    memoryLimit: 512M
+    mountSources: true
+    sourceMapping: /projects
+    volumeMounts:
+    - name: plugins
+      path: /plugins
+    - name: theia-local
+      path: /home/theia/.theia
+  name: theia-ide
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspace4bdbaf7a58884128
+  name: plugins
+  volume: {}
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspace4bdbaf7a58884128
+  name: theia-local
+  volume: {}
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspace4bdbaf7a58884128
+  container:
+    command:
+    - /go/bin/che-machine-exec
+    - --url
+    - 0.0.0.0:3333
+    cpuLimit: 500m
+    cpuRequest: 30m
+    image: quay.io/eclipse/che-machine-exec:next
+    memoryLimit: 128Mi
+    memoryRequest: 32Mi
+    sourceMapping: /projects
+  name: che-machine-exec
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspace4bdbaf7a58884128
+  container:
+    cpuLimit: 500m
+    cpuRequest: 30m
+    env:
+    - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+      value: /remote-endpoint/plugin-remote-endpoint
+    - name: REMOTE_ENDPOINT_VOLUME_NAME
+      value: remote-endpoint
+    image: quay.io/eclipse/che-theia-endpoint-runtime-binary:next
+    memoryLimit: 128Mi
+    memoryRequest: 32Mi
+    sourceMapping: /projects
+    volumeMounts:
+    - name: remote-endpoint
+      path: /remote-endpoint
+  name: remote-runtime-injector
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspace4bdbaf7a58884128
+  name: remote-endpoint
+  volume:
+    ephemeral: true
+- attributes:
+    app.kubernetes.io/name: tools
+    che-theia.eclipse.org/vscode-extensions:
+    - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.75.0-60.vsix
+    - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix
+    - https://open-vsx.org/api/vscjava/vscode-java-test/0.28.1/file/vscjava.vscode-java-test-0.28.1.vsix
+    che-theia.eclipse.org/vscode-preferences:
+      java.server.launchMode: Standard
+  container:
+    args:
+    - sh
+    - -c
+    - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
+    env:
+    - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+      value: /remote-endpoint/plugin-remote-endpoint
+    - name: THEIA_PLUGINS
+      value: local-dir:///plugins/sidecars/tools
+    image: quay.io/eclipse/che-java11-maven:nightly
+    memoryLimit: 1536M
+    sourceMapping: /projects
+    endpoints:
+      - attributes:
+          controller.devfile.io/endpoint-url: https://workspace4bdbaf7a58884128-1.apps.cluster-c1dd.c1dd.sandbox85.opentlc.com/debug
+          cookiesAuthEnabled: true
+          discoverable: false
+        exposure: none
+        name: debug
+        protocol: tcp
+        targetPort: 5005
+      - attributes:
+          controller.devfile.io/endpoint-url: https://workspace4bdbaf7a58884128-1.apps.cluster-c1dd.c1dd.sandbox85.opentlc.com/8080
+        exposure: public
+        name: 8080-tcp
+        protocol: tcp
+        targetPort: 8080
+    volumeMounts:
+    - name: m2
+      path: /home/user/.m2
+    - name: remote-endpoint
+      path: /remote-endpoint
+    - name: plugins
+      path: /plugins
+  name: tools
+- name: m2
+  volume:
+    size: 1G
+- container:
+    cpuLimit: 50m
+    cpuRequest: 5m
+    image: quay.io/devfile/project-clone:next
+    memoryLimit: 300Mi
+    memoryRequest: 64Mi
+    mountSources: true
+  name: project-clone
+events:
+  preStart:
+  - copy-vsix
+  - init-container-command
+  - clone-projects
+projects:
+- git:
+    checkoutFrom:
+      revision: devfilev2
+    remotes:
+      origin: https://github.com/che-samples/spring-petclinic
+  name: spring-petclinic


### PR DESCRIPTION
### What does this PR do?
Add support for devworkspaces in ports-plugin
For now when starting a devWorkspace we have a failure saying that extension can't read machines field (which is only che-server implementation)

### Screenshot/screencast of this PR
![image](https://user-images.githubusercontent.com/436777/121529441-b0cb7f00-c9fc-11eb-8fc4-ac4f215e4b49.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19188

### How to test this PR?
Start devWorkspace with che-theia and see that ports-plugin display endpoints

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next

Change-Id: I67d3d67dd52d9ec6a0b12b7aeeb65f7bdf34d801
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
