### PR TITLE
chore(theia-dev container): adding libsecret and tig to theia dev container

### DIFF
--- a/dockerfiles/theia-dev/docker/alpine/install-dependencies.dockerfile
+++ b/dockerfiles/theia-dev/docker/alpine/install-dependencies.dockerfile
@@ -16,4 +16,6 @@ RUN apk add --update --no-cache \
     # synchronization tool
     rsync \
     # patch (required in che-theia to apply patches)
-    patch
+    patch \
+    # requirements to run theia with yarn start
+    libsecret

--- a/dockerfiles/theia-dev/docker/ubi8/install-dependencies.dockerfile
+++ b/dockerfiles/theia-dev/docker/ubi8/install-dependencies.dockerfile
@@ -1,3 +1,3 @@
 USER root
-RUN yum install -y curl make cmake gcc gcc-c++ python2 git git-core-doc openssh less bash tar gzip rsync patch \
+RUN yum install -y curl make cmake gcc gcc-c++ python2 git git-core-doc openssh less bash tar gzip rsync patch libsecret \
     && yum -y clean all && rm -rf /var/cache/yum


### PR DESCRIPTION
### What does this PR do?
adding libsecret and tig for theia-dev container to be used in theia and che-theia dogfooding devfiles
- libsecret is required now by Theia. And it is impossible to run yarn start without it.
- tig is a nice cli tool for git to be used by developers.


### Screenshot/screencast of this PR
N/A


### What issues does this PR fix or reference?
N/A


### How to test this PR?
build theia-dev container, push it to quay.io, and use it with theia devfile instead the default theia-dev image https://github.com/eclipse-theia/theia/blob/master/devfile.yaml#L15

running theia after having built it should work.



### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
