### PR TITLE
fix: Plugins without sidecars were not injected

### DIFF
--- a/dockerfiles/theia-endpoint-runtime-binary/build.sh
+++ b/dockerfiles/theia-endpoint-runtime-binary/build.sh
@@ -13,3 +13,8 @@ base_dir=$(cd "$(dirname "$0")"; pwd)
 
 init --name:theia-endpoint-runtime-binary "$@"
 build
+
+# Run unit tests
+UNIT_TEST_CHECK_IMAGE_NAME="${IMAGE_NAME}-test"
+docker build -t "${UNIT_TEST_CHECK_IMAGE_NAME}" -f test.Dockerfile .
+printf "${GREEN}Tests run successfully: ${BLUE}${UNIT_TEST_CHECK_IMAGE_NAME}${NC}\n"

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/runtime-setup.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/runtime-setup.dockerfile
@@ -1,1 +1,1 @@
-RUN apk add --update --no-cache curl bash
+RUN apk add --update --no-cache curl bash jq python3 py3-pip && pip install yq

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/runtime-setup.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/runtime-setup.dockerfile
@@ -1,1 +1,2 @@
 # curl already installed in ubi8
+RUN microdnf install -y python38 jq && pip3 install yq

--- a/dockerfiles/theia-endpoint-runtime-binary/src/entrypoint.sh
+++ b/dockerfiles/theia-endpoint-runtime-binary/src/entrypoint.sh
@@ -31,7 +31,7 @@ extract_dest_from_item() {
   jq -n "$1" | jq -r '.[].env[] | select(.name == "THEIA_PLUGINS") | .value' | sed 's|local-dir://\([^"][^"]*\)|\1|'
 }
 
