### PR TITLE
fix: Fix hostpattern changed warning notification

### DIFF
--- a/extensions/eclipse-che-theia-mini-browser/src/browser/che-mini-browser-environment.ts
+++ b/extensions/eclipse-che-theia-mini-browser/src/browser/che-mini-browser-environment.ts
@@ -41,4 +41,10 @@ export class CheMiniBrowserEnvironment extends MiniBrowserEnvironment {
 
     this._hostPatternPromise = Promise.resolve(miniBrowserHostName);
   }
+
+  get hostPatternPromise(): Promise<string> {
+    return this.environment
+      .getValue(MiniBrowserEndpoint.HOST_PATTERN_ENV)
+      .then(envVar => envVar?.value || MiniBrowserEndpoint.HOST_PATTERN_DEFAULT);
+  }
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-webview-environment.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-webview-environment.ts
@@ -45,6 +45,12 @@ export class CheWebviewEnvironment extends WebviewEnvironment {
     return new URI(host).resolve('webview');
   }
 
+  get hostPatternPromise(): Promise<string> {
+    return this.environments
+      .getValue(WebviewExternalEndpoint.pattern)
+      .then(variable => variable?.value || WebviewExternalEndpoint.defaultPattern);
+  }
+
   protected async getWebviewCheEndpoint(): Promise<string | undefined> {
     const webviewCheEndpoints = await this.endpointService.getEndpointsByType(SERVER_WEBVIEWS_ATTR_VALUE);
     if (webviewCheEndpoints.length === 1) {


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Override `hostPatternPromise` field for `CheWebviewEnvironment` and `CheMiniBrowserEnvironment` classes as they are used by upstream theia.
 
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/20077

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Start a workspace from dev file:
```
apiVersion: 1.0.0
metadata:
  name: wksp-ff9w4
components:
  - type: cheEditor
    reference: 'https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-1168/che_theia_meta.yaml'
```
See: no warning notifications appear.
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
