### PR TITLE
chore: ensure the loop is done on a space separated variable

### DIFF
--- a/dockerfiles/theia-endpoint-runtime-binary/src/entrypoint.sh
+++ b/dockerfiles/theia-endpoint-runtime-binary/src/entrypoint.sh
@@ -64,6 +64,7 @@ processDevWorkspacePlugins() {
     # transform it into a space separated list
     urls=$(extract_urls_from_item "$componentData")
   
+    IFS=' '
     for url in $urls; do
       CURL_OPTIONS=""
       # check if URL starts with relative:extension/


### PR DESCRIPTION
### What does this PR do?
Multiple URLs were not analyzed as the for loop separator was set to newline

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
Fixes the fix of https://github.com/eclipse/che/issues/20786

it was adding a new separator on for loop using only newlines and then we need here to reset it to be space separated again

### How to test this PR?
You may test with quay.io/fbenoit/che-theia-endpoint-runtime-binary:20211119 image

```
https://<che-host>#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?che-editor=https://gist.githubusercontent.com/benoitf/2253b07833857f1f1a5a5d50c42b7be2/raw/32ef83517a5e961a01ab633e332250305412fcfe/theia-next
```
![image](https://user-images.githubusercontent.com/436777/142602802-e0f4d470-9c08-4aec-899f-6897089fe55c.png)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [x] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next


Change-Id: I8f2519576f982d74e58dcf9a728021a4a1874eab
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
