### PR TITLE
fix: Add volume component if plug-in declares a volumeMount

### DIFF
--- a/tools/devworkspace-handler/src/devfile/dev-container-component-updater.ts
+++ b/tools/devworkspace-handler/src/devfile/dev-container-component-updater.ts
@@ -78,6 +78,19 @@ export class DevContainerComponentUpdater {
     );
     devContainer.volumeMounts.push(...toInsertVolumeMounts);
 
+    // grab existing components that are volumes
+    const devWorkspaceComponents = devfileContext.devWorkspace?.spec?.template?.components || [];
+    const volumeComponents = devWorkspaceComponents
+      .filter(component => component.volume)
+      .map(component => component.name);
+    // keep only the volumes that are not yet there
+    const volumeComponentsToAdd = toInsertVolumeMounts
+      .filter(volumeMount => !volumeComponents.includes(volumeMount.name))
+      .map(volume => ({ name: volume.name, volume: {} }));
+    volumeComponentsToAdd.forEach(volumeComponent => {
+      devWorkspaceComponents.push(volumeComponent);
+    });
+
     // need to tweak the entrypoint to call the ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
     devContainer.args = ['sh', '-c', '${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}'];
 

--- a/tools/devworkspace-handler/tests/devfile/dev-container-component-updater.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/dev-container-component-updater.spec.ts
@@ -44,7 +44,20 @@ describe('Test DevContainerComponentUpdater', () => {
   });
 
   test('basics', async () => {
-    const devfileContext = {} as DevfileContext;
+    const devfileContext = {
+      devWorkspace: {
+        spec: {
+          template: {
+            components: [
+              {
+                name: 'existingVolume',
+                volume: {},
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as DevfileContext;
 
     const devContainerComponent: V1alpha2DevWorkspaceSpecTemplateComponents = {
       name: 'foo',
@@ -125,6 +138,11 @@ describe('Test DevContainerComponentUpdater', () => {
     ]);
     // args updated
     expect(devContainerComponent?.container?.args).toStrictEqual(['sh', '-c', '${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}']);
+
+    // check we have a new volume added
+    const components = devfileContext.devWorkspace.spec?.template?.components || [];
+    const componentsWithVolumes = components.filter(component => component.volume).map(component => component.name);
+    expect(componentsWithVolumes).toStrictEqual(['existingVolume', 'foo']);
   });
 
   test('basics without existing', async () => {


### PR DESCRIPTION
### What does this PR do?
A volume component should be added if a VSCode extension / che-theia plug-in requires a volumeMount that is not specified.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20805

### How to test this PR?
Look at the test or try out
node lib/entrypoint.js --devfile-url:https://github.com/benoitf/spring-petclinic/tree/testmario --output-file:/tmp/all-ione.yaml

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [x] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next


Change-Id: If31e8c63d259e80566aac743869668e6fac4ee9f
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
