### PR TITLE
fix: make sure we don't loop if there are spaces in the fields

### DIFF
--- a/dockerfiles/theia-endpoint-runtime-binary/src/entrypoint.sh
+++ b/dockerfiles/theia-endpoint-runtime-binary/src/entrypoint.sh
@@ -46,6 +46,7 @@ processDevWorkspacePlugins() {
   # Array of object containing: name, env and extensions fields
   flattenedDevfile=$(cat "/devworkspace-metadata/flattened.devworkspace.yaml")
   vsixPerComponents=$(analyze_flattened_devfile "$flattenedDevfile")
+  IFS=$'\n' 
   for componentData in $vsixPerComponents; do
   
     # Component is in the name


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Always download vsix files as expected

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/20786


### How to test this PR?

Click on a link like https://che-host/#https://github.com/svor/scala-sbt/tree/44377a575ff436dd17903d123048b7c03e112a25?che-editor=https://gist.githubusercontent.com/benoitf/2253b07833857f1f1a5a5d50c42b7be2/raw/295a9941a9fbf0da7357511dedbc0aa0dbed126e/theia-next
with DevWorkspace engine being enabled

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [x] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next


Change-Id: I789b2f6ce4ef8e733b3a3633e7523fd416d977e3
Signed-off-by: Florent Benoit <fbenoit@redhat.com>