### PR TITLE
chore(linkless): Use correct base dir for che-theia extensions

### DIFF
--- a/generator/src/generate-assembly.ts
+++ b/generator/src/generate-assembly.ts
@@ -52,7 +52,7 @@ export async function handleCommand(args: any) {
         packageRefPrefix: '../extensions/',
     });
 
-    const extensionsDir = path.resolve(__dirname, '../../extensions');
+    const extensionsDir = path.resolve(cheTheiaDir, 'extensions');
     const folderNames = await fs.readdir(extensionsDir);
     const extensions = new Map<string, string>();
     for (const folderName of folderNames) {

--- a/generator/src/yargs.ts
+++ b/generator/src/yargs.ts
@@ -114,7 +114,7 @@ const commandArgs = yargs
     })
     .command({
         command: 'generate',
-        describe: 'Yarn link to a given theia source tree',
+        describe: 'Generate the che-theia assembly folder',
         handler: handleGenerateCommand,
         builder: generateArgsBuilder,
     })


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes erroneous use of install dir instead of target che-theia dir for finding extensions in che-theia.

### What issues does this PR fix or reference?
che-theia generate is broken in theia-dev image https://github.com/eclipse/che/issues/19943

### How to test this PR?
Follow the instructions in linkless-build.md


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
