### PR TITLE
use Theia with a backport of fix for VS Code AtlasMap

### DIFF
--- a/build.include
+++ b/build.include
@@ -11,10 +11,10 @@ set -e
 set -u
 
 IMAGE_TAG="next"
-THEIA_GITHUB_REPO="eclipse-theia/theia"
+THEIA_GITHUB_REPO="apupier/theia"
 THEIA_VERSION="master"
-THEIA_BRANCH="master"
-THEIA_COMMIT_SHA="9f4f56e388109178dbfed244522bbe49ba474c31"
+THEIA_BRANCH="BackportAtlasMapModif"
+THEIA_COMMIT_SHA="7b1da69e00416eee6de22b870ea473a54b863e1d"
 THEIA_GIT_REFS="refs\\/heads\\/master"
 THEIA_DOCKER_IMAGE_VERSION=
 SHA1_SUFFIX=


### PR DESCRIPTION
This is to test a fix in Theia inside Che

### What does this PR do?

use a [specific branch](https://github.com/apupier/theia/commits/BackportAtlasMapModif) with a backport of https://github.com/eclipse-theia/theia/commit/814d9be1ef6888602c024c490b249bd2e8b5e0d3 and https://github.com/eclipse-theia/theia/commit/68dbea5b568a98f13228e5a87875097fa6a2f53f to test with latest Che.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
this is doen in the context of this issue https://github.com/eclipse/che/issues/13922

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

use this devfile:
```
apiVersion: 1.0.0
metadata:
  name: pr-che_theia-maven-1220-ow4oy
projects:
  - name: console-java-simple
    source:
      location: 'https://github.com/che-samples/console-java-simple'
      type: git
      branch: java1.11
components:
  - id: redhat/java/latest
    preferences:
      java.server.launchMode: Standard
    type: chePlugin
  - type: chePlugin
    reference: 'https://gist.githubusercontent.com/apupier/ce1ad44916598ad57231d6e2cbb62830/raw/80e6c01de665d73132fab83ce808ef4de94300a8/meta.yaml'
  - mountSources: true
    endpoints:
      - attributes:
          public: 'false'
        name: debug
        port: 5005
    memoryLimit: 512Mi
    type: dockerimage
    volumes:
      - name: m2
        containerPath: /home/user/.m2
    alias: maven
    image: 'quay.io/eclipse/che-java11-maven:next'
    env:
      - value: ''
        name: MAVEN_CONFIG
      - value: '-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/user'
        name: MAVEN_OPTS
      - value: '-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom'
        name: JAVA_OPTS
      - value: '-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom'
        name: JAVA_TOOL_OPTIONS
  - type: cheEditor
    reference: 'https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-1220/simple/che-theia-editor.yaml'
commands:
  - name: maven build
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/console-java-simple'
        type: exec
        command: mvn clean install
        component: maven
  - name: maven build and run
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/console-java-simple'
        type: exec
        command: mvn clean install && java -jar ./target/*.jar
        component: maven

```
- call Open AtlasMap command


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)https://github.com/theia
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
