### PR TITLE
fix: ensure registry URL is defined and not exit on error

### DIFF
--- a/dockerfiles/theia-vsix-installer/src/entrypoint.sh
+++ b/dockerfiles/theia-vsix-installer/src/entrypoint.sh
@@ -23,6 +23,11 @@ for container in $(echo "$WORKSPACE" | sed -e 's|[[,]\({"attributes":{"app.kuber
         # check if URL starts with relative:extension/
         # example of url: "relative:extension/resources/download_jboss_org/jbosstools/static/jdt_ls/stable/java-0.75.0-60.vsix
         if [[ "$url" =~ ^relative:extension/.* ]]; then
+            # if there is no CHE_PLUGIN_REGISTRY_URL env var, skip
+            if [ -z "${CHE_PLUGIN_REGISTRY_URL}" ]; then
+                echo "CHE_PLUGIN_REGISTRY_URL env var is not set, skipping relative url ${url}"
+                continue
+            fi
             # update URL by using the Plugin Registry URL as prefix
             url=${CHE_PLUGIN_REGISTRY_URL}/${url#relative:extension/}
         fi


### PR DESCRIPTION
### What does this PR do?
It avoids CrashLoopBackedOff if for some reason it's not set
Due to a bug, the env var may not be set, so just avoid to download the plug-in instead of breaking workspace startup


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20198
https://github.com/eclipse/che/issues/20201


### How to test this PR?
Can be tested on nightly CRW (which has the bug with empty URL + relative URLs)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next

Change-Id: Ibee32589402fd327d8c6af590499aaf8d1b0898f
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
