### PR TITLE
feat: devWorkspaces: Add link to dashboard, implement stop

### DIFF
--- a/extensions/eclipse-che-theia-dashboard/package.json
+++ b/extensions/eclipse-che-theia-dashboard/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@eclipse-che/api": "latest",
     "@theia/core": "next",
+    "@theia/plugin-ext": "next",
     "@eclipse-che/theia-remote-api": "^0.0.1"
   },
   "scripts": {

--- a/extensions/eclipse-che-theia-dashboard/src/browser/che-theia-dashboard-module.ts
+++ b/extensions/eclipse-che-theia-dashboard/src/browser/che-theia-dashboard-module.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2021 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,11 +8,13 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+import { CommandContribution } from '@theia/core';
 import { ContainerModule } from 'inversify';
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { TheiaDashboardClient } from './theia-dashboard-client';
 
 export default new ContainerModule(bind => {
   bind(TheiaDashboardClient).toSelf().inSingletonScope();
+  bind(CommandContribution).toService(TheiaDashboardClient);
   bind(FrontendApplicationContribution).toDynamicValue(c => c.container.get(TheiaDashboardClient));
 });

--- a/extensions/eclipse-che-theia-remote-api/src/browser/che-remote-api-frontend-module.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/browser/che-remote-api-frontend-module.ts
@@ -10,6 +10,7 @@
 
 import { CertificateService, cheCertificateServicePath } from '../common/certificate-service';
 import { CheK8SService, cheK8SServicePath } from '../common/k8s-service';
+import { DashboardService, cheDashboardServicePath } from '../common';
 import { DevfileService, cheDevfileServicePath } from '../common/devfile-service';
 import { EndpointService, cheEndpointServicePath } from '../common/endpoint-service';
 import { FactoryService, cheFactoryServicePath } from '../common/factory-service';
@@ -100,6 +101,13 @@ export default new ContainerModule(bind => {
     .toDynamicValue(ctx => {
       const provider = ctx.container.get(WebSocketConnectionProvider);
       return provider.createProxy<EndpointService>(cheHttpServicePath);
+    })
+    .inSingletonScope();
+
+  bind(DashboardService)
+    .toDynamicValue(ctx => {
+      const provider = ctx.container.get(WebSocketConnectionProvider);
+      return provider.createProxy<DashboardService>(cheDashboardServicePath);
     })
     .inSingletonScope();
 });

--- a/extensions/eclipse-che-theia-remote-api/src/common/dashboard-service.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/common/dashboard-service.ts
@@ -8,12 +8,10 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-export * from './certificate-service';
-export * from './factory-service';
-export * from './k8s-service';
-export * from './oauth-service';
-export * from './ssh-key-service';
-export * from './telemetry-service';
-export * from './user-service';
-export * from './workspace-service';
-export * from './dashboard-service';
+export const cheDashboardServicePath = '/services/che-dashboard-service';
+
+export const DashboardService = Symbol('DashboardService');
+
+export interface DashboardService {
+  getDashboardUrl(): Promise<string | undefined>;
+}

--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-dashboard-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-dashboard-service-impl.ts
@@ -8,12 +8,12 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-export * from './certificate-service';
-export * from './factory-service';
-export * from './k8s-service';
-export * from './oauth-service';
-export * from './ssh-key-service';
-export * from './telemetry-service';
-export * from './user-service';
-export * from './workspace-service';
-export * from './dashboard-service';
+import { DashboardService } from '@eclipse-che/theia-remote-api/lib/common/dashboard-service';
+import { injectable } from 'inversify';
+
+@injectable()
+export class CheDashboardServiceImpl implements DashboardService {
+  async getDashboardUrl(): Promise<string | undefined> {
+    return process.env.CHE_DASHBOARD_URL;
+  }
+}

--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-remote-impl-che-server-backend-module.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-remote-impl-che-server-backend-module.ts
@@ -14,6 +14,7 @@ import {
 } from '@eclipse-che/theia-remote-api/lib/common/certificate-service';
 import { CheK8SService, cheK8SServicePath } from '@eclipse-che/theia-remote-api/lib/common/k8s-service';
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core';
+import { DashboardService, cheDashboardServicePath } from '@eclipse-che/theia-remote-api/lib/common/dashboard-service';
 import { DevfileService, cheDevfileServicePath } from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
 import { EndpointService, cheEndpointServicePath } from '@eclipse-che/theia-remote-api/lib/common/endpoint-service';
 import { FactoryService, cheFactoryServicePath } from '@eclipse-che/theia-remote-api/lib/common/factory-service';
@@ -24,6 +25,7 @@ import { TelemetryService, cheTelemetryServicePath } from '@eclipse-che/theia-re
 import { UserService, cheUserServicePath } from '@eclipse-che/theia-remote-api/lib/common/user-service';
 import { WorkspaceService, cheWorkspaceServicePath } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
 
+import { CheDashboardServiceImpl } from './che-dashboard-service-impl';
 import { CheK8SServiceImpl } from './che-server-k8s-service-impl';
 import { CheServerCertificateServiceImpl } from './che-server-certificate-service-impl';
 import { CheServerDevfileServiceImpl } from './che-server-devfile-service-impl';
@@ -59,6 +61,7 @@ export default new ContainerModule(bind => {
   bind(CheServerEndpointServiceImpl).toSelf().inSingletonScope();
   bind(CheK8SServiceImpl).toSelf().inSingletonScope();
   bind(CheServerHttpServiceImpl).toSelf().inSingletonScope();
+  bind(CheDashboardServiceImpl).toSelf().inSingletonScope();
 
   bind(CertificateService).to(CheServerCertificateServiceImpl).inSingletonScope();
   bind(FactoryService).to(CheServerFactoryServiceImpl).inSingletonScope();
@@ -71,6 +74,7 @@ export default new ContainerModule(bind => {
   bind(DevfileService).to(CheServerDevfileServiceImpl).inSingletonScope();
   bind(EndpointService).to(CheServerEndpointServiceImpl).inSingletonScope();
   bind(HttpService).to(CheServerHttpServiceImpl).inSingletonScope();
+  bind(DashboardService).to(CheDashboardServiceImpl).inSingletonScope();
 
   bind(ConnectionHandler)
     .toDynamicValue(
@@ -122,5 +126,11 @@ export default new ContainerModule(bind => {
 
   bind(ConnectionHandler)
     .toDynamicValue(ctx => new JsonRpcConnectionHandler(cheHttpServicePath, () => ctx.container.get(HttpService)))
+    .inSingletonScope();
+
+  bind(ConnectionHandler)
+    .toDynamicValue(
+      ctx => new JsonRpcConnectionHandler(cheDashboardServicePath, () => ctx.container.get(DashboardService))
+    )
     .inSingletonScope();
 });

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-backend-module.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-backend-module.ts
@@ -14,6 +14,7 @@ import {
 } from '@eclipse-che/theia-remote-api/lib/common/certificate-service';
 import { CheK8SService, cheK8SServicePath } from '@eclipse-che/theia-remote-api/lib/common/k8s-service';
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core';
+import { DashboardService, cheDashboardServicePath } from '@eclipse-che/theia-remote-api/lib/common/dashboard-service';
 import { DevfileService, cheDevfileServicePath } from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
 import { EndpointService, cheEndpointServicePath } from '@eclipse-che/theia-remote-api/lib/common/endpoint-service';
 import { FactoryService, cheFactoryServicePath } from '@eclipse-che/theia-remote-api/lib/common/factory-service';
@@ -28,6 +29,7 @@ import { ContainerModule } from 'inversify';
 import { K8SHttpServiceImpl } from './k8s-http-service-impl';
 import { K8SServiceImpl } from './k8s-service-impl';
 import { K8sCertificateServiceImpl } from './k8s-certificate-service-impl';
+import { K8sDashboardServiceImpl } from './k8s-dashboard-service-impl';
 import { K8sDevWorkspaceEnvVariables } from './k8s-devworkspace-env-variables';
 import { K8sDevfileServiceImpl } from './k8s-devfile-service-impl';
 import { K8sEndpointServiceImpl } from './k8s-endpoint-service-impl';
@@ -57,6 +59,7 @@ export default new ContainerModule(bind => {
   bind(K8sEndpointServiceImpl).toSelf().inSingletonScope();
   bind(K8SHttpServiceImpl).toSelf().inSingletonScope();
   bind(K8sDevWorkspaceEnvVariables).toSelf().inSingletonScope();
+  bind(K8sDashboardServiceImpl).toSelf().inSingletonScope();
 
   bind(CertificateService).to(K8sCertificateServiceImpl).inSingletonScope();
   bind(FactoryService).to(K8sFactoryServiceImpl).inSingletonScope();
@@ -69,6 +72,7 @@ export default new ContainerModule(bind => {
   bind(DevfileService).to(K8sDevfileServiceImpl).inSingletonScope();
   bind(EndpointService).to(K8sEndpointServiceImpl).inSingletonScope();
   bind(HttpService).to(K8SHttpServiceImpl).inSingletonScope();
+  bind(DashboardService).to(K8sDashboardServiceImpl).inSingletonScope();
 
   bind(ConnectionHandler)
     .toDynamicValue(
@@ -120,5 +124,11 @@ export default new ContainerModule(bind => {
 
   bind(ConnectionHandler)
     .toDynamicValue(ctx => new JsonRpcConnectionHandler(cheHttpServicePath, () => ctx.container.get(HttpService)))
+    .inSingletonScope();
+
+  bind(ConnectionHandler)
+    .toDynamicValue(
+      ctx => new JsonRpcConnectionHandler(cheDashboardServicePath, () => ctx.container.get(DashboardService))
+    )
     .inSingletonScope();
 });

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-dashboard-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-dashboard-service-impl.ts
@@ -1,0 +1,24 @@
+/**********************************************************************
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { inject, injectable } from 'inversify';
+
+import { DashboardService } from '@eclipse-che/theia-remote-api/lib/common/dashboard-service';
+import { K8sDevWorkspaceEnvVariables } from './k8s-devworkspace-env-variables';
+
+@injectable()
+export class K8sDashboardServiceImpl implements DashboardService {
+  @inject(K8sDevWorkspaceEnvVariables)
+  private k8sDevWorkspaceEnvVariables: K8sDevWorkspaceEnvVariables;
+
+  async getDashboardUrl(): Promise<string | undefined> {
+    return this.k8sDevWorkspaceEnvVariables.getDashboardURL();
+  }
+}

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-devworkspace-env-variables.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-devworkspace-env-variables.ts
@@ -50,6 +50,11 @@ export class K8sDevWorkspaceEnvVariables {
    */
   private readonly pluginRegistryInternalURL: string;
 
+  /**
+   * dashboardURL - Dashboard URL
+   */
+  private readonly dashboardURL: string;
+
   constructor() {
     if (process.env.DEVWORKSPACE_ID === undefined) {
       console.error('Environment variable DEVWORKSPACE_ID is not set');
@@ -92,6 +97,12 @@ export class K8sDevWorkspaceEnvVariables {
     } else {
       this.pluginRegistryInternalURL = process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL;
     }
+
+    if (process.env.CHE_DASHBOARD_URL === undefined) {
+      console.error('Environment variable CHE_DASHBOARD_URL is not set');
+    } else {
+      this.dashboardURL = process.env.CHE_DASHBOARD_URL;
+    }
   }
 
   getWorkspaceId(): string {
@@ -120,5 +131,9 @@ export class K8sDevWorkspaceEnvVariables {
 
   getPluginRegistryInternalURL(): string {
     return this.pluginRegistryInternalURL;
+  }
+
+  getDashboardURL(): string {
+    return this.dashboardURL;
   }
 }

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-workspace-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-workspace-service-impl.ts
@@ -8,6 +8,8 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+import * as k8s from '@kubernetes/client-node';
+
 import {
   Container,
   Workspace,
@@ -19,10 +21,14 @@ import { inject, injectable } from 'inversify';
 import { DevfileService } from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
 import { EndpointService } from '@eclipse-che/theia-remote-api/lib/common/endpoint-service';
 import { HttpService } from '@eclipse-che/theia-remote-api/lib/common/http-service';
+import { K8SServiceImpl } from './k8s-service-impl';
 import { K8sDevWorkspaceEnvVariables } from './k8s-devworkspace-env-variables';
 
 @injectable()
 export class K8sWorkspaceServiceImpl implements WorkspaceService {
+  @inject(K8SServiceImpl)
+  private k8SService: K8SServiceImpl;
+
   @inject(DevfileService)
   private devfileService: DevfileService;
 
@@ -82,8 +88,35 @@ export class K8sWorkspaceServiceImpl implements WorkspaceService {
   }
 
   public async stop(): Promise<void> {
-    // stopping the workspace is changing the state to false
-    throw new Error('workspaceService.stop() not supported');
+    // stopping the workspace is changing the started state to false
+
+    const customObjectsApi = this.k8SService.makeApiClient(k8s.CustomObjectsApi);
+    const group = 'workspace.devfile.io';
+    const version = 'v1alpha2';
+    const namespace = this.env.getWorkspaceNamespace();
+    const plural = 'devworkspaces';
+    const name = this.env.getWorkspaceName();
+    const patch = [
+      {
+        op: 'replace',
+        path: '/spec/started',
+        value: false,
+      },
+    ];
+
+    const options = { headers: { 'Content-type': k8s.PatchUtils.PATCH_FORMAT_JSON_PATCH } };
+    await customObjectsApi.patchNamespacedCustomObject(
+      group,
+      version,
+      namespace,
+      plural,
+      name,
+      patch,
+      undefined,
+      undefined,
+      undefined,
+      options
+    );
   }
 
   public async getWorkspaceSettings(): Promise<WorkspaceSettings> {


### PR DESCRIPTION
### What does this PR do?
- Add a link to dashboard in command palette for DevWorkspace mode
- Implement the stopWorkspace method (instead of current throwing 'not implemented' error) of a DevWorkspace
- Redirect to the dashboard page when closing the Workspace in DevWorkspace mode (today it's doing nothing. workspace is not stopped and we stay in the IDE page)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/20808



### How to test this PR?
In DevWorkspace mode:
open a getting started, check there is a link in command palette to open dashboard and you can open dashboard
close the workspace and check we're redirected to dashboard
you can try with:
`https://<che-host-with-devworkspace>#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?che-editor=https://gist.githubusercontent.com/benoitf/8603992a73e902792b8961c645395897/raw/619f4ae4b29dfdb27e016e73353715050c75d4f1/pr1264-theia.yaml`

in che-server-mode:
check open dashboard command is NOT in command palette (it's only for DevWorkspace mode)
Try to use menu "close workspace", it should display again the workspaces as before (we stay in dashboard)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [x] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next

Change-Id: I55672c6ed1b8933e921d85f8bcb956f127680cf6
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