-# extract the destination folder from one item of the analyze
+# extract the urls from one item of the analyze
 # parameter: $1 is the component data item
 extract_urls_from_item() {
   # URLs are wrapped into extensions custom field

--- a/dockerfiles/theia-endpoint-runtime-binary/src/entrypoint.sh
+++ b/dockerfiles/theia-endpoint-runtime-binary/src/entrypoint.sh
@@ -11,48 +11,95 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-processDevWorkspacePlugins() {
-  KUBE_API_ENDPOINT="https://kubernetes.default.svc/apis/workspace.devfile.io/v1alpha2/namespaces/${DEVWORKSPACE_NAMESPACE}/devworkspaces/${DEVWORKSPACE_NAME}"
-  TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-  WORKSPACE=$(curl -fsS --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer ${TOKEN}" "$KUBE_API_ENDPOINT")
-  IFS=$'\n'
-  for container in $(echo "$WORKSPACE" | sed -e 's|[[,]\({"attributes":{"app.kubernetes.io\)|\n\1|g' | grep '"che-theia.eclipse.org/vscode-extensions":' | grep -e '^{"attributes".*'); do
-      dest=$(echo "$container" | sed 's|.*{"name":"THEIA_PLUGINS","value":"local-dir://\([^"][^"]*\)"}.*|\1|' - )
-      urls=$(echo "$container" | sed 's|.*"che-theia.eclipse.org/vscode-extensions":\[\([^]][^]]*\)\].*|\1|' - )
-      mkdir -p "$dest"
-      if ls -A "${dest}"/*.vsix 2> /dev/null ; then
-        echo "VSIX files are already in folder ${dest}, skipping the download"
-        return 0
-      fi
-      unset IFS
-      for url in $(echo "$urls" | sed 's/[",]/ /g' - ); do
-          CURL_OPTIONS=""
-          # check if URL starts with relative:extension/
-          # example of url: "relative:extension/resources/download_jboss_org/jbosstools/static/jdt_ls/stable/java-0.75.0-60.vsix
-          if [[ "$url" =~ ^relative:extension/.* ]]; then
-              # if there is CHE_PLUGIN_REGISTRY_INTERNAL_URL env var, use it
-              if [ -n "$CHE_PLUGIN_REGISTRY_INTERNAL_URL" ]; then
-                  # update URL by using the Plugin Registry internal URL as prefix
-                  url=${CHE_PLUGIN_REGISTRY_INTERNAL_URL}/${url#relative:extension/}
-              elif [ -n "$CHE_PLUGIN_REGISTRY_URL" ]; then
-                  # if there is CHE_PLUGIN_REGISTRY_URL env var, use it but also use insecure
-                  # options as we don't have all certificates in a devWorkspace for now
-                  CURL_OPTIONS="--insecure"
-                  # update URL by using the Plugin Registry internal URL as prefix
-                  url=${CHE_PLUGIN_REGISTRY_URL}/${url#relative:extension/}
-              else
-                  echo "no plugin registry URL env var is set (CHE_PLUGIN_REGISTRY_INTERNAL_URL or CHE_PLUGIN_REGISTRY_URL), skipping relative url ${url}"
-                  continue
-              fi
-          fi
-          echo; echo "downloading $urls to $dest"
-          curl ${CURL_OPTIONS} -L "$url" > "$dest/$(basename "$url")"
-      done
-  done
+# Create a struct from the given content which should be a flattened devfile
+# parameter: $1 is the content of the file to analyze
+# return: Array of object containing: name, env and extensions fields
+analyze_flattened_devfile() {
+    echo "$1" | yq -c '.components[] | select(.attributes."che-theia.eclipse.org/vscode-extensions") | [{name:(.attributes."app.kubernetes.io/name" // "theia"), env:(.container.env), extensions:(.attributes."che-theia.eclipse.org/vscode-extensions")}]'
 }
 
-if [ ! -z "$DEVWORKSPACE_NAMESPACE" ]; then
-  processDevWorkspacePlugins
-fi
+# extract the name of the component from one item of the analyze
+# parameter: $1 is the component data item
+extract_component_name_from_item() {
+  jq -n "$1" | jq -r '.[].name'
+}
 
-cp -rf /plugin-remote-endpoint /remote-endpoint/plugin-remote-endpoint
+# extract the destination folder from one item of the analyze
+# parameter: $1 is the component data item
+extract_dest_from_item() {
+  # also remove the local-dir:// prefix
+  jq -n "$1" | jq -r '.[].env[] | select(.name == "THEIA_PLUGINS") | .value' | sed 's|local-dir://\([^"][^"]*\)|\1|'
+}
+
+# extract the destination folder from one item of the analyze
+# parameter: $1 is the component data item
+extract_urls_from_item() {
+  # URLs are wrapped into extensions custom field
+  # transform it into a space separated list
+  jq -n "$1" | jq -r -c '.[].extensions | @sh' | sed -e "s/'//g"
+}
+
+
+
+processDevWorkspacePlugins() {
+  # Create a struct from the flattened devfile
+  # Array of object containing: name, env and extensions fields
+  flattenedDevfile=$(cat "/devworkspace-metadata/flattened.devworkspace.yaml")
+  vsixPerComponents=$(analyze_flattened_devfile "$flattenedDevfile")
+  for componentData in $vsixPerComponents; do
+  
+    # Component is in the name
+    componentName=$(extract_component_name_from_item "$componentData")
+  
+    # Destination Folder is defined by THEIA_PLUGINS value
+    dest=$(extract_dest_from_item "$componentData")
+    mkdir -p "$dest"
+    if ls -A "${dest}"/*.vsix 2> /dev/null ; then
+      echo "VSIX files are already in folder ${dest}, skipping the download"
+      return 0
+    fi
+  
+    # URLs are wrapped into extensions custom field
+    # transform it into a space separated list
+    urls=$(extract_urls_from_item "$componentData")
+  
+    for url in $urls; do
+      CURL_OPTIONS=""
+      # check if URL starts with relative:extension/
+      # example of url: "relative:extension/resources/download_jboss_org/jbosstools/static/jdt_ls/stable/java-0.75.0-60.vsix
+      if [[ "$url" =~ ^relative:extension/.* ]]; then
+        # if there is CHE_PLUGIN_REGISTRY_INTERNAL_URL env var, use it
+        if [ -n "$CHE_PLUGIN_REGISTRY_INTERNAL_URL" ]; then
+          # update URL by using the Plugin Registry internal URL as prefix
+          url=${CHE_PLUGIN_REGISTRY_INTERNAL_URL}/${url#relative:extension/}
+        elif [ -n "$CHE_PLUGIN_REGISTRY_URL" ]; then
+          # if there is CHE_PLUGIN_REGISTRY_URL env var, use it but also use insecure
+          # options as we don't have all certificates in a devWorkspace for now
+          CURL_OPTIONS="--insecure"
+          # update URL by using the Plugin Registry internal URL as prefix
+          url=${CHE_PLUGIN_REGISTRY_URL}/${url#relative:extension/}
+        else
+          echo "no plugin registry URL env var is set (CHE_PLUGIN_REGISTRY_INTERNAL_URL or CHE_PLUGIN_REGISTRY_URL), skipping relative url ${url}"
+          continue
+        fi
+      fi
+      echo; echo "downloading $url to $dest for component $componentName"
+      curl ${CURL_OPTIONS} -L "$url" > "$dest/$(basename "$url")"
+    done;
+  done;
+}
+
+# main function
+run_main() {
+  if [ -n "$DEVWORKSPACE_NAMESPACE" ]; then
+    processDevWorkspacePlugins
+  fi
+
+  cp -rf /plugin-remote-endpoint /remote-endpoint/plugin-remote-endpoint
+}
+
+# do not execute the main function in unit tests
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
+then
+    run_main "${@}"
+fi

--- a/dockerfiles/theia-endpoint-runtime-binary/test.Dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/test.Dockerfile
@@ -1,0 +1,17 @@
+# Copyright (c) 2019-21 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
+FROM registry.access.redhat.com/ubi8-minimal:8.4-210 as runtime
+
+RUN microdnf install -y python38 jq && pip3 install yq
+COPY /src/ /tests/src
+COPY /tests /tests/tests/
+RUN /tests/tests/test_entrypoint.sh

--- a/dockerfiles/theia-endpoint-runtime-binary/tests/_data/flattened_devfile.yaml
+++ b/dockerfiles/theia-endpoint-runtime-binary/tests/_data/flattened_devfile.yaml
@@ -1,0 +1,269 @@
+commands:
+- apply:
+    component: remote-runtime-injector
+  attributes:
+    controller.devfile.io/imported-by: theia-ide-workspace42b53fb0416c4bb3
+  id: init-container-command
+- exec:
+    commandLine: npm install
+    component: nodejs
+    group:
+      isDefault: true
+      kind: build
+    label: Download dependencies
+    workingDir: ${PROJECTS_ROOT}/web-nodejs-sample/app
+  id: dependencies
+- exec:
+    commandLine: nodemon app.js
+    component: nodejs
+    group:
+      kind: run
+    label: Run the web app 
+    workingDir: ${PROJECTS_ROOT}/web-nodejs-sample/app
+  id: runapp
+- exec:
+    commandLine: nodemon --inspect app.js
+    component: nodejs
+    group:
+      isDefault: true
+      kind: debug
+    label: Run the web app (debugging enabled)
+    workingDir: ${PROJECTS_ROOT}/web-nodejs-sample/app
+  id: debug
+- exec:
+    commandLine: 'node_server_pids=$(pgrep -fx ''.*nodemon (--inspect )?app.js'' | tr "\\n" " ") && echo "Stopping node server with PIDs: ${node_server_pids}" &&  kill -15 ${node_server_pids} &>/dev/null && echo ''Done.'''
+    component: nodejs
+    group:
+      kind: run
+    label: Stop the web app
+  id: stopapp
+- apply:
+    component: project-clone
+  id: clone-projects
+components:
+- attributes:
+    app.kubernetes.io/component: che-theia
+    app.kubernetes.io/part-of: che-theia.eclipse.org
+    che-theia.eclipse.org/vscode-extensions:
+    - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-eslint/vscode-eslint-2.1.1-1e15d3.vsix
+    - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-eslint/vscode-2.vsix
+    controller.devfile.io/imported-by: theia-ide-workspace42b53fb0416c4bb3
+  container:
+    cpuLimit: 1500m
+    cpuRequest: 100m
+    endpoints:
+    - attributes:
+        controller.devfile.io/endpoint-url: https://che-eclipse-che.apps.cluster-fce1.fce1.sandbox1073.opentlc.com/workspace42b53fb0416c4bb3/theia-ide/3100/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: main
+        urlRewriteSupported: true
+      exposure: public
+      name: theia
+      protocol: https
+      targetPort: 3100
+    - attributes:
+        controller.devfile.io/endpoint-url: https://che-eclipse-che.apps.cluster-fce1.fce1.sandbox1073.opentlc.com/workspace42b53fb0416c4bb3/theia-ide/webviews/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: webview
+        unique: true
+        urlRewriteSupported: true
+      exposure: public
+      name: webviews
+      protocol: https
+      targetPort: 3100
+    - attributes:
+        controller.devfile.io/endpoint-url: https://che-eclipse-che.apps.cluster-fce1.fce1.sandbox1073.opentlc.com/workspace42b53fb0416c4bb3/theia-ide/mini-browser/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: mini-browser
+        unique: true
+        urlRewriteSupported: true
+      exposure: public
+      name: mini-browser
+      protocol: https
+      targetPort: 3100
+    - attributes:
+        controller.devfile.io/endpoint-url: https://che-eclipse-che.apps.cluster-fce1.fce1.sandbox1073.opentlc.com/workspace42b53fb0416c4bb3/theia-ide/3130/
+        discoverable: false
+        type: ide-dev
+        urlRewriteSupported: true
+      exposure: public
+      name: theia-dev
+      protocol: http
+      targetPort: 3130
+    - attributes:
+        controller.devfile.io/endpoint-url: https://che-eclipse-che.apps.cluster-fce1.fce1.sandbox1073.opentlc.com/workspace42b53fb0416c4bb3/theia-ide/13131/
+        discoverable: false
+        urlRewriteSupported: true
+      exposure: public
+      name: theia-redirect-1
+      protocol: http
+      targetPort: 13131
+    - attributes:
+        controller.devfile.io/endpoint-url: https://che-eclipse-che.apps.cluster-fce1.fce1.sandbox1073.opentlc.com/workspace42b53fb0416c4bb3/theia-ide/13132/
+        discoverable: false
+        urlRewriteSupported: true
+      exposure: public
+      name: theia-redirect-2
+      protocol: http
+      targetPort: 13132     
+    - attributes:
+        controller.devfile.io/endpoint-url: https://che-eclipse-che.apps.cluster-fce1.fce1.sandbox1073.opentlc.com/workspace42b53fb0416c4bb3/theia-ide/13133/
+        discoverable: false
+        urlRewriteSupported: true
+      exposure: public
+      name: theia-redirect-3
+      protocol: http
+      targetPort: 13133
+    - attributes:
+        controller.devfile.io/endpoint-url: wss://che-eclipse-che.apps.cluster-fce1.fce1.sandbox1073.opentlc.com/workspace42b53fb0416c4bb3/theia-ide/3333/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: collocated-terminal
+        urlRewriteSupported: true
+      exposure: public
+      name: terminal
+      protocol: wss
+      targetPort: 3333
+    env:
+    - name: THEIA_PLUGINS
+      value: local-dir:///plugins
+    - name: HOSTED_PLUGIN_HOSTNAME
+      value: 0.0.0.0
+    - name: HOSTED_PLUGIN_PORT
+      value: "3130"
+    - name: THEIA_HOST
+      value: 127.0.0.1
+    - name: CHE_DASHBOARD_URL
+      value: https://che-eclipse-che.apps.cluster-fce1.fce1.sandbox1073.opentlc.com
+    - name: CHE_PLUGIN_REGISTRY_URL
+      value: https://che-eclipse-che.apps.cluster-fce1.fce1.sandbox1073.opentlc.com/plugin-registry/v3
+    - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
+      value: http://plugin-registry.eclipse-che.svc:8080/v3
+    image: quay.io/eclipse/che-theia:next
+    memoryLimit: 512M
+    mountSources: true
+    sourceMapping: /projects
+    volumeMounts:
+    - name: plugins
+      path: /plugins
+    - name: theia-local
+      path: /home/theia/.theia
+  name: theia-ide
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspace42b53fb0416c4bb3
+  name: plugins             
+  volume: {}
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspace42b53fb0416c4bb3
+  name: theia-local
+  volume: {}
+- attributes:
+    app.kubernetes.io/component: machine-exec
+    app.kubernetes.io/part-of: che-theia.eclipse.org
+    controller.devfile.io/imported-by: theia-ide-workspace42b53fb0416c4bb3
+  container:
+    command:
+    - /go/bin/che-machine-exec
+    - --url
+    - 127.0.0.1:3333
+    - --idle-timeout
+    - 15m
+    cpuLimit: 500m
+    cpuRequest: 30m
+    env:
+    - name: CHE_DASHBOARD_URL
+      value: https://che-eclipse-che.apps.cluster-fce1.fce1.sandbox1073.opentlc.com
+    - name: CHE_PLUGIN_REGISTRY_URL
+      value: https://che-eclipse-che.apps.cluster-fce1.fce1.sandbox1073.opentlc.com/plugin-registry/v3
+    - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
+      value: http://plugin-registry.eclipse-che.svc:8080/v3
+    image: quay.io/eclipse/che-machine-exec:next
+    memoryLimit: 128Mi
+    memoryRequest: 32Mi
+    sourceMapping: /projects
+  name: che-machine-exec
+- attributes:
+    app.kubernetes.io/component: remote-runtime-injector
+    app.kubernetes.io/part-of: che-theia.eclipse.org
+    controller.devfile.io/imported-by: theia-ide-workspace42b53fb0416c4bb3
+  container:
+    cpuLimit: 500m
+    cpuRequest: 30m
+    env:
+    - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+      value: /remote-endpoint/plugin-remote-endpoint
+    - name: REMOTE_ENDPOINT_VOLUME_NAME
+      value: remote-endpoint
+    - name: CHE_DASHBOARD_URL
+      value: https://che-eclipse-che.apps.cluster-fce1.fce1.sandbox1073.opentlc.com
+    - name: CHE_PLUGIN_REGISTRY_URL
+      value: https://che-eclipse-che.apps.cluster-fce1.fce1.sandbox1073.opentlc.com/plugin-registry/v3
+    - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
+      value: http://plugin-registry.eclipse-che.svc:8080/v3
+    image: quay.io/eclipse/che-theia-endpoint-runtime-binary:next
+    memoryLimit: 128Mi
+    memoryRequest: 32Mi
+    sourceMapping: /projects
+    volumeMounts:
+    - name: plugins
+      path: /plugins
+    - name: remote-endpoint
+      path: /remote-endpoint
+  name: remote-runtime-injector
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspace42b53fb0416c4bb3
+  name: remote-endpoint
+  volume:
+    ephemeral: true
+- attributes:
+    app.kubernetes.io/name: nodejs
+    che-theia.eclipse.org/vscode-extensions: []
+  container:
+    args:
+    - sh
+    - -c
+    - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
+    endpoints:
+    - attributes:
+        controller.devfile.io/endpoint-url: http://workspace42b53fb0416c4bb3-1.apps.cluster-fce1.fce1.sandbox1073.opentlc.com/
+      exposure: public
+      name: nodejs
+      protocol: http
+      targetPort: 3000
+    env:
+    - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+      value: /remote-endpoint/plugin-remote-endpoint
+    - name: THEIA_PLUGINS
+      value: local-dir:///plugins/sidecars/nodejs
+    image: quay.io/devfile/universal-developer-image:ubi8-b452131
+    memoryLimit: 1G
+    mountSources: true
+    sourceMapping: /projects
+    volumeMounts:
+    - name: remote-endpoint
+      path: /remote-endpoint
+    - name: plugins
+      path: /plugins
+  name: nodejs
+- container:
+    cpuLimit: 1000m
+    cpuRequest: 100m        
+    image: quay.io/devfile/project-clone:v0.9.0
+    memoryLimit: 1Gi
+    memoryRequest: 128Mi
+    mountSources: true
+  name: project-clone
+events:
+  preStart:
+  - init-container-command
+  - clone-projects
+projects:
+- git:
+    checkoutFrom:
+      revision: noplugins
+    remotes:
+      origin: https://github.com/svor/web-nodejs-sample.git
+  name: web-nodejs-sample

--- a/dockerfiles/theia-endpoint-runtime-binary/tests/test_entrypoint.sh
+++ b/dockerfiles/theia-endpoint-runtime-binary/tests/test_entrypoint.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+CURRENT_DIR=$(cd "$(dirname "$0")"; pwd)
+TESTS_DIR="$CURRENT_DIR/_data"
+
+# shellcheck disable=SC1090
+source "${CURRENT_DIR}/../src/entrypoint.sh"
+
+
+function assertEquals() {
+    if [[ "$1" != "$2" ]]; then
+        echo -e "assertEquals failed!"
+        echo "Result:"
+        echo "$1"
+        echo "Expected:"
+        echo "$2"
+        exit 1
+    fi
+}
+
+# $1 item being lines
+# $2 the expected size
+function assertSize() {
+  length=$(echo "$1" | wc -l)
+
+  if [[ "$length" != "$2" ]]; then
+        echo -e "assertSize failed!"
+        echo "Result:"
+        echo "$length"
+        echo "Expected length:"
+        echo "$2"
+        exit 1
+    fi
+}
+
+
+
+# Check the analyze
+FILE1=$(cat "$TESTS_DIR/flattened_devfile.yaml")
+
+ANALYZE1=$(analyze_flattened_devfile "$FILE1")
+
+# expect two items
+assertSize "$ANALYZE1" 2
+
+# Grab first item
+FIRST_ITEM=$(echo "$ANALYZE1" | head -n1)
+
+# Check item name
+itemName1=$(extract_component_name_from_item "$FIRST_ITEM")
+assertEquals "$itemName1" "theia"
+
+# Check dest folder
+itemDest1=$(extract_dest_from_item "$FIRST_ITEM")
+assertEquals "$itemDest1" "/plugins"
+
+# Check urls
+itemUrls1=$(extract_urls_from_item "$FIRST_ITEM")
+assertEquals "$itemUrls1" "https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-eslint/vscode-eslint-2.1.1-1e15d3.vsix https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-eslint/vscode-2.vsix"
+
+# Grab second item
+SECOND_ITEM=$(echo "$ANALYZE1" | tail -n 1 | head -n1)
+
+# Check item name
+itemName2=$(extract_component_name_from_item "$SECOND_ITEM")
+assertEquals "$itemName2" "nodejs"
+
+# Check dest folder
+itemDest2=$(extract_dest_from_item "$SECOND_ITEM")
+assertEquals "$itemDest2" "/plugins/sidecars/nodejs"
+
+# Check urls (none)
+itemUrls2=$(extract_urls_from_item "$SECOND_ITEM")
+assertEquals "$itemUrls2" ""


### PR DESCRIPTION
### What does this PR do?
At the beginning, theia component was part of the devWorkspace and then we
had access to the atttributes from the DevWorkspace object
Now, it's part of the devWorkspaceTemplate object

Switch to the flattened devfile instead so nothing to query externally
Also, in order to reduce sed usage, use jq/yq instead as there was also a bug
on empty list

Added some unit tests as well


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20718


### How to test this PR?
Start the workspace from the issue
Eslint should not be there (check output widget inside theia or command palette)
if you check the logs of the init container you might as well see tons of errors

Open a terminal and drop anything located inside /plugins folder

Edit the DevWorkspaceTemplate object

Search for the `remote-runtime` component
```yaml
app.kubernetes.io/component: remote-runtime-injector
app.kubernetes.io/part-of: che-theia.eclipse.org
```

and replace the default image by `quay.io/fbenoit/che-theia-endpoint-runtime-binary:20211104c`

restart the workspace
eslint should be there

Also you might check the log trace of the init-container and see something like
```
downloading https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-eslint/vscode-eslint-2.1.1-1e15d3.vsix to /plugins for component theia
```


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [x] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next


Change-Id: Ic8b417484596f8440a157e0d24cd7bbf4da9c40c
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
