### PR TITLE
fix: handle multiple containers in one devfile.yaml

### DIFF
--- a/tools/devworkspace-handler/package.json
+++ b/tools/devworkspace-handler/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "prepare": "yarn run clean && yarn run build",
     "clean": "rimraf lib",
-    "build": "yarn run format && yarn run compile && yarn run lint",
+    "build": "yarn run format && yarn run compile && yarn run lint && yarn run test",
     "compile": "tsc --project .",
     "format": "if-env SKIP_FORMAT=true && echo 'skip format check' || prettier --check '{src,tests}/**/*.ts' package.json",
     "format:fix": "prettier --write '{src,tests}/**/*.ts' package.json",


### PR DESCRIPTION
### What does this PR do?
Enhance pattern to find the devcontainer from a devfile:
- Allow to set 'che-theia.eclipse.org/dev-container': true attribute to specify the container
- Skip all mountSources:false containers
- Take first container if more than one container is found


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20725

### How to test this PR?
Look at the tests
Also you can check DevWorkspace generated by the command

```bash
$ cd tools/devworkspace-handler
$ node lib/entrypoint.js --devfile-url:https://github.com/svor/console-java-simple/tree/devfile2 --output-file:/tmp/all-ione.yaml
No plug-in registry url. Setting to https://eclipse-che.github.io/che-plugin-registry/main/v3
No editor. Setting to eclipse/che-theia/next
No sidecar policy. Setting to useDevContainer
More than one dev container component has been potentially found, taking the first one of tools,mongo
```

as you can see it will take tools component now (previously there was an error saying that there were too many)

and if you try with my fork
```
node lib/entrypoint.js --devfile-url:https://github.com/benoitf/console-java-simple/tree/devfile2 --output-file:/tmp/all-ione.yaml
No plug-in registry url. Setting to https://eclipse-che.github.io/che-plugin-registry/main/v3
No editor. Setting to eclipse/che-theia/next
No sidecar policy. Setting to useDevContainer
```
As mongodb component is annotated with mountSources:false it's skipped as well

note: you can check the output result file `/tmp/all-ione.yaml` to see that vsix annotations are added, entrypoint overrided, etc.

note2: this library needs to be merged into dashboard to propagate the changes


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [x] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next


Change-Id: I8a441374408056d7571c02d8f43ea6be4edcc711
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
