### PR TITLE
chore(build): fix theia images build for systems with bash 5

### DIFF
--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -43,7 +43,7 @@ build_directory() {
 
 build_all() {
   # loop on all directories and call build.sh script if present
-  for directory in */ ; do
+  for directory in 'theia-dev/' 'theia/' 'theia-endpoint-runtime-binary/' 'theia-vsix-installer/' ; do
     if [ -e ${directory}/build.sh ] ; then
       build_directory ${directory}
     else

--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -43,7 +43,7 @@ build_directory() {
 
 build_all() {
   # loop on all directories and call build.sh script if present
-  for directory in 'theia-dev/' 'theia/' 'theia-endpoint-runtime-binary/' 'theia-vsix-installer/' ; do
+  for directory in $(ls -d */ | sort) ; do
     if [ -e ${directory}/build.sh ] ; then
       build_directory ${directory}
     else


### PR DESCRIPTION



### What does this PR do?
Fix theia images build for systems with bash 5

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
On the bash 4 behavior is expected:

```bash
 ls
theia  theia-dev  theia-endpoint-runtime-binary  theia-vsix-installer
[root@c3bcd6e82f45 test]#  for dir in */ ; do echo $dir; done
theia/
theia-dev/
theia-endpoint-runtime-binary/
theia-vsix-installer/
[root@c3bcd6e82f45 test]# bash --version
GNU bash, version 4.4.23(1)-release (x86_64-redhat-linux-gnu)
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

```
But with newer bash 5:

```bash
[root@8e4788b010b4 test]# ls
ls
theia  theia-dev  theia-endpoint-runtime-binary  theia-vsix-installer
printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"
[root@8e4788b010b4 test]#  for dir in */ ; do echo $dir; done
 for dir in */ ; do echo $dir; done
theia-dev/
theia-endpoint-runtime-binary/
theia-vsix-installer/
theia/
printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"
[root@8e4788b010b4 test]# bash --version
bash --version
GNU bash, version 5.1.0(1)-release (x86_64-redhat-linux-gnu)
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"
```
Image build order is differ, so che-theia images build will fail.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>