### PR TITLE
fix: Use build.include sha commit version of theia during release

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -69,7 +69,7 @@ apply_files_edits () {
     THEIA_VERSION=$(curl --silent http://registry.npmjs.org/-/package/@theia/core/dist-tags | sed 's/.*"next":"\(.*\)".*/\1/')
   fi
   if [[ ! ${THEIA_VERSION} ]] || [[ ${THEIA_VERSION} == \"Unauthorized\" ]]; then
-    echo "Failed to get Theia next version from npmjs.org or from .build-include. Try again."; echo
+    echo "Failed to get Theia next version from npmjs.org or from build.include. Try again."; echo
     exit 1
   fi
 

--- a/make-release.sh
+++ b/make-release.sh
@@ -66,7 +66,7 @@ apply_files_edits () {
   if [ -z "${BUILD_INCLUDE_THEIA_COMMIT_SHA}"]; then
     THEIA_VERSION=$(curl -sSL -H "Accept: application/vnd.npm.install-v1+json" https://registry.npmjs.org/@theia/core | jq -r '.versions | keys[]' | grep "${BUILD_INCLUDE_THEIA_COMMIT_SHA:0:8}")
   else
-    THEIA_VERSION=$(curl --silent http://registry.npmjs.org/-/package/@theia/core/dist-tags | sed 's/.*"next":"\(.*\)".*/\1/')
+    THEIA_VERSION=$(curl -sSL http://registry.npmjs.org/-/package/@theia/core/dist-tags | jq -r '.next')
   fi
   if [[ ! ${THEIA_VERSION} ]] || [[ ${THEIA_VERSION} == \"Unauthorized\" ]]; then
     echo "Failed to get Theia next version from npmjs.org or from build.include. Try again."; echo

--- a/make-release.sh
+++ b/make-release.sh
@@ -62,9 +62,14 @@ if [[ "${BASEBRANCH}" != "${BRANCH}" ]]; then
 fi
 
 apply_files_edits () {
-  THEIA_VERSION=$(curl --silent http://registry.npmjs.org/-/package/@theia/core/dist-tags | sed 's/.*"next":"\(.*\)".*/\1/')
+  BUILD_INCLUDE_THEIA_COMMIT_SHA=$(grep -e "^THEIA_COMMIT_SHA=" build.include | cut -d '=' -f2 | tr -d '"')
+  if [ -z "${BUILD_INCLUDE_THEIA_COMMIT_SHA}"]; then
+    THEIA_VERSION=${BUILD_INCLUDE_THEIA_COMMIT_SHA}
+  else
+    THEIA_VERSION=$(curl --silent http://registry.npmjs.org/-/package/@theia/core/dist-tags | sed 's/.*"next":"\(.*\)".*/\1/')
+  fi
   if [[ ! ${THEIA_VERSION} ]] || [[ ${THEIA_VERSION} == \"Unauthorized\" ]]; then
-    echo "Failed to get Theia next version from npmjs.org. Try again."; echo
+    echo "Failed to get Theia next version from npmjs.org or from .build-include. Try again."; echo
     exit 1
   fi
 

--- a/make-release.sh
+++ b/make-release.sh
@@ -64,7 +64,7 @@ fi
 apply_files_edits () {
   BUILD_INCLUDE_THEIA_COMMIT_SHA=$(grep -e "^THEIA_COMMIT_SHA=" build.include | cut -d '=' -f2 | tr -d '"')
   if [ -z "${BUILD_INCLUDE_THEIA_COMMIT_SHA}"]; then
-    THEIA_VERSION=${BUILD_INCLUDE_THEIA_COMMIT_SHA}
+    THEIA_VERSION=$(curl -sSL -H "Accept: application/vnd.npm.install-v1+json" https://registry.npmjs.org/@theia/core | jq -r '.versions | keys[]' | grep "${BUILD_INCLUDE_THEIA_COMMIT_SHA:0:8}")
   else
     THEIA_VERSION=$(curl --silent http://registry.npmjs.org/-/package/@theia/core/dist-tags | sed 's/.*"next":"\(.*\)".*/\1/')
   fi


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
If build include contains THEIA_COMMIT_SHA value, then use it as theia version, otherwise use next version

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
closes https://github.com/eclipse/che/issues/20221

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
