### PR TITLE
fix(ssh-plugin): Disable the plug-in on DevWorkspace as there is no REST API (including ssh)

### DIFF
--- a/plugins/ssh-plugin/src/ssh-plugin.ts
+++ b/plugins/ssh-plugin/src/ssh-plugin.ts
@@ -26,6 +26,11 @@ import { UploadPrivateKey } from './command/upload-private-key';
 import { ViewPublicKey } from './command/view-public-key';
 
 export async function start(): Promise<SSHPlugin> {
+  // disable this plug-in on DevWorkspace as there is no che API / ssh service
+  if (process.env.DEVWORKSPACE_COMPONENT_NAME) {
+    return {} as SSHPlugin;
+  }
+
   const container = new InversifyBinding().initBindings();
 
   // start SSH authentication agent


### PR DESCRIPTION
### What does this PR do?
There is no ssh service yet with DevWorkspace. Disable it when running with devWorkspace instead of showing error messages about not finding SSH service

### Screenshot/screencast of this PR
![image](https://user-images.githubusercontent.com/436777/121704737-500f7580-cad4-11eb-877c-c9ac4dea6a20.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19188

### How to test this PR?
Start with DevWorkspace mode and check ssh-plugin is disabled (no warning notification about failure on ssh keys)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next


Change-Id: I9fe4d0bf637c6fdba805fb1374dd67fbe807e083
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
