### PR TITLE
fix(workspace-plugins): fix custom workspace folders

### DIFF
--- a/plugins/workspace-plugin/src/workspace-projects-manager.ts
+++ b/plugins/workspace-plugin/src/workspace-projects-manager.ts
@@ -74,12 +74,9 @@ export class WorkspaceProjectsManager {
       // we need it to support workspaces which were created before switching multi-root mode to ON by default
       for (const project of projects) {
         const projectPath = this.getProjectPath(project);
-        // All projects should be added to the default workspace
-        // But only the project which defined on workspace config should be added to current workspace
-        // see issues https://github.com/eclipse/che/issues/20196
-        const shouldAddedToWorkspaced =
+        const shouldAddedToWorkspace =
           !isCustomWorkspaceRoot || workspaceFolders.some(each => each.uri.path === projectPath);
-        if (!shouldAddedToWorkspaced) {
+        if (!shouldAddedToWorkspace) {
           return;
         }
         if (await fs.pathExists(projectPath)) {

--- a/plugins/workspace-plugin/tests/workspace-projects-manager.spec.ts
+++ b/plugins/workspace-plugin/tests/workspace-projects-manager.spec.ts
@@ -526,4 +526,40 @@ describe('Test Workspace Projects Manager', () => {
     expect(appendLineMock).toBeCalledTimes(1);
     expect(appendLineMock).toBeCalledWith('failure to delete project');
   });
+  test('Projects must be added to the default workspace', async () => {
+    getDevfileMock.mockReturnValue({
+      ...devfileWith_MultiRoot_On_Attribute,
+      projects: [firstProject, secondProject],
+    });
+    const mockWorkspace = {
+      ...workspace,
+      workspaceFile: {
+        path: '/projects/che.theia-workspace',
+      },
+      workspaceFolders: [],
+    };
+    pathExistsItems = ['/projects/che-theia', '/projects/theia'];
+    Object.assign(theia, { workspace: mockWorkspace });
+    await workspaceProjectsManager.run();
+    Object.assign(theia, { workspace });
+    expect(addWorkspaceFolderMock).toBeCalledTimes(2);
+  });
+  test('Project should be added to custom workspace only if it is declared on the *.theia-workspace config', async () => {
+    getDevfileMock.mockReturnValue({
+      ...devfileWith_MultiRoot_On_Attribute,
+      projects: [firstProject, secondProject],
+    });
+    pathExistsItems = ['/projects/che-theia', '/projects/theia', '/projects/a'];
+    const mockWorkspace = {
+      ...workspace,
+      workspaceFile: {
+        path: '/projects/custom.theia-workspace',
+      },
+      workspaceFolders: [{ uri: { path: '/projects/a' } }, { uri: { path: '/projects/che-theia' } }],
+    };
+    Object.assign(theia, { workspace: mockWorkspace });
+    await workspaceProjectsManager.run();
+    Object.assign(theia, { workspace });
+    expect(addWorkspaceFolderMock).toBeCalledTimes(1);
+  });
 });


### PR DESCRIPTION
fixed https://github.com/eclipse/che/issues/20196

### What does this PR do?

Fix the bug that all of projects would be added to custom workspace

### How to test this PR?

- create a che workspace
- create folder `a` and `b`
![image](https://user-images.githubusercontent.com/13031838/127151116-f331d16a-c5ab-469b-9018-4f972c17cd59.png)
- create a custom theia workspace config file `custom.theia-workspace`
![image](https://user-images.githubusercontent.com/13031838/127151486-7250887e-a431-414b-ac2d-24f09fbcd91e.png)

  
```json
{
   "folders": [
      {
         "path": "a"
      },
      {
         "path": "b"
      },
   ]
}
```
- press `F1` and select `Open Workspace Root`
![image](https://user-images.githubusercontent.com/13031838/127151326-6536f1a5-c8a4-49e0-8548-c29ca1165d07.png)
- select `custom.theia-workspace`
![image](https://user-images.githubusercontent.com/13031838/127151348-846b7c3a-2885-4143-8c1a-a39086dad2ab.png)


Only the folder which defined on workspace config would be added to workspace 

![image](https://user-images.githubusercontent.com/13031838/127151531-1d9347a3-97c1-47f7-8162-0a94235ba8a5.png)

![image](https://user-images.githubusercontent.com/13031838/127151630-0d5e3a85-697c-4df4-afe6-b21f6609a52d.png)
