### PR TITLE
fix(loading-sidecar-fs): Fixing loading of sidecar filesystem provider by resolving local js files

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-api-provider.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-api-provider.ts
@@ -21,7 +21,7 @@ export class ChePluginApiProvider implements ExtPluginApiProvider {
         initFunction: 'initializeApi',
         initVariable: 'che_api_provider',
       },
-      backendInitPath: require.resolve('@eclipse-che/theia-plugin-ext/lib/plugin/node/che-api-node-provider'),
+      backendInitPath: '@eclipse-che/theia-plugin-ext/lib/plugin/node/che-api-node-provider',
     };
   }
 }


### PR DESCRIPTION
### What does this PR do?
Fixing loading of sidecar filesystem provider by resolving local js files.
Was broken after https://github.com/eclipse-che/che-theia/commit/732da858f5572eb51fc1397005a6d625c7eca351#diff-589b5b8947b39aa1b6053732321110a0df085189ef25b28df77623958d4bacf3


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
Fix https://github.com/eclipse/che/issues/20057 (Cannot open jupyter notebooks)


### How to test this PR?
With the devfile:
```yaml
apiVersion: 1.0.0
metadata:
  generateName: python-jupyter-
projects:
  - name: jupyter-hello-world1
    source:
      startPoint: master
      location: 'https://github.com/chasbecker/TextAnalysis.git'
      type: git
components:
  - id: ms-python/python/latest
    type: chePlugin
  - mountSources: true
    memoryLimit: 512Mi
    type: dockerimage
    volumes:
      - name: venv
        containerPath: /home/user/.venv
    image: 'quay.io/eclipse/che-python-3.8:nightly'
    alias: python
  - type: cheEditor
    id: eclipse/che-theia/next
    registryUrl: https://sunix-che-plugin-registry-dev-c1mf2.surge.sh/v3/
commands:
  - name: set up venv with requirements
    actions:
      - workdir: /home/user
        type: exec
        command: python -m venv .venv && . .venv/bin/activate && python -m pip install -r /projects/jupyter-hello-world1/requirements.txt
        component: python
```
Making sure that this scenario works: https://www.youtube.com/watch?v=FPZa5jc8sYE
Note that sometimes the jupyter notebook is empty. refreshing the browser should fix the issue. I will open an issue once this is merged.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
