### PR TITLE
chore(tasks): use default shell instead of hardcoded one

### DIFF
--- a/plugins/task-plugin/src/task/che-task-runner.ts
+++ b/plugins/task-plugin/src/task/che-task-runner.ts
@@ -67,7 +67,7 @@ export class CheTaskRunner {
           machineName: containerName,
           workspaceId: target.workspaceId || '',
         },
-        cmd: ['sh', '-c', taskConfig.command],
+        cmd: ['', '-c', taskConfig.command],
         tty: true,
         cwd: target.workingDir,
       };


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
When executing command, switches to using the default shell, as it configured in `/etc/passws`.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
Screenshot explaining the problem
![Screenshot from 2021-10-27 18-02-20](https://user-images.githubusercontent.com/1655894/139667338-6d36e494-c4a0-413e-8823-089380c58cc1.png)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20699

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

- create a workspace with following
<details>
<summary>devfile</summary>

```
---
apiVersion: 1.0.0
metadata:
  name: java-guestbook-dev-environment

projects:
  - name: java-guestbook
    source:
      type: git
      location: "https://github.com/vitaliy-guliy/java-guestbook.git"
      branch: master

components:
  - type: cheEditor
    alias: che-theia
    reference: https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-1243/che_theia_meta.yaml
    memoryLimit: 512Mi

  -
    type: chePlugin
    id: redhat/java8/latest

  -
    type: dockerimage
    alias: maven
    # image: quay.io/eclipse/che-java8-maven:ce0526f
    image: quay.io/devfile/universal-developer-image:ubi8-112f94a
    env:
    - name: MAVEN_CONFIG
      value: ""
    - name: JAVA_OPTS
      value: "-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
            -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
            -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
            -Duser.home=/home/user"
    - name: MAVEN_OPTS
      value: $(JAVA_OPTS)
    memoryLimit: 512Mi
    mountSources: true
    endpoints:
    - name: java-guestbook-backend
      attributes:
        discoverable: 'true'
        public: 'false'
      port: 8080
    - name: java-guestbook
      attributes:
        discoverable: 'true'
        public: 'true'
      port: 8443
    - name: debug
      attributes:
        public: 'false'
      port: 5005
    volumes:
    - name: m2
      containerPath: /home/user/.m2

commands:
  - name: maven build backend
    actions:
    - type: exec
      component: maven
      command: "mvn clean install"
      workdir: "${CHE_PROJECTS_ROOT}/java-guestbook/backend"

  - name: maven build frontend
    actions:
    - type: exec
      component: maven
      command: "mvn clean install"
      workdir: "${CHE_PROJECTS_ROOT}/java-guestbook/frontend"
```
</details>

- run `maven build backend` command
- pay attention which shell is used for tasks

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next
