### PR TITLE
chore: apply preferences and sidecar's updates form che-theia-plugins.yaml 

### DIFF
--- a/tools/devworkspace-handler/src/devfile/che-theia-plugins-analyzer.ts
+++ b/tools/devworkspace-handler/src/devfile/che-theia-plugins-analyzer.ts
@@ -37,7 +37,7 @@ export class CheTheiaPluginsAnalyzer {
       return cheTheiaPluginsYamlInRepository.map(entry => {
         const sidecar: V1alpha2DevWorkspaceSpecTemplateComponentsItemsContainer = entry.override?.sidecar;
         if (sidecar && !sidecar.image) {
-          // image will be applied form the plugin registry
+          // image will be applied from the plugin registry
           sidecar.image = '';
         }
         return {

--- a/tools/devworkspace-handler/src/plugin-registry/plugin-registry-resolver.ts
+++ b/tools/devworkspace-handler/src/plugin-registry/plugin-registry-resolver.ts
@@ -134,8 +134,24 @@ export class PluginRegistryResolver {
       vSCodeExtensionEntry.sidecarName = sidecar.name;
       delete sidecar.name;
     }
+    const vSCodeExtensionEntrySidecar = vSCodeExtensionEntry.sidecar;
     vSCodeExtensionEntry.sidecar = sidecar;
-    vSCodeExtensionEntry.preferences = cheTheiaPluginYaml.preferences;
+
+    //overwrite cpu and memory limit in sidecar
+    if (vSCodeExtensionEntrySidecar?.cpuLimit) {
+      vSCodeExtensionEntry.sidecar.cpuLimit = vSCodeExtensionEntrySidecar.cpuLimit;
+    }
+    if (vSCodeExtensionEntrySidecar?.memoryLimit) {
+      vSCodeExtensionEntry.sidecar.memoryLimit = vSCodeExtensionEntrySidecar.memoryLimit;
+    }
+
+    // merge preferences
+    // a preference from entry should overwrite a preference from registry which has identical key
+    const pluginPreferences = cheTheiaPluginYaml.preferences || {};
+    const overriddenPreferences = vSCodeExtensionEntry.preferences || {};
+    const allPreferences = { ...pluginPreferences, ...overriddenPreferences };
+
+    vSCodeExtensionEntry.preferences = allPreferences;
     vSCodeExtensionEntry.dependencies = cheTheiaPluginYaml.dependencies;
   }
 }

--- a/tools/devworkspace-handler/tests/_data/che-theia/che-theia-plugins-id.yaml
+++ b/tools/devworkspace-handler/tests/_data/che-theia/che-theia-plugins-id.yaml
@@ -1,1 +1,6 @@
 - id: redhat/java/latest
+  override:
+    preferences:
+      java.server.launchMode: LightWeight
+    sidecar:
+      memoryLimit: 1280Mi 

--- a/tools/devworkspace-handler/tests/_data/che-theia/che-theia-plugins-id.yaml
+++ b/tools/devworkspace-handler/tests/_data/che-theia/che-theia-plugins-id.yaml
@@ -1,6 +1,2 @@
 - id: redhat/java/latest
-  override:
-    preferences:
-      java.server.launchMode: LightWeight
-    sidecar:
-      memoryLimit: 1280Mi 
+- id: golang/go/latest

--- a/tools/devworkspace-handler/tests/_data/che-theia/che-theia-plugins.yaml
+++ b/tools/devworkspace-handler/tests/_data/che-theia/che-theia-plugins.yaml
@@ -1,0 +1,6 @@
+- id: redhat/java/latest
+  override:
+    preferences:
+      java.server.launchMode: LightWeight
+    sidecar:
+      memoryLimit: 1280Mi 

--- a/tools/devworkspace-handler/tests/devfile/che-theia-plugins-analyzer.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/che-theia-plugins-analyzer.spec.ts
@@ -29,8 +29,27 @@ describe('Test CheTheiaPluginsAnalyzer', () => {
     cheTheiaPluginsAnalyzer = container.get(CheTheiaPluginsAnalyzer);
   });
 
-  test('basic', async () => {
+  test('che-theia-plugins.yaml contains only id', async () => {
     const cheTheiaPluginsYamlPath = path.resolve(__dirname, '..', '_data', 'che-theia', 'che-theia-plugins-id.yaml');
+    const cheTheiaPluginsYamlContent = await fs.readFile(cheTheiaPluginsYamlPath, 'utf-8');
+
+    const entries = await cheTheiaPluginsAnalyzer.extractPlugins(cheTheiaPluginsYamlContent);
+
+    expect(entries.length).toBe(2);
+    expect(entries[0]).toEqual({
+      id: 'redhat/java/latest',
+      resolved: false,
+      extensions: [],
+    });
+    expect(entries[1]).toEqual({
+      id: 'golang/go/latest',
+      resolved: false,
+      extensions: [],
+    });
+  });
+
+  test('basic', async () => {
+    const cheTheiaPluginsYamlPath = path.resolve(__dirname, '..', '_data', 'che-theia', 'che-theia-plugins.yaml');
     const cheTheiaPluginsYamlContent = await fs.readFile(cheTheiaPluginsYamlPath, 'utf-8');
 
     const entries = await cheTheiaPluginsAnalyzer.extractPlugins(cheTheiaPluginsYamlContent);

--- a/tools/devworkspace-handler/tests/devfile/che-theia-plugins-analyzer.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/che-theia-plugins-analyzer.spec.ts
@@ -34,9 +34,12 @@ describe('Test CheTheiaPluginsAnalyzer', () => {
     const cheTheiaPluginsYamlContent = await fs.readFile(cheTheiaPluginsYamlPath, 'utf-8');
 
     const entries = await cheTheiaPluginsAnalyzer.extractPlugins(cheTheiaPluginsYamlContent);
+
     expect(entries.length).toBe(1);
     expect(entries[0]).toStrictEqual({
       id: 'redhat/java/latest',
+      preferences: { 'java.server.launchMode': 'LightWeight' },
+      sidecar: { image: '', memoryLimit: '1280Mi' },
       resolved: false,
       extensions: [],
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2971,6 +2971,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/fs-extra@^9.0.11":
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
+  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@*", "@types/glob@^7.1.1":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz#ea59e21d2ee5c517914cb4bc8e4153b99e566672"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Makes it possible to overwrite default values of preferences and resources limits of a sidecar which come from the plugin registry. 
New values are taken from the `.che/che-theia-plugins.yaml` which is located in the sample repository.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20596


### How to test this PR?
To check that preferences were applied:
- Go into che-theia/tools/devworkspace-handler
- Execute `node lib/entrypoint.js --devfile-url:https://github.com/svor/java-spring-petclinic/tree/sv-che-preferences --output-file:/tmp/all-in-one.yaml`
- Check the content `/tmp/all-in-one.yaml`. 
Tools component should contain:
```yaml
che-theia.eclipse.org/vscode-preferences:
      java.server.launchMode: LightWeight
``` 
This preference comes from [che-theia-plguins.yaml](https://github.com/svor/java-spring-petclinic/blob/sv-che-preferences/.che/che-theia-plugins.yaml):
```yaml
- id: redhat/java/latest
  override:
    preferences:
      java.server.launchMode: LightWeight
    sidecar:
      memoryLimit: 1G
      cpuLimit: 100m
```
To check that sidecar resources limits were applied:
- Execute `node lib/entrypoint.js --devfile-url:https://github.com/svor/java-spring-petclinic/tree/sv-che-preferences --output-file:/tmp/all-in-one.yaml --sidecar-policy:mergeImage`
- Check the content `/tmp/all-in-one.yaml`. 
It should contain:
```yaml
      - name: vscode-java
        attributes:
          app.kubernetes.io/part-of: che-theia.eclipse.org
          app.kubernetes.io/component: vscode-extension
          che-theia.eclipse.org/vscode-extensions:
            - >-
              https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.75.0-60.vsix
            - >-
              https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix
            - >-
              https://open-vsx.org/api/vscjava/vscode-java-test/0.28.1/file/vscjava.vscode-java-test-0.28.1.vsix
          che-theia.eclipse.org/vscode-preferences:
            java.server.launchMode: LightWeight
        container:
          memoryLimit: 1G
          memoryRequest: 20Mi
          cpuLimit: 100m
          cpuRequest: 30m
          volumeMounts:
            - name: m2
              path: /home/theia/.m2
            - path: /remote-endpoint
              name: remote-endpoint
            - path: /plugins
              name: plugins
          image: quay.io/eclipse/che-plugin-sidecar:java-23e57d6
          env:
            - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
              value: /remote-endpoint/plugin-remote-endpoint
            - name: THEIA_PLUGINS
              value: local-dir:///plugins/sidecars/vscode-java
```
with updated preference and container's resource limits.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [x] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
