### PR TITLE
feat: DevWorkspace: Do not download vsix if already fetched in volume

### DIFF
--- a/dockerfiles/theia-endpoint-runtime-binary/src/entrypoint.sh
+++ b/dockerfiles/theia-endpoint-runtime-binary/src/entrypoint.sh
@@ -20,6 +20,10 @@ processDevWorkspacePlugins() {
       dest=$(echo "$container" | sed 's|.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*|\1|' - )
       urls=$(echo "$container" | sed 's|.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\].*|\1|' - )
       mkdir -p "$dest"
+      if ls -A "${dest}"/*.vsix 2> /dev/null ; then
+        echo "VSIX files are already in folder ${dest}, skipping the download"
+        return 0
+      fi
       unset IFS
       for url in $(echo "$urls" | sed 's/[",]/ /g' - ); do
           CURL_OPTIONS=""


### PR DESCRIPTION
### What does this PR do?
Avoid to download again vsix files on restarting a workspace

### Screenshot/screencast of this PR
![image](https://user-images.githubusercontent.com/436777/136583547-46254b2a-c24d-49bf-9a5a-ae158b2bcc8a.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20592


### How to test this PR?
Start a devWorkspace like spring petclinic devfile v2 getting started sample
look at endpoint-runtime logs: you can see curl commands fetching vsix and then java extensions are running in the workspace

And if you restart this workspace, look at init container endpoint runtime: you won't see curl command but a line saying it's already there and when workspace is loaded, you can see that the java extensions are still there as well

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [x] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next

Change-Id: I7dbc51bbb7c1509dbdd35677c59b625c24b64813
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
