### PR TITLE
chore: bug: fix: CRW-1995 according to https://www.npmjs.com/package/keytar need to install libsecret-devel on RHEL systems

### DIFF
--- a/dockerfiles/theia-dev/docker/ubi8/install-dependencies.dockerfile
+++ b/dockerfiles/theia-dev/docker/ubi8/install-dependencies.dockerfile
@@ -1,3 +1,3 @@
 USER root
-RUN yum install -y curl make cmake gcc gcc-c++ python2 git git-core-doc openssh less bash tar gzip rsync patch libsecret \
+RUN yum install -y curl make cmake gcc gcc-c++ python2 git git-core-doc openssh less bash tar gzip rsync patch libsecret libsecret-devel \
     && yum -y clean all && rm -rf /var/cache/yum

--- a/dockerfiles/theia/docker/ubi8/runtime-install-dependencies.dockerfile
+++ b/dockerfiles/theia/docker/ubi8/runtime-install-dependencies.dockerfile
@@ -12,7 +12,7 @@ ARG SSHPASS_VERSION="1.06"
 # Install less for handling git diff properly
 # Install sshpass for handling passwords for SSH keys
 # Install libsecret as Theia requires it
-RUN yum install -y sudo git bzip2 which bash curl openssh less libsecret && \
+RUN yum install -y sudo git bzip2 which bash curl openssh less libsecret libsecret-devel && \
     curl -ssl https://netcologne.dl.sourceforge.net/project/sshpass/sshpass/"${SSHPASS_VERSION}"/sshpass-"${SSHPASS_VERSION}".tar.gz -o sshpass.tar.gz && \
     tar -xvf sshpass.tar.gz && cd sshpass-"${SSHPASS_VERSION}" && ./configure && make install && cd .. && rm -rf sshpass-"${SSHPASS_VERSION}" && \
     yum -y clean all && rm -rf /var/cache/yum


### PR DESCRIPTION
### What does this PR do?

chore: bug: fix: CRW-1995 according to https://www.npmjs.com/package/keytar need to install libsecret-devel on RHEL systems 
chore: bug: fix: put back deleted line that creates theia-source-code.tgz as we need that in downstream bootstrapping

Change-Id: I9b3ed273062cff2a4a6d33ea398131f25dc1f085
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.