### PR TITLE
fix(generator): Increase jest timeout to give the test extra time when CPU is overloaded

### DIFF
--- a/generator/tests/link.spec.ts
+++ b/generator/tests/link.spec.ts
@@ -15,6 +15,8 @@ import * as tmp from 'tmp';
 
 import { handleCommand } from '../src/link';
 
+jest.setTimeout(30000);
+
 describe('Test link command', () => {
     let rootFolderTmp: string;
     let srcFolder: string;


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
If CPU is overloaded, following test is failing due to timeout.
This PR adds an additional timeout in 30 seconds.

```
@eclipse-che/theia-generator: FAIL tests/link.spec.ts (7.606 s)
@eclipse-che/theia-generator:   ● Test link command › test link
@eclipse-che/theia-generator:     : Timeout - Async callback was not invoked within the 5000 ms timeout specified by jest.setTimeout.Timeout - Async callback was not invoked within the 5000 ms timeout specified by jest.setTimeout.Error:
@eclipse-che/theia-generator:       36 |     });
@eclipse-che/theia-generator:       37 |
@eclipse-che/theia-generator:     > 38 |     test('test link', async () => {
@eclipse-che/theia-generator:          |     ^
@eclipse-che/theia-generator:       39 |         await handleCommand({
@eclipse-che/theia-generator:       40 |             theia: theiaFolder,
@eclipse-che/theia-generator:       41 |             'che-theia': srcFolder,
@eclipse-che/theia-generator:       at new Spec (../node_modules/jest-jasmine2/build/jasmine/Spec.js:116:22)
@eclipse-che/theia-generator:       at Suite.<anonymous> (tests/link.spec.ts:38:5)
@eclipse-che/theia-generator:       at Object.<anonymous> (tests/link.spec.ts:18:1)

```

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
No issue

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
- clone che-theia
- build with yarn

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next
