### PR TITLE
fix(vsix-installer): Should handle relative URLs

### DIFF
--- a/dockerfiles/theia-vsix-installer/src/entrypoint.sh
+++ b/dockerfiles/theia-vsix-installer/src/entrypoint.sh
@@ -20,6 +20,12 @@ for container in $(echo "$WORKSPACE" | sed -e 's|[[,]\({"attributes":{"app.kuber
     mkdir -p "$dest"
     unset IFS
     for url in $(echo "$urls" | sed 's/[",]/ /g' - ); do
+        # check if URL starts with relative:extension/
+        # example of url: "relative:extension/resources/download_jboss_org/jbosstools/static/jdt_ls/stable/java-0.75.0-60.vsix
+        if [[ "$url" =~ ^relative:extension/.* ]]; then
+            # update URL by using the Plugin Registry URL as prefix
+            url=${CHE_PLUGIN_REGISTRY_URL}/${url#relative:extension/}
+        fi
         echo; echo "downloading $urls to $dest"
         curl -L "$url" > "$dest/$(basename "$url")"
     done


### PR DESCRIPTION
### What does this PR do?
Use registry URL as prefix for relative URLS

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20198

### How to test this PR?
Try with offline registry or try to use in the script an url with relative format

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next
