### PR TITLE
fix(generator): fix excluded packages in production command

### DIFF
--- a/generator/src/conf/.yarnclean
+++ b/generator/src/conf/.yarnclean
@@ -28,6 +28,7 @@ dugite/git/*
 onigasm
 oniguruma
 @theia/monaco
+react
 react-dom
 font-awesome
 @theia/monaco-editor-core


### PR DESCRIPTION
### What does this PR do?
- fixed excluded packages which directly defined on package.json.
- add `react` to `generator/conf/.yarnclean`

 fixed https://github.com/eclipse/che/issues/20056

### How to test this PR?

1. `che-theia init`
2. `yarn`
2. `cd example/assembly`
3. `yarn add react`
4. `cd ../.. && che-theia production`
5. `find production/node_modules -name 'react'`
6. `find production/node_modules/@theia -name 'monaco' `

![image](https://user-images.githubusercontent.com/13031838/124062552-76855880-da63-11eb-9099-48b149190898.png)


