### PR TITLE
Move sidecar fs init out of che API init

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
@@ -21,8 +21,6 @@ import { CheK8SImpl } from './che-k8s';
 import { CheOauthImpl } from './che-oauth';
 import { CheOpenshiftImpl } from './che-openshift';
 import { CheProductImpl } from './che-product';
-import { CheSideCarContentReaderImpl } from './che-sidecar-content-reader';
-import { CheSideCarFileSystemImpl } from './che-sidecar-file-system';
 import { CheSshImpl } from './che-ssh';
 import { CheTelemetryImpl } from './che-telemetry';
 import { CheUserImpl } from './che-user';
@@ -53,8 +51,6 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
   const cheK8SImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_K8S, new CheK8SImpl(rpc));
   const cheUserImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_USER, new CheUserImpl(rpc));
   const cheHttpImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_HTTP, new CheHttpImpl(rpc));
-  rpc.set(PLUGIN_RPC_CONTEXT.CHE_SIDERCAR_CONTENT_READER, new CheSideCarContentReaderImpl(rpc));
-  rpc.set(PLUGIN_RPC_CONTEXT.CHE_SIDECAR_FILE_SYSTEM, new CheSideCarFileSystemImpl(rpc));
 
   const cheProductImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_PRODUCT, new CheProductImpl(rpc));
   const cheTelemetryImpl = rpc.set(PLUGIN_RPC_CONTEXT.CHE_TELEMETRY, new CheTelemetryImpl(rpc));

--- a/extensions/eclipse-che-theia-plugin-ext/webpack.config.js
+++ b/extensions/eclipse-che-theia-plugin-ext/webpack.config.js
@@ -37,24 +37,17 @@ module.exports = {
     ],
     resolve: {
         fallback: {
-            'child_process': false,
-            'crypto': false,
             'net': false,
-            'fs': false,
+            'crypto': false,
             'os': false,
-            'path': false,
-            'constants': false,
-            'stream': false,
-            'assert': false,
-            'util': false
-
+            'path': false
         },
         extensions: ['.ts', '.js']
     },
     output: {
         filename: 'che-api-worker-provider.js',
-        libraryTarget: "var",
-        library: "che_api_provider",
+        libraryTarget: 'var',
+        library: 'che_api_provider',
         path: path.resolve(__dirname, 'lib/webworker')
     }
 };

--- a/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-init.ts
+++ b/extensions/eclipse-che-theia-plugin-remote/src/node/plugin-remote-init.ts
@@ -31,7 +31,10 @@ import { LogCallback, RemoteHostTraceLogger } from './remote-trace-logger';
 import { MAIN_RPC_CONTEXT, PluginDependencies, PluginDeployer, PluginDeployerEntry } from '@theia/plugin-ext';
 import { OutputChannelRegistryExt, PluginDeployerHandler } from '@theia/plugin-ext/lib/common';
 
+import { PLUGIN_RPC_CONTEXT as CHE_PLUGIN_RPC_CONTEXT } from '@eclipse-che/theia-plugin-ext/lib/common/che-protocol';
 import { CheEnvVariablesServerImpl } from '@eclipse-che/theia-plugin-ext/lib/node/che-env-variables-server';
+import { CheSideCarContentReaderImpl } from '@eclipse-che/theia-plugin-ext/lib/plugin/che-sidecar-content-reader';
+import { CheSideCarFileSystemImpl } from '@eclipse-che/theia-plugin-ext/lib/plugin/che-sidecar-file-system';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { DocumentContainerAware } from './document-container-aware';
 import { Emitter } from '@theia/core/lib/common/event';
@@ -262,6 +265,15 @@ to pick-up automatically a free port`)
     const pluginRemoteBrowser = webSocketClient.rpc.getProxy(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_BROWSER);
     const pluginRemoteNodeImplt = new PluginRemoteNodeImpl(pluginRemoteBrowser);
     webSocketClient.rpc.set(MAIN_REMOTE_RPC_CONTEXT.PLUGIN_REMOTE_NODE, pluginRemoteNodeImplt);
+
+    webSocketClient.rpc.set(
+      CHE_PLUGIN_RPC_CONTEXT.CHE_SIDERCAR_CONTENT_READER,
+      new CheSideCarContentReaderImpl(webSocketClient.rpc)
+    );
+    webSocketClient.rpc.set(
+      CHE_PLUGIN_RPC_CONTEXT.CHE_SIDECAR_FILE_SYSTEM,
+      new CheSideCarFileSystemImpl(webSocketClient.rpc)
+    );
 
     const pluginHostRPC = new PluginHostRPC(webSocketClient.rpc);
     pluginHostRPC.initialize();


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

### What does this PR do?
Moves the initialization of the sidecar files system and resource loader out of the API setup function. These classes only are used when the Che API is running inside a sidecar, so there is no reason to run them in the front end. This allows to remove some stuff from the webpack config, since it's no longer referenced from the Che API proper.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20331

### How to test this PR?
Since we have no front-end plugins using Che, we can't really test that case, but we should make sure the Che-related views ("My Workspace") are still working.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
