### PR TITLE
feat(multi-root): Multi-root is the only mode in Che-Theia, no feature toggle anymore

### DIFF
--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-attributes.yaml
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/devfile-attributes.yaml
@@ -1,7 +1,6 @@
 ---
 apiVersion: 1.0.0
 attributes:
-  multiRoot: 'off'
   attributeName: 'attributeValue' 
 metadata:
   name: test

--- a/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/workspace-status-runtime.json
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/tests/_data/workspace-status-runtime.json
@@ -168,9 +168,6 @@
         "metadata": {
             "name": "nodejs-mongo-l7t46"
         },
-        "attributes": {
-            "multiRoot": "on"
-        },
         "components": [
             {
                 "memoryLimit": "512Mi",

--- a/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
+++ b/extensions/eclipse-che-theia-workspace/src/node/che-workspace-server.ts
@@ -14,7 +14,6 @@ import * as path from 'path';
 import { inject, injectable } from 'inversify';
 
 import { DefaultWorkspaceServer } from '@theia/workspace/lib/node/default-workspace-server';
-import { DevfileService } from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
 import { FileUri } from '@theia/core/lib/node';
 import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
 
@@ -28,20 +27,12 @@ interface TheiaWorkspacePath {
 
 @injectable()
 export class CheWorkspaceServer extends DefaultWorkspaceServer {
-  @inject(DevfileService)
-  protected devfileService: DevfileService;
-
   @inject(WorkspaceService)
   protected workspaceService: WorkspaceService;
 
   // override any workspace that could have been defined through CLI and use entries from the devfile
   // if not possible, use default method
   protected async getRoot(): Promise<string | undefined> {
-    const devfile = await this.devfileService.get();
-    if (devfile?.metadata?.attributes?.multiRoot === 'off') {
-      return super.getRoot();
-    }
-
     const projectsRoot = await this.workspaceService.getProjectsRootDirectory();
 
     // first, check if we have a che.theia-workspace file

--- a/plugins/workspace-plugin/tests/workspace-projects-manager.spec.ts
+++ b/plugins/workspace-plugin/tests/workspace-projects-manager.spec.ts
@@ -150,7 +150,7 @@ che.devfile.get = getDevfileMock;
 const updateDevfileMock = jest.fn();
 che.devfile.update = updateDevfileMock;
 
-const devfile_Without_Attributes = {
+const devfile = {
   metadata: {},
   projects: [firstProject],
 };
@@ -158,24 +158,6 @@ const devfile_Without_Attributes = {
 const devfile_With_Two_Projects = {
   metadata: {},
   projects: [firstProject, secondProject],
-};
-
-const devfileWith_MultiRoot_On_Attribute = {
-  metadata: {
-    attributes: {
-      multiRoot: 'on',
-    },
-  },
-  projects: [firstProject],
-};
-
-const devfileWith_MultiRoot_Off_Attribute = {
-  metadata: {
-    attributes: {
-      multiRoot: 'off',
-    },
-  },
-  projects: [firstProject],
 };
 
 const fileSystemWatcherMock = {
@@ -259,28 +241,11 @@ describe('Test Workspace Projects Manager', () => {
   });
 
   test('Should add workspace folder when there are no attributes - multi root mode is ON by default', async () => {
-    getDevfileMock.mockReturnValue(devfile_Without_Attributes);
+    getDevfileMock.mockReturnValue(devfile);
 
     await workspaceProjectsManager.run();
 
     expect(addWorkspaceFolderMock).toBeCalledTimes(1);
-  });
-
-  test('Should add workspace folder when there is the `multiRoot` attribute with `on` value', async () => {
-    getDevfileMock.mockReturnValue(devfileWith_MultiRoot_On_Attribute);
-
-    await workspaceProjectsManager.run();
-
-    expect(addWorkspaceFolderMock).toBeCalledTimes(1);
-  });
-
-  test('Should NOT add workspace folder when there is the `multiRoot` attribute with `off` value', async () => {
-    getDevfileMock.mockReturnValue(devfileWith_MultiRoot_Off_Attribute);
-
-    await workspaceProjectsManager.run();
-
-    expect(addWorkspaceFolderMock).toBeCalledTimes(0);
-    expect(showInfoMessageMock).toBeCalledTimes(2);
   });
 
   test('Should clone the second project and add it as workspace folder when cloning of the first project was failed', async () => {
@@ -308,7 +273,7 @@ describe('Test Workspace Projects Manager', () => {
   });
 
   test('Should check steps of successful cloning process execution', async () => {
-    getDevfileMock.mockReturnValue(devfile_Without_Attributes);
+    getDevfileMock.mockReturnValue(devfile);
 
     await workspaceProjectsManager.run();
 
@@ -341,7 +306,7 @@ describe('Test Workspace Projects Manager', () => {
 
   test('Commands were NOT found for execution cloning process', async () => {
     buildProjectImportCommandMock.mockReturnValue(undefined);
-    getDevfileMock.mockReturnValue(devfile_Without_Attributes);
+    getDevfileMock.mockReturnValue(devfile);
 
     await workspaceProjectsManager.run();
 
@@ -385,7 +350,7 @@ describe('Test Workspace Projects Manager', () => {
    * - onProjectRemoved must NOT be called
    */
   test('onProjectChanged must be called on change event', async () => {
-    getDevfileMock.mockReturnValue(devfileWith_MultiRoot_On_Attribute);
+    getDevfileMock.mockReturnValue(devfile);
 
     pathExistsItems = [PROJECTS_ROOT];
     await workspaceProjectsManager.run();
@@ -427,7 +392,7 @@ describe('Test Workspace Projects Manager', () => {
    *     ( devfileService.updateProject must NOT be called )
    */
   test('devfileService.updateProject must NOT be called for not Git repository', async () => {
-    getDevfileMock.mockReturnValue(devfileWith_MultiRoot_On_Attribute);
+    getDevfileMock.mockReturnValue(devfile);
 
     pathExistsItems = [PROJECTS_ROOT];
     await workspaceProjectsManager.run();
@@ -461,7 +426,7 @@ describe('Test Workspace Projects Manager', () => {
    * - onProjectRemoved must be called
    */
   test('onProjectRemoved must be called on change event for non existent item', async () => {
-    getDevfileMock.mockReturnValue(devfileWith_MultiRoot_On_Attribute);
+    getDevfileMock.mockReturnValue(devfile);
 
     pathExistsItems = [PROJECTS_ROOT];
     await workspaceProjectsManager.run();
@@ -528,7 +493,7 @@ describe('Test Workspace Projects Manager', () => {
   });
   test('Projects must be added to the default workspace', async () => {
     getDevfileMock.mockReturnValue({
-      ...devfileWith_MultiRoot_On_Attribute,
+      ...devfile,
       projects: [firstProject, secondProject],
     });
     const mockWorkspace = {
@@ -546,7 +511,7 @@ describe('Test Workspace Projects Manager', () => {
   });
   test('Project should be added to custom workspace only if it is declared on the *.theia-workspace config', async () => {
     getDevfileMock.mockReturnValue({
-      ...devfileWith_MultiRoot_On_Attribute,
+      ...devfile,
       projects: [firstProject, secondProject],
     });
     pathExistsItems = ['/projects/che-theia', '/projects/theia', '/projects/a'];


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Removes the `Multi-root` feature toggle support from `Che-Theia`.
It was possible to turn on single root mode in a devfile, like:
```
attributes:
 multiRoot: 'off'
```
So, with current PR changes the corresponding attribute in a devfile has no effect.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19594

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
- All functionality should work correctly as before these changes.
- I tested with the following section in my devfile:
```
attributes:
  multiRoot: 'off'
```
The result: it creates a workspace in `multi-root` (not `single` root) mode
- I tested backward compatibility:

first, I created a workspace from a devfile with default editor in the `single` root mode
<details>
  <summary>example of devfile for single root mode</summary>

  ```

  apiVersion: 1.0.0
metadata:
  name: default-editor-single-root
attributes:
  multiRoot: 'off'
projects:
  - name: console-java-simple
    source:
      location: 'https://github.com/che-samples/console-java-simple'
      type: git
      branch: java1.11
components:
  - id: redhat/java/latest
    preferences:
      java.server.launchMode: Standard
    type: chePlugin
  - mountSources: true
    endpoints:
      - attributes:
          public: 'false'
        name: debug
        port: 5005
    memoryLimit: 512Mi
    type: dockerimage
    volumes:
      - name: m2
        containerPath: /home/user/.m2
    alias: maven
    image: 'quay.io/eclipse/che-java11-maven:next'
    env:
      - value: ''
        name: MAVEN_CONFIG
      - value: '-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/user'
        name: MAVEN_OPTS
      - value: '-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom'
        name: JAVA_OPTS
      - value: '-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom'
        name: JAVA_TOOL_OPTIONS
commands:
  - name: maven build
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/console-java-simple'
        type: exec
        command: mvn clean install
        component: maven
  - name: maven build and run
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/console-java-simple'
        type: exec
        command: mvn clean install && java -jar ./target/*.jar
        component: maven

  ```
</details>

then I added an editor with my changes to the existing devfile:
```
- type: cheEditor
    reference: 'https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-1191/simple/che-theia-editor.yaml'
```
and restarted my workspace.
The result: my workspace started in the `multi-root` mode. 

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
