### PR TITLE
chore(recommendations-plugin): Use upper tsconfig file

### DIFF
--- a/plugins/recommendations-plugin/src/devfile/devfile-handler.ts
+++ b/plugins/recommendations-plugin/src/devfile/devfile-handler.ts
@@ -8,7 +8,6 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 import * as che from '@eclipse-che/plugin';
-import * as theia from '@theia/plugin';
 
 import { che as cheApi } from '@eclipse-che/api';
 import { injectable } from 'inversify';

--- a/plugins/recommendations-plugin/src/registry/che-plugin-registry.ts
+++ b/plugins/recommendations-plugin/src/registry/che-plugin-registry.ts
@@ -9,7 +9,6 @@
  ***********************************************************************/
 
 import * as che from '@eclipse-che/plugin';
-import * as theia from '@theia/plugin';
 
 import { injectable, postConstruct } from 'inversify';
 

--- a/plugins/recommendations-plugin/tests/find/find-file-extensions.spec.ts
+++ b/plugins/recommendations-plugin/tests/find/find-file-extensions.spec.ts
@@ -11,8 +11,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import 'reflect-metadata';
 
-import * as globby from 'globby';
-import * as path from 'path';
 import * as theia from '@theia/plugin';
 
 import { Container } from 'inversify';
@@ -30,7 +28,6 @@ describe('Test FindFile implementation', () => {
     findFilesSpy = jest.spyOn(theia.workspace, 'findFiles');
     cancelMethod = jest.fn();
 
-    const spy = jest.spyOn(theia.workspace, 'findFiles');
     (theia as any).CancellationTokenSource = jest.fn().mockImplementation(() => ({
       cancel: cancelMethod,
     }));

--- a/plugins/recommendations-plugin/tests/strategy/recommend-plugin-open-file-strategy.spec.ts
+++ b/plugins/recommendations-plugin/tests/strategy/recommend-plugin-open-file-strategy.spec.ts
@@ -32,7 +32,6 @@ describe('Test RecommendPluginOpenFileStrategy', () => {
     vscodeExtensionByLanguageId,
   };
 
-  const installPluginsMock = jest.fn();
   const fetchMethodMock = jest.fn();
   const pluginsByLanguageFetcher = {
     fetch: fetchMethodMock,

--- a/plugins/recommendations-plugin/tsconfig.json
+++ b/plugins/recommendations-plugin/tsconfig.json
@@ -1,33 +1,18 @@
 {
+    "extends": "../../configs/base.tsconfig",
     "compilerOptions": {
-      "target": "es6",
-      "module": "commonjs",
-      "moduleResolution": "node",
-      "outDir": "./lib",
-      "sourceMap": true,
-      "noEmitOnError": true,
-      "noImplicitReturns" : true,
-      "noImplicitThis": true,
-      "noUnusedLocals": false,
-      "removeComments": true,
-      "noFallthroughCasesInSwitch": true,
-      "strict": true,
-      "strictPropertyInitialization": false,
-      "skipLibCheck": true,
-      "skipDefaultLibCheck": true,
-      "types": ["node", "reflect-metadata", "jest"],
-      "experimentalDecorators": true,
-      "emitDecoratorMetadata": true,
-      "lib": [
-        "es6"
-    ],
-    }
-  ,
+        "lib": [
+            "es6",
+            "webworker"
+        ],
+        "sourceMap": true,
+        "rootDir": "src",
+        "outDir": "lib",
+        "types": [
+            "node", "jest"
+        ]
+    },
     "include": [
-      "src/**/*"
+        "src"
     ]
-  ,
-    "exclude": [
-      "node_modules",
-    ]
-  }
+}


### PR DESCRIPTION
### What does this PR do?
recommendations plug-in was using a custom (one that is added by the yeoman generator) while it should use upper configuration like the other plug-ins

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
N/A

### How to test this PR?
Recommendations plug-in should work as before

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [x] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next
