### PR TITLE
fix(task): Temporary fix to reveal tasks executed from the myworkspace view

### DIFF
--- a/plugins/containers-plugin/src/containers-tree-data-provider.ts
+++ b/plugins/containers-plugin/src/containers-tree-data-provider.ts
@@ -292,7 +292,9 @@ export async function containersTreeTaskLauncherCommandHandler(label: string, co
       }
       task.definition.target.containerName = containerName;
 
-      theia.tasks.executeTask(task);
+      // temporary executing generic command to fix https://github.com/eclipse/che/issues/19805
+      // theia.tasks.executeTask(task);
+      theia.commands.executeCommand('workbench.action.tasks.runTask', label);
       return;
     }
   }


### PR DESCRIPTION
### What does this PR do?
Fix tasks not being revealed.

This is temporary as it is not possible to provide fix to theia right now. Bug will be fixed for the user.

Note that if the task is available for multiple containers, it would ask in which container to execute even if the user expects it to be executed in the container where the action is located. It shouldn't happen at the moment anyway: 
- not possible to have multiple component attached to the same command in the devfile
- kubernetes type components seem to be buggy. I tried the devfile from https://github.com/sleshchenko/NodeJS-Sample-App/tree/348e76c900527ccc77202c9bcf401df2c89121ed but had no tasks available in the myworkspace

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19805


### How to test this PR?
- with this build of che-theia, 
- open any devfile with task
- from my workspace view, try to execute a task
- the task logs should appear in the theia UI as expected.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
