### PR TITLE
 fix: fix GH Actions workflows sending notification on failure

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -47,14 +47,20 @@ jobs:
       run: printf "//registry.npmjs.org/:_authToken=${{ secrets.CHE_NPM_AUTH_TOKEN }}\n" >> ~/.npmrc
     - name: Publish packages to npmjs
       run: yarn publish:next
-    - name: Create failure MM message
-      if: ${{ failure() }}
-      run: |
-        echo "{\"text\":\":no_entry_sign: Next Che Theia build has failed: https://github.com/eclipse-che/che-theia/actions/workflows/next-build.yml\"}" > mattermost.json
-    - name: Send MM message
-      if: ${{ failure() }}
-      uses: mattermost/action-mattermost-notify@1.1.0
-      env:
-        MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-        MATTERMOST_CHANNEL: eclipse-che-ci
-        MATTERMOST_USERNAME: che-bot
+
+notify:
+  runs-on: ubuntu-20.04
+  needs: build
+  if: always() && (needs.build.result == 'failure')
+  steps:
+  - name: Create failure MM message
+    if: ${{ failure() }}
+    run: |
+      echo "{\"text\":\":no_entry_sign: Next Che Theia build has failed: https://github.com/eclipse-che/che-theia/actions/workflows/next-build.yml\"}" > mattermost.json
+  - name: Send MM message
+    if: ${{ success() }} || ${{ failure() }}
+    uses: mattermost/action-mattermost-notify@1.1.0
+    env:
+      MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+      MATTERMOST_CHANNEL: eclipse-che-releases
+      MATTERMOST_USERNAME: che-bot

--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -10,9 +10,10 @@
 name: Build & Publish `next`
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - main
+      - main 
 
 jobs:
   build:

--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main 
+      - main
 
 jobs:
   build:
@@ -48,20 +48,19 @@ jobs:
       run: printf "//registry.npmjs.org/:_authToken=${{ secrets.CHE_NPM_AUTH_TOKEN }}\n" >> ~/.npmrc
     - name: Publish packages to npmjs
       run: yarn publish:next
-
-notify:
-  runs-on: ubuntu-20.04
-  needs: build
-  if: always() && (needs.build.result == 'failure')
-  steps:
-  - name: Create failure MM message
-    if: ${{ failure() }}
-    run: |
-      echo "{\"text\":\":no_entry_sign: Next Che Theia build has failed: https://github.com/eclipse-che/che-theia/actions/workflows/next-build.yml\"}" > mattermost.json
-  - name: Send MM message
-    if: ${{ success() }} || ${{ failure() }}
-    uses: mattermost/action-mattermost-notify@1.1.0
-    env:
-      MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-      MATTERMOST_CHANNEL: eclipse-che-releases
-      MATTERMOST_USERNAME: che-bot
+  notify:
+    runs-on: ubuntu-20.04
+    needs: build
+    if: always() && (needs.build.result == 'failure')
+    steps:
+    - name: Create failure MM message
+      if: ${{ failure() }}
+      run: |
+        echo "{\"text\":\":no_entry_sign: Next Che Theia build has failed: https://github.com/eclipse-che/che-theia/actions/workflows/next-build.yml\"}" > mattermost.json
+    - name: Send MM message
+      if: ${{ success() }} || ${{ failure() }}
+      uses: mattermost/action-mattermost-notify@1.1.0
+      env:
+        MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+        MATTERMOST_CHANNEL: eclipse-che-releases
+        MATTERMOST_USERNAME: che-bot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
   notify:
     runs-on: ubuntu-20.04
     needs: build
+    if: always() && ((needs.build.result == 'failure') || (needs.build.result == 'success'))
     steps:
     - name: Create failure MM message
       if: ${{ failure() }}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fix the notifications not being send in the case of failure for Next and Release workflows (docker image removal in the build job requires to put notification action in a separate job)
A special condition is needed in order to ensure that the notification job always is run, but only at success or failed state of the previous build job.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
