### PR TITLE
chore(plugins-view): plugin list was not displayed for DevWorkspace instances

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-plugin-service.ts
@@ -46,14 +46,24 @@ export interface ChePluginMetadataInternal {
 /**
  * Workspace Settings :: Plugin Registry URI.
  * Public URI to load registry resources, e.g. icons.
+ * 
+ * For some Che deployments the Plugin Registry URL could be set as CHE_PLUGIN_REGISTRY_URL environment variable.
+ * We expect the WorkspaceService will set the property with original name.
  */
 const PLUGIN_REGISTRY_URL = 'cheWorkspacePluginRegistryUrl';
+
+const CHE_PLUGIN_REGISTRY_URL = "CHE_PLUGIN_REGISTRY_URL";
 
 /**
  * Workspace Settings :: Plugin Registry internal URI.
  * Is used for cross-container communication and mostly for getting plugins metadata.
+ * 
+ * For some Che deployments the Plugin Registry internal URL could be set as CHE_PLUGIN_REGISTRY_INTERNAL_URL environment variable.
+ * We expect the WorkspaceService will set the property with original name.
  */
 const PLUGIN_REGISTRY_INTERNAL_URL = 'cheWorkspacePluginRegistryInternalUrl';
+
+const CHE_PLUGIN_REGISTRY_INTERNAL_URL = "CHE_PLUGIN_REGISTRY_INTERNAL_URL";
 
 @injectable()
 export class ChePluginServiceImpl implements ChePluginService {
@@ -99,8 +109,11 @@ export class ChePluginServiceImpl implements ChePluginService {
     try {
       const workspaceSettings: WorkspaceSettings = await this.workspaceService.getWorkspaceSettings();
       if (workspaceSettings) {
-        const publicUri = workspaceSettings[PLUGIN_REGISTRY_URL];
-        const uri = workspaceSettings[PLUGIN_REGISTRY_INTERNAL_URL] || publicUri;
+        const publicUri = workspaceSettings[PLUGIN_REGISTRY_URL] ||
+          workspaceSettings[CHE_PLUGIN_REGISTRY_URL];
+
+        const uri = workspaceSettings[PLUGIN_REGISTRY_INTERNAL_URL] ||
+          workspaceSettings[CHE_PLUGIN_REGISTRY_INTERNAL_URL] || publicUri;
 
         this.defaultRegistry = {
           name: 'Eclipse Che plugins',

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-devworkspace-env-variables.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-devworkspace-env-variables.ts
@@ -15,6 +15,7 @@ import { injectable } from 'inversify';
  */
 @injectable()
 export class K8sDevWorkspaceEnvVariables {
+
   /**
    * workspaceId - workspace ID taken from environment variable, always the same at workspace lifecycle
    */
@@ -40,31 +41,57 @@ export class K8sDevWorkspaceEnvVariables {
    */
   private readonly projectsRoot: string;
 
+  /**
+   * pluginRegistryURL - Plugin registry public URL
+   */
+  private readonly pluginRegistryURL: string;
+
+  /**
+   * pluginRegistryInternalURL - Plugin registry internal URL
+   */
+  private readonly pluginRegistryInternalURL: string;
+
   constructor() {
     if (process.env.DEVWORKSPACE_ID === undefined) {
       console.error('Environment variable DEVWORKSPACE_ID is not set');
     } else {
       this.workspaceId = process.env.DEVWORKSPACE_ID;
     }
+
     if (process.env.DEVWORKSPACE_NAMESPACE === undefined) {
       console.error('Environment variable DEVWORKSPACE_NAMESPACE is not set');
     } else {
       this.workspaceNamespace = process.env.DEVWORKSPACE_NAMESPACE;
     }
+
     if (process.env.DEVWORKSPACE_NAME === undefined) {
       console.error('Environment variable DEVWORKSPACE_NAME is not set');
     } else {
       this.workspaceName = process.env.DEVWORKSPACE_NAME;
     }
+
     if (process.env.DEVWORKSPACE_FLATTENED_DEVFILE === undefined) {
       console.error('Environment variable DEVWORKSPACE_FLATTENED_DEVFILE is not set');
     } else {
       this.devWorkspaceFlattenedDevfilePath = process.env.DEVWORKSPACE_FLATTENED_DEVFILE;
     }
+
     if (process.env.PROJECTS_ROOT === undefined) {
       console.error('Environment variable PROJECTS_ROOT is not set');
     } else {
       this.projectsRoot = process.env.PROJECTS_ROOT;
+    }
+
+    if (process.env.CHE_PLUGIN_REGISTRY_URL === undefined) {
+      console.error('Environment variable CHE_PLUGIN_REGISTRY is not set');
+    } else {
+      this.pluginRegistryURL = process.env.CHE_PLUGIN_REGISTRY_URL;
+    }
+
+    if (process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL === undefined) {
+      console.error('Environment variable CHE_PLUGIN_REGISTRY_INTERNAL_URL is not set');
+    } else {
+      this.pluginRegistryInternalURL = process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL;
     }
   }
 
@@ -86,5 +113,13 @@ export class K8sDevWorkspaceEnvVariables {
 
   getProjectsRoot(): string {
     return this.projectsRoot;
+  }
+
+  getPluginRegistryURL(): string {
+    return this.pluginRegistryURL;
+  }
+
+  getPluginRegistryInternalURL(): string {
+    return this.pluginRegistryInternalURL;
   }
 }

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-workspace-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-workspace-service-impl.ts
@@ -71,8 +71,12 @@ export class K8sWorkspaceServiceImpl implements WorkspaceService {
   }
 
   public async getWorkspaceSettings(): Promise<WorkspaceSettings> {
-    console.log('workspaceService.getWorkspaceSettings() not supported');
-    return {};
+    console.log('workspaceService.getWorkspaceSettings() is implemented partially');
+
+    return {
+      CHE_PLUGIN_REGISTRY_URL: this.env.getPluginRegistryURL(),
+      CHE_PLUGIN_REGISTRY_INTERNAL_URL: this.env.getPluginRegistryInternalURL(),
+    };
   }
 
   public async getContainerList(): Promise<Container[]> {


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Implements [`K8sWorkspaceServiceImpl.getWorkspaceSettings()` method](https://github.com/eclipse-che/che-theia/blob/main/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-workspace-service-impl.ts#L74) to be able Che-Theia get plugin registry internal/external URLs.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20448

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
