### PR TITLE
chore: Per Florent's explanation, let's tag if can pull; else skip. This is just a performance enhancement to reuse unchanged layers when building che-theia-dev, not an indicator to SKIP the che-theia-dev build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,8 @@ jobs:
       - |
         set -e
         docker image prune -a -f
-        docker pull quay.io/eclipse/che-theia-dev:next-travis
-        docker tag quay.io/eclipse/che-theia-dev:next-travis eclipse/che-theia-dev:next-travis
+        docker pull quay.io/eclipse/che-theia-dev:next-travis && \
+        docker tag quay.io/eclipse/che-theia-dev:next-travis eclipse/che-theia-dev:next-travis || true
         TAG=$TAG-${TRAVIS_CPU_ARCH} ./build.sh --root-yarn-opts:--ignore-scripts --dockerfile:Dockerfile.$DIST
     - <<: *docker-build
       name: Docker build (Alpine) on arm64


### PR DESCRIPTION
### What does this PR do?

chore: Per Florent's explanation, let's tag if can pull; else skip. This is just a performance enhancement to reuse unchanged layers when building che-theia-dev, not an indicator to SKIP the che-theia-dev build.

Change-Id: I2f8a2c2eaecc68aad3a1e5f034bc7093d610e489
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.