### PR TITLE
Install plugins to devworkspaces

### DIFF
--- a/extensions/eclipse-che-theia-about/package.json
+++ b/extensions/eclipse-che-theia-about/package.json
@@ -9,7 +9,8 @@
     "inversify": "^5.0.1",
     "@theia/core": "next",
     "@theia/mini-browser": "next",
-    "@eclipse-che/theia-plugin-ext": "^0.0.1"
+    "@eclipse-che/theia-plugin-ext": "^0.0.1",
+    "react": "^16.8.0"
   },
   "devDependencies": {
     "ts-jest": "27.0.7",

--- a/extensions/eclipse-che-theia-plugin-ext/package.json
+++ b/extensions/eclipse-che-theia-plugin-ext/package.json
@@ -37,7 +37,9 @@
     "drivelist": "9.0.2",
     "@eclipse-che/theia-remote-api": "^0.0.1",
     "@eclipse-che/workspace-telemetry-client": "latest",
-    "mime": "2.5.2"
+    "mime": "2.5.2",
+    "react": "^16.8.0",
+    "@phosphor/messaging": "1"
   },
   "devDependencies": {
     "clean-webpack-plugin": "^3.0.0",

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-frontend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-frontend-module.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2018-2020 Red Hat, Inc.
+ * Copyright (c) 2018-2022 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,6 @@ import {
   CheTaskClient,
   CheTaskService,
 } from '../common/che-protocol';
-import { CHE_PLUGIN_SERVICE_PATH, ChePluginService, ChePluginServiceClient } from '../common/che-plugin-protocol';
 import { CheSideCarContentReaderRegistryImpl, CheSideCarResourceResolver } from './che-sidecar-resource';
 import { CommandContribution, ResourceResolver } from '@theia/core/lib/common';
 import { ContainerModule, interfaces } from 'inversify';
@@ -35,6 +34,7 @@ import { ChePluginFrontentService } from './plugin/che-plugin-frontend-service';
 import { ChePluginHandleRegistry } from './che-plugin-handle-registry';
 import { ChePluginManager } from './plugin/che-plugin-manager';
 import { ChePluginMenu } from './plugin/che-plugin-menu';
+import { ChePluginServiceClient } from '@eclipse-che/theia-remote-api/lib/common/plugin-service';
 import { ChePluginServiceClientImpl } from './plugin/che-plugin-service-client';
 import { ChePluginView } from './plugin/che-plugin-view';
 import { ChePluginViewContribution } from './plugin/che-plugin-view-contribution';
@@ -72,13 +72,6 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
   bind(ChePluginServiceClientImpl).toSelf().inSingletonScope();
   bind(ChePluginServiceClient).toService(ChePluginServiceClientImpl);
-  bind(ChePluginService)
-    .toDynamicValue(ctx => {
-      const provider = ctx.container.get(WebSocketConnectionProvider);
-      const client: ChePluginServiceClient = ctx.container.get(ChePluginServiceClient);
-      return provider.createProxy<ChePluginService>(CHE_PLUGIN_SERVICE_PATH, client);
-    })
-    .inSingletonScope();
 
   rebind(WebviewEnvironment).to(CheWebviewEnvironment).inSingletonScope();
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
@@ -12,7 +12,7 @@ import { Command, CommandContribution, CommandRegistry, MessageService } from '@
 import { inject, injectable } from 'inversify';
 
 import { ChePluginManager } from './che-plugin-manager';
-import { ChePluginRegistry } from '../../common/che-plugin-protocol';
+import { ChePluginRegistry } from '@eclipse-che/theia-remote-api/lib/common/plugin-service';
 import { QuickInputService } from '@theia/core/lib/browser';
 
 function cmd(id: string, label: string): Command {

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-frontend-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-frontend-service.ts
@@ -11,8 +11,8 @@
 import { DeployedPlugin, HostedPluginServer, PluginMetadata } from '@theia/plugin-ext/lib/common/plugin-protocol';
 import { inject, injectable } from 'inversify';
 
-import { ChePluginMetadata } from '../../common/che-plugin-protocol';
-import { PluginFilter } from '../../common/plugin/plugin-filter';
+import { ChePluginMetadata } from '@eclipse-che/theia-remote-api/lib/common/plugin-service';
+import { PluginFilter } from './plugin-filter';
 
 @injectable()
 export class ChePluginFrontentService {

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/plugin-filter.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/plugin-filter.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2019-2020 Red Hat, Inc.
+ * Copyright (c) 2019-2022 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-import { ChePluginMetadata } from '../che-plugin-protocol';
+import { ChePluginMetadata } from '@eclipse-che/theia-remote-api/lib/common/plugin-service';
 
 export namespace PluginFilter {
   // @installed
@@ -49,10 +49,8 @@ export namespace PluginFilter {
     const filters = filter.split(' ');
 
     filters.forEach(f => {
-      if (f) {
-        if (!f.startsWith('@')) {
-          filteredPlugins = PluginFilter.filterByText(filteredPlugins, f);
-        }
+      if (f && !f.startsWith('@')) {
+        filteredPlugins = PluginFilter.filterByText(filteredPlugins, f);
       }
     });
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/style/che-plugins-notification.css
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/style/che-plugins-notification.css
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2018-2020 Red Hat, Inc.
+ * Copyright (c) 2018-2022 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -26,17 +26,18 @@
     margin-left: 1px;
     overflow: hidden;
     transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, opacity 500ms ease-in-out 0ms;
-    background-color: var(--theia-successBackground);
-    color: #FFFFFF;
+    background-color: var(--theia-button-background);
+    color: var(--theia-button-foreground);
 }
 
 .che-plugins-notification .notification-button-panel:hover {
-    background-color: var(--theia-button-hover-background);
+    background-color: var(--theia-button-hoverBackground);
 }
 
-.che-plugins-notification .notification-button-panel:active {
-    box-shadow: 0px 0px 2px 0px var(--theia-button-background);
+.che-plugins-notification .notification-button-panel:focus {
+    box-shadow: 0px 0px 1px 1px var(--theia-focusBorder);
     outline: none;
+    background-color: var(--theia-button-hoverBackground);
 }
 
 .che-plugins-notification .notification.hiding {
@@ -44,7 +45,8 @@
 }
 
 .che-plugins-notification .notification-message,
-.che-plugins-notification .notification-button {
+.che-plugins-notification .notification-button,
+.che-plugins-notification .notification-persist-button {
     position: absolute;
     left: 0px;
     top: 9px;
@@ -54,7 +56,12 @@
     overflow: hidden;
 }
 
-.che-plugins-notification .notification-button {
+.che-plugins-notification .notification-persist-button {
+    right: 1px;
+}
+
+.che-plugins-notification .notification-button,
+.che-plugins-notification .notification-persist-button {
     cursor: pointer;
 }
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/style/che-plugins.css
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/style/che-plugins.css
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2018-2020 Red Hat, Inc.
+ * Copyright (c) 2018-2022 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -230,7 +230,7 @@
     top: 58px;
     height: 20px;
     line-height: 20px;
-    right: 85px;
+    right: 95px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -253,10 +253,12 @@
 | Plugin actions
 |----------------------------------------------------------------------------*/
 
-.che-plugin-list .che-plugin-action-add,
-.che-plugin-list .che-plugin-action-remove,
+.che-plugin-list .che-plugin-action-install,
 .che-plugin-list .che-plugin-action-installing,
-.che-plugin-list .che-plugin-action-removing {
+.che-plugin-list .che-plugin-action-installed,
+.che-plugin-list .che-plugin-action-to-be-installed,
+.che-plugin-list .che-plugin-action-removing,
+.che-plugin-list .che-plugin-action-to-be-removed {
     display: block;
     position: absolute;
     font-size: var(--theia-ui-font-size0);
@@ -266,49 +268,97 @@
     height: 22px;
     line-height: 22px;
     right: 4px;
-    width: 75px;
+    width: 85px;
     text-align: center;
     user-select: none;
     border-radius: 1px;
 }
 
-.che-plugin-list .che-plugin-action-add {
+/*************************************************************************
+ *
+ * Install
+ *
+ *************************************************************************/
+.che-plugin-list .che-plugin-action-install {
     cursor: pointer;
     color: var(--theia-button-foreground);
     background-color: var(--theia-button-background);
 }
 
-.che-plugin-list .che-plugin-action-add:hover {
+.che-plugin-list .che-plugin-action-install:hover {
     background-color: var(--theia-button-hoverBackground);
 }
 
-.che-plugin-list .che-plugin-action-add:active {
+.che-plugin-list .che-plugin-action-install:active {
     box-shadow: 0px 0px 1px 1px var(--theia-button-hoverBackground);
     outline: none;
 }
 
-.che-plugin-list .che-plugin-action-remove {
-    cursor: pointer;
-    color: var(--theia-inputValidation-warningBackground);
-    background-color: var(--theia-successBackground);
-}
-
-.che-plugin-list .che-plugin-action-remove:hover {
-    color: var(--theia-secondaryButton-foreground);
-    background-color: var(--theia-secondaryButton-hoverBackground);
-}
-
-.che-plugin-list .che-plugin-action-remove:active {
-    box-shadow: 0px 0px 1px 1px var(--theia-successBackground);
-    outline: none;
-}
+/*************************************************************************
+ *
+ * Installing
+ *
+ *************************************************************************/
 
 .che-plugin-list .che-plugin-action-installing {
     color: var(--theia-secondaryButton-disabledForeground);
     background-color: var(--theia-secondaryButton-disabledBackground);
 }
 
+/*************************************************************************
+ *
+ * Installed, To be Installed
+ *
+ *************************************************************************/
+
+.che-plugin-list .che-plugin-action-installed,
+.che-plugin-list .che-plugin-action-to-be-installed {
+    cursor: pointer;
+    color: var(--theia-inputValidation-warningBackground);
+    background-color: var(--theia-successBackground);
+}
+
+.che-plugin-list .che-plugin-action-installed:hover,
+.che-plugin-list .che-plugin-action-to-be-installed:hover {
+    color: var(--theia-secondaryButton-foreground);
+    background-color: var(--theia-secondaryButton-hoverBackground);
+}
+
+.che-plugin-list .che-plugin-action-installed:active,
+.che-plugin-list .che-plugin-action-to-be-installed:active {
+    box-shadow: 0px 0px 1px 1px var(--theia-successBackground);
+    outline: none;
+}
+
+/*************************************************************************
+ *
+ * Removing
+ *
+ *************************************************************************/
+
 .che-plugin-list .che-plugin-action-removing {
     color: var(--theia-secondaryButton-disabledForeground);
     background-color: var(--theia-secondaryButton-disabledBackground);
+}
+
+/*************************************************************************
+ *
+ * To be Removed
+ *
+ *************************************************************************/
+
+.che-plugin-list .che-plugin-action-to-be-removed {
+    cursor: pointer;
+    color: var(--theia-warningForeground);
+    background-color: var(--theia-warningBackground);
+}
+
+.che-plugin-list .che-plugin-action-to-be-removed:hover {
+    color: var(--theia-secondaryButton-foreground);
+    background-color: var(--theia-secondaryButton-hoverBackground);
+}
+
+.che-plugin-list .che-plugin-action-to-be-removed:active {
+    box-shadow: 0px 0px 1px 1px var(--theia-successBackground);
+    outline: none;
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/ws-request-validator-contribution.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/ws-request-validator-contribution.ts
@@ -16,16 +16,16 @@ import { inject, injectable } from 'inversify';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { EndpointService } from '@eclipse-che/theia-remote-api/lib/common/endpoint-service';
 import { ILogger } from '@theia/core/lib/common/logger';
-import { PluginApiContribution } from '@theia/plugin-ext/lib/main/node/plugin-service';
 import { SERVER_WEBVIEWS_ATTR_VALUE } from '../common/che-server-common';
 import { WebviewExternalEndpoint } from '@theia/plugin-ext/lib/main/common/webview-protocol';
+import { PluginApiContribution as WsRequestValidatorContributionImpl } from '@theia/plugin-ext/lib/main/node/plugin-service';
 
 const vhost = require('vhost');
 
 const pluginPath = (process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE) + './theia/plugins/';
 
 @injectable()
-export class PluginApiContributionIntercepted extends PluginApiContribution {
+export class WsRequestValidatorContributionIntercepted extends WsRequestValidatorContributionImpl {
   @inject(EndpointService)
   private endpointService: EndpointService;
 

--- a/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
+++ b/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
@@ -72,7 +72,8 @@ declare module '@eclipse-che/plugin' {
         }
 
         export interface Devfile {
-            apiVersion: string;
+            apiVersion?: string;
+            schemaVersion?: string;
             attributes?: { [attributeName: string]: string };
             metadata: DevfileMetadata;
             projects?: DevfileProject[];

--- a/extensions/eclipse-che-theia-remote-api/package.json
+++ b/extensions/eclipse-che-theia-remote-api/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@kubernetes/client-node": "^0.12.1",
     "@theia/core": "next",
+    "js-yaml": "3.13.1",
     "inversify": "^5.0.1"
   },
   "devDependencies": {

--- a/extensions/eclipse-che-theia-remote-api/src/browser/che-remote-api-frontend-module.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/browser/che-remote-api-frontend-module.ts
@@ -10,6 +10,7 @@
 
 import { CertificateService, cheCertificateServicePath } from '../common/certificate-service';
 import { CheK8SService, cheK8SServicePath } from '../common/k8s-service';
+import { ChePluginService, ChePluginServiceClient, chePluginServicePath } from '../common/plugin-service';
 import { DashboardService, cheDashboardServicePath } from '../common';
 import { DevfileService, cheDevfileServicePath } from '../common/devfile-service';
 import { EndpointService, cheEndpointServicePath } from '../common/endpoint-service';
@@ -73,6 +74,14 @@ export default new ContainerModule(bind => {
     .toDynamicValue(ctx => {
       const provider = ctx.container.get(WebSocketConnectionProvider);
       return provider.createProxy<WorkspaceService>(cheWorkspaceServicePath);
+    })
+    .inSingletonScope();
+
+  bind(ChePluginService)
+    .toDynamicValue(ctx => {
+      const provider = ctx.container.get(WebSocketConnectionProvider);
+      const client: ChePluginServiceClient = ctx.container.get(ChePluginServiceClient);
+      return provider.createProxy<ChePluginService>(chePluginServicePath, client);
     })
     .inSingletonScope();
 

--- a/extensions/eclipse-che-theia-remote-api/src/common/dashboard-service.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/common/dashboard-service.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2021 Red Hat, Inc.
+ * Copyright (c) 2021-2022 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,4 +14,6 @@ export const DashboardService = Symbol('DashboardService');
 
 export interface DashboardService {
   getDashboardUrl(): Promise<string | undefined>;
+
+  getEditorUrl(): Promise<string | undefined>;
 }

--- a/extensions/eclipse-che-theia-remote-api/src/common/devfile-service.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/common/devfile-service.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2021 Red Hat, Inc.
+ * Copyright (c) 2021-2022 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -22,6 +22,7 @@ export interface DevfileComponentStatus {
     };
   };
 }
+
 export interface DevfileMetadata {
   attributes?: { [attributeName: string]: string };
   description?: string;
@@ -34,13 +35,15 @@ export interface DevfileMetadata {
 }
 
 export interface Devfile {
-  apiVersion: string;
+  apiVersion?: string;
+  schemaVersion?: string;
   attributes?: { [attributeName: string]: string };
   metadata: DevfileMetadata;
   projects?: DevfileProject[];
   components?: DevfileComponent[];
   commands?: DevfileCommand[];
 }
+
 export interface DevfileCommandGroup {
   isDefault?: boolean;
   kind: 'build' | 'run' | 'test' | 'debug';

--- a/extensions/eclipse-che-theia-remote-api/src/common/http-service.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/common/http-service.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2021 Red Hat, Inc.
+ * Copyright (c) 2021-2022 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,5 +15,10 @@ export const HttpService = Symbol('HttpService');
 export interface HttpService {
   get(url: string): Promise<string | undefined>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get(url: string, responseType: 'text' | 'arraybuffer'): Promise<any | undefined>;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   post(url: string, data?: any): Promise<string | undefined>;
+
+  head(url: string): Promise<boolean>;
 }

--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-dashboard-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-dashboard-service-impl.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2021 Red Hat, Inc.
+ * Copyright (c) 2021-2022 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -15,5 +15,9 @@ import { injectable } from 'inversify';
 export class CheDashboardServiceImpl implements DashboardService {
   async getDashboardUrl(): Promise<string | undefined> {
     return process.env.CHE_DASHBOARD_URL;
+  }
+
+  async getEditorUrl(): Promise<string | undefined> {
+    return undefined;
   }
 }

--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-http-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-http-service-impl.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2021 Red Hat, Inc.
+ * Copyright (c) 2021-2022 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,12 +23,13 @@ export class CheServerHttpServiceImpl implements HttpService {
   @inject(CertificateService)
   private certificateService: CertificateService;
 
-  async get(uri: string): Promise<string | undefined> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async get(uri: string, responseType?: 'text' | 'arraybuffer'): Promise<any | undefined> {
     const axiosInstance = await this.getAxiosInstance(uri);
     try {
       const response = await axiosInstance.get(uri, {
         transformResponse: [data => data],
-        responseType: 'text',
+        responseType: responseType || 'text',
       });
       return response.data;
     } catch (error) {
@@ -43,6 +44,10 @@ export class CheServerHttpServiceImpl implements HttpService {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async post(uri: string, data?: any): Promise<string | undefined> {
     throw new Error('httpsService.post() not supported');
+  }
+
+  async head(uri: string): Promise<boolean> {
+    throw new Error('httpsService.head() not supported');
   }
 
   /**

--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-plugin-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-plugin-service-impl.ts
@@ -1,0 +1,185 @@
+/**********************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import { DevfileComponent, DevfileService } from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
+import { WorkspaceService, WorkspaceSettings } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
+import { inject, injectable } from 'inversify';
+
+import { ChePluginRegistry } from '@eclipse-che/theia-remote-api/lib/common/plugin-service';
+import { PluginServiceImpl } from '@eclipse-che/theia-remote-api/lib/common/plugin-service-impl';
+
+/**
+ * Workspace Settings :: Plugin Registry URI.
+ * Public URI to load registry resources, e.g. icons.
+ */
+const PLUGIN_REGISTRY_URL = 'cheWorkspacePluginRegistryUrl';
+
+/**
+ * Workspace Settings :: Plugin Registry internal URI.
+ * Is used for cross-container communication and mostly for getting plugins metadata.
+ */
+const PLUGIN_REGISTRY_INTERNAL_URL = 'cheWorkspacePluginRegistryInternalUrl';
+
+@injectable()
+export class CheServerPluginServiceImpl extends PluginServiceImpl {
+  @inject(WorkspaceService)
+  private workspaceService: WorkspaceService;
+
+  @inject(DevfileService)
+  private devfileService: DevfileService;
+
+  async getDefaultRegistry(): Promise<ChePluginRegistry> {
+    if (this.defaultRegistry) {
+      return this.defaultRegistry;
+    }
+
+    try {
+      const workspaceSettings: WorkspaceSettings = await this.workspaceService.getWorkspaceSettings();
+      if (workspaceSettings) {
+        const publicUri = workspaceSettings[PLUGIN_REGISTRY_URL];
+        const internalUri = workspaceSettings[PLUGIN_REGISTRY_INTERNAL_URL] || publicUri;
+
+        if (publicUri) {
+          this.defaultRegistry = {
+            name: 'Eclipse Che plugins',
+            internalURI: this.trimTrailingSlash(internalUri),
+            publicURI: this.trimTrailingSlash(publicUri),
+          };
+
+          return this.defaultRegistry;
+        }
+      }
+
+      return Promise.reject('Plugin registry is not configured');
+    } catch (error) {
+      console.error(error);
+      return Promise.reject(`Unable to get default plugin registry URI. ${error.message}`);
+    }
+  }
+
+  /**
+   * Removes /meta.yaml from the end of the plugin ID (reference)
+   */
+  normalizeId(id: string): string {
+    if ((id.startsWith('http://') || id.startsWith('https://')) && id.endsWith('/meta.yaml')) {
+      id = id.substring(0, id.length - '/meta.yaml'.length);
+    }
+
+    return id;
+  }
+
+  /**
+   * Creates a plugin component for the given plugin ID (reference)
+   */
+  createPluginComponent(id: string): DevfileComponent {
+    if (id.startsWith('http://') || id.startsWith('https://')) {
+      return {
+        plugin: {
+          url: `${id}/meta.yaml`,
+        },
+      };
+    } else {
+      return {
+        plugin: {
+          id: `${id}`,
+        },
+      };
+    }
+  }
+
+  /**
+   * Returns list of installed plugins.
+   */
+  async getInstalledPlugins(): Promise<string[]> {
+    const devfile = await this.devfileService.get();
+    const devfileComponents: DevfileComponent[] = devfile.components || [];
+    devfile.components = devfileComponents;
+
+    const plugins: string[] = [];
+    devfileComponents.forEach(component => {
+      if (component.plugin) {
+        if (component.plugin.url) {
+          plugins.push(this.normalizeId(component.plugin.url));
+        } else if (component.plugin.id) {
+          plugins.push(component.plugin.id);
+        }
+      }
+    });
+    return plugins;
+  }
+
+  /**
+   * Sets new list of plugins to workspace configuration.
+   */
+  async setWorkspacePlugins(plugins: string[]): Promise<void> {
+    const devfile = await this.devfileService.get();
+    const devfileComponents: DevfileComponent[] = devfile.components || [];
+
+    const components = devfileComponents.filter(component => component.plugin !== undefined);
+
+    components.forEach(component => {
+      const id = component.plugin!.url ? this.normalizeId(component.plugin!.url) : component.plugin?.id!;
+      const foundIndex = plugins.indexOf(id);
+      if (foundIndex >= 0) {
+        plugins.splice(foundIndex, 1);
+      } else {
+        devfileComponents.splice(devfileComponents.indexOf(component), 1);
+      }
+    });
+
+    plugins.forEach((plugin: string) => {
+      devfileComponents.push(this.createPluginComponent(plugin));
+    });
+    devfile.components = devfileComponents;
+
+    await this.devfileService.updateDevfile(devfile);
+  }
+
+  /**
+   * Adds a plugin to current Che workspace.
+   */
+  async installPlugin(pluginKey: string): Promise<boolean> {
+    try {
+      const plugins: string[] = await this.getInstalledPlugins();
+      plugins.push(pluginKey);
+      await this.setWorkspacePlugins(plugins);
+      return true;
+    } catch (error) {
+      console.error(error);
+      return Promise.reject('Unable to install plugin ' + pluginKey + ' ' + error.message);
+    }
+  }
+
+  /**
+   * Removes a plugin from workspace configuration.
+   */
+  async removePlugin(pluginKey: string): Promise<void> {
+    try {
+      const plugins: string[] = await this.getInstalledPlugins();
+      const filteredPlugins = plugins.filter(p => p !== pluginKey);
+      await this.setWorkspacePlugins(filteredPlugins);
+    } catch (error) {
+      console.error(error);
+      return Promise.reject('Unable to remove plugin ' + pluginKey + ' ' + error.message);
+    }
+  }
+
+  async updatePlugin(oldPluginKey: string, newPluginKey: string): Promise<void> {
+    try {
+      const plugins: string[] = await this.getInstalledPlugins();
+      const filteredPlugins = plugins.filter(p => p !== oldPluginKey);
+      filteredPlugins.push(newPluginKey);
+      await this.setWorkspacePlugins(filteredPlugins);
+    } catch (error) {
+      console.error(error);
+      return Promise.reject(`Unable to update plugin from ${oldPluginKey} to ${newPluginKey}: ${error.message}`);
+    }
+  }
+}

--- a/extensions/eclipse-che-theia-remote-impl-k8s/package.json
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/package.json
@@ -26,7 +26,8 @@
     "request": "2.82.0",
     "@eclipse-che/workspace-telemetry-client": "latest",
     "@kubernetes/client-node": "^0.12.1",
-    "@eclipse-che/theia-remote-api": "^0.0.1"
+    "@eclipse-che/theia-remote-api": "^0.0.1",
+    "jsonc-parser": "^3.0.0"
   },
   "scripts": {
     "prepare": "yarn clean && yarn build && yarn test",

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-dashboard-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-dashboard-service-impl.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2021 Red Hat, Inc.
+ * Copyright (c) 2021-2022 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,5 +20,13 @@ export class K8sDashboardServiceImpl implements DashboardService {
 
   async getDashboardUrl(): Promise<string | undefined> {
     return this.k8sDevWorkspaceEnvVariables.getDashboardURL();
+  }
+
+  async getEditorUrl(): Promise<string | undefined> {
+    const dashboardURL = this.k8sDevWorkspaceEnvVariables.getDashboardURL();
+    const namespace = this.k8sDevWorkspaceEnvVariables.getWorkspaceNamespace();
+    const workspaceName = this.k8sDevWorkspaceEnvVariables.getWorkspaceName();
+
+    return `${dashboardURL}/dashboard/#/ide/${namespace}/${workspaceName}`;
   }
 }

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-http-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-http-service-impl.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2021 Red Hat, Inc.
+ * Copyright (c) 2021-2022 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -23,12 +23,13 @@ export class K8SHttpServiceImpl implements HttpService {
   @inject(CertificateService)
   private certificateService: CertificateService;
 
-  async get(uri: string): Promise<string | undefined> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async get(uri: string, responseType?: 'text' | 'arraybuffer'): Promise<any | undefined> {
     const axiosInstance = await this.getAxiosInstance(uri);
     try {
       const response = await axiosInstance.get(uri, {
         transformResponse: [data => data],
-        responseType: 'text',
+        responseType: responseType || 'text',
       });
       return response.data;
     } catch (error) {
@@ -53,6 +54,20 @@ export class K8SHttpServiceImpl implements HttpService {
       // not found then we return undefined
       if (error.response && error.response.status === 404) {
         return undefined;
+      }
+      throw error;
+    }
+  }
+
+  async head(uri: string): Promise<boolean> {
+    const axiosInstance = await this.getAxiosInstance(uri);
+    try {
+      await axiosInstance.head(uri);
+      return true;
+    } catch (error) {
+      // not found then we return false
+      if (error.response && error.response.status === 404) {
+        return false;
       }
       throw error;
     }

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-plugin-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-plugin-service-impl.ts
@@ -1,0 +1,781 @@
+/**********************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+import * as fs from 'fs-extra';
+import * as jsYaml from 'js-yaml';
+import * as jsoncparser from 'jsonc-parser';
+import * as path from 'path';
+
+import { Changes, ChePluginRegistry } from '@eclipse-che/theia-remote-api/lib/common/plugin-service';
+import { Devfile, DevfileComponent } from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
+import { inject, injectable, postConstruct } from 'inversify';
+
+import { K8sDevWorkspaceEnvVariables } from './k8s-devworkspace-env-variables';
+import { K8sDevfileServiceImpl } from './k8s-devfile-service-impl';
+import { K8sWorkspaceServiceImpl } from './k8s-workspace-service-impl';
+import { PluginServiceImpl } from '@eclipse-che/theia-remote-api/lib/common/plugin-service-impl';
+
+export const CHE_PLUGINS_JSON = '/plugins/che-plugins.json';
+
+export const PLUGINS_DIR = '/plugins';
+export const SIDECAR_PLUGINS_DIR = '/plugins/sidecars';
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// che-theia-plugin.yaml definition
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export namespace CheTheiaPlugin {
+  export interface Plugin {
+    schemaVersion: string;
+    metadata: Metadata;
+    sidecar?: Sidecar;
+    preferences?: Preferences;
+    dependencies?: string[];
+    extensions?: string[];
+  }
+
+  export interface Metadata {
+    id: string;
+    publisher: string;
+    name: string;
+    version: string;
+    displayName: string;
+    description: string;
+    repository: string;
+    categories: string[];
+    icon: string;
+  }
+
+  export interface Sidecar {
+    name?: string;
+    memoryLimit?: string;
+    memoryRequest?: string;
+    cpuLimit?: string;
+    cpuRequest?: string;
+    volumeMounts?: VolumeMount[];
+    image: string;
+  }
+
+  export interface VolumeMount {
+    name: string;
+    path: string;
+  }
+
+  export interface Preferences {
+    [name: string]: string;
+  }
+}
+
+export interface Installation {
+  plugins: string[];
+
+  cache: {
+    [plugin: string]: CheTheiaPlugin.Plugin;
+  };
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// plugin.json definition
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+interface PluginList {
+  /**
+   * array of plugin identifiers
+   * identifier should be in format ${publisher}.${name}
+   */
+  plugins: string[];
+}
+
+export class Deferred<T> {
+  state: 'pending' | 'resolved' | 'rejected' = 'pending';
+  resolve: (value?: T) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reject: (err?: any) => void;
+
+  promise = new Promise<T>((resolve, reject) => {
+    this.resolve = result => {
+      resolve(result as T);
+      if (this.state === 'pending') {
+        this.state = 'resolved';
+      }
+    };
+    this.reject = err => {
+      reject(err);
+      if (this.state === 'pending') {
+        this.state = 'rejected';
+      }
+    };
+  });
+}
+
+@injectable()
+export class K8sPluginServiceImpl extends PluginServiceImpl {
+  @inject(K8sDevWorkspaceEnvVariables)
+  env: K8sDevWorkspaceEnvVariables;
+
+  @inject(K8sDevfileServiceImpl)
+  devfileService: K8sDevfileServiceImpl;
+
+  @inject(K8sWorkspaceServiceImpl)
+  workspaceService: K8sWorkspaceServiceImpl;
+
+  deferred = new Deferred<void>();
+
+  @postConstruct()
+  protected startup(): void {
+    this.initialize()
+      .then(() => this.deferred.resolve())
+      .catch(e => this.deferred.reject(e));
+  }
+
+  async initialize(): Promise<void> {
+    const ERRMSG = 'Failure to initialize K8sPluginServiceImpl';
+
+    const projectsRoot = this.env.getProjectsRoot();
+
+    if (!projectsRoot) {
+      throw new Error(ERRMSG + 'Projects Root is not set.');
+    }
+
+    if (!(await fs.pathExists(projectsRoot))) {
+      throw new Error(ERRMSG + `Projects root [${projectsRoot}] does not exist`);
+    }
+
+    if (await fs.pathExists(CHE_PLUGINS_JSON)) {
+      try {
+        const list = await this.readChePluginsJSON();
+        for (const plugin of list.plugins) {
+          const parts: string[] = plugin.split('.');
+          this.installedPlugins.push(`${parts[0]}/${parts[1]}/latest`);
+        }
+      } catch (error) {
+        throw new Error('Unable to get list of installed plugins. ' + error.message);
+      }
+
+      return;
+    }
+
+    try {
+      const pluginList: PluginList = { plugins: [] };
+
+      const projects = await fs.readdir(projectsRoot);
+      for (const project of projects) {
+        const extensionsJson = path.join(projectsRoot, project, '.vscode', 'extensions.json');
+
+        if ((await fs.pathExists(extensionsJson)) && (await fs.stat(extensionsJson)).isFile()) {
+          try {
+            const content = await fs.readFile(extensionsJson, 'utf-8');
+            const strippedContent = jsoncparser.stripComments(content);
+            const extensions = jsoncparser.parse(strippedContent);
+
+            const recommendations = extensions['recommendations'];
+
+            const heap: Installation = {
+              plugins: [],
+              cache: {},
+            };
+
+            for (const recommendation of recommendations) {
+              const parts: string[] = recommendation.split('.');
+
+              await this.prepareToInstall(`${parts[0]}/${parts[1]}/latest`, heap, false);
+
+              for (const plugin of heap.plugins) {
+                const pluginParts: string[] = plugin.split('/');
+
+                if (!pluginList.plugins.find(value => value === `${pluginParts[0]}.${pluginParts[1]}`)) {
+                  pluginList.plugins.push(`${pluginParts[0]}.${pluginParts[1]}`);
+                }
+
+                if (!this.installedPlugins.find(value => value === plugin)) {
+                  this.installedPlugins.push(plugin);
+                }
+              }
+            }
+          } catch (thisError) {
+            console.error(
+              `Unable to get list of extensions for ${project}. ${thisError.message ? thisError.message : thisError}`
+            );
+          }
+        }
+      }
+
+      await this.writeChePluginsJSON(pluginList);
+    } catch (error) {
+      throw new Error(ERRMSG + (error ? ' :: ' + (error.message ? error.message : error) : ''));
+    }
+  }
+
+  /**
+   * Reads plugin list from /plugins/che-plugins.json
+   *
+   * @returns plugin list
+   */
+  async readChePluginsJSON(): Promise<PluginList> {
+    const content = await fs.readFile(CHE_PLUGINS_JSON, 'utf-8');
+    return JSON.parse(content);
+  }
+
+  /**
+   * Writes plugin list to /plugins/che-plugins.json
+   *
+   * @param plugins plugin list
+   */
+  async writeChePluginsJSON(plugins: PluginList): Promise<void> {
+    const data = `${JSON.stringify(plugins, undefined, 2)}\n`;
+    await fs.writeFile(CHE_PLUGINS_JSON, data);
+  }
+
+  /**
+   * Returns default plugin registry.
+   *
+   * @returns default plugin registry
+   */
+  async getDefaultRegistry(): Promise<ChePluginRegistry> {
+    if (this.defaultRegistry) {
+      return this.defaultRegistry;
+    }
+
+    await this.deferred.promise;
+
+    const registryURL = this.env.getPluginRegistryURL();
+    const registryInternalURL = this.env.getPluginRegistryInternalURL();
+
+    if (!registryURL) {
+      throw new Error('Plugin registry URL is not configured.');
+    }
+
+    if (!registryInternalURL) {
+      throw new Error('Plugin registry internal URL is not configured.');
+    }
+
+    this.defaultRegistry = {
+      name: 'Eclipse Che plugins',
+      internalURI: this.trimTrailingSlash(registryInternalURL),
+      publicURI: this.trimTrailingSlash(registryURL),
+    };
+
+    return this.defaultRegistry;
+  }
+
+  async getInstalledPlugins(): Promise<string[]> {
+    await this.deferred.promise;
+    return this.installedPlugins;
+  }
+
+  installedPlugins: string[] = [];
+  toInstall: string[] = [];
+  toRemove: string[] = [];
+
+  async fetchCheTheiaPluginYaml(plugin: string): Promise<CheTheiaPlugin.Plugin> {
+    const registryURL = this.trimTrailingSlash(this.env.getPluginRegistryInternalURL());
+    const yamlURL = `${registryURL}/plugins/${plugin}/che-theia-plugin.yaml`;
+    const pluginYaml = await this.httpService.get(yamlURL);
+
+    if (!pluginYaml) {
+      throw new Error(`Unable to get ${yamlURL}`);
+    }
+
+    const yaml = jsYaml.load(pluginYaml);
+
+    if (!yaml.metadata) {
+      throw new Error(`Failure to parse ${yamlURL}, wrong format.`);
+    }
+
+    return yaml;
+  }
+
+  async installPlugin(pluginId: string): Promise<boolean> {
+    // check for existence in this.toRemove
+    if (this.toRemove.find(value => value === pluginId)) {
+      this.toRemove = this.toRemove.filter(value => value !== pluginId);
+      return true;
+    }
+
+    const installation: Installation = {
+      plugins: [],
+      cache: {},
+    };
+
+    await this.prepareToInstall(pluginId, installation, true);
+
+    // if there are more than one plugin, it means that the plugin requires some dependencies
+    // and it is required to ask the user before installation
+    if (installation.plugins.length > 1) {
+      if (!this.client) {
+        return false;
+      }
+
+      const dependencies = installation.plugins.slice(1, installation.plugins.length);
+      const toConfirm: string[] = [];
+
+      const allPlugins = await this.getPlugins();
+
+      for (const dependency of dependencies) {
+        if (allPlugins.find(value => `${value.publisher}/${value.name}/${value.version}` === dependency)) {
+          toConfirm.push(dependency);
+        }
+      }
+
+      if (toConfirm.length) {
+        const confirmed = await this.client.askToInstallDependencies({
+          plugins: toConfirm,
+        });
+
+        if (!confirmed) {
+          return false;
+        }
+      }
+    }
+
+    for (const plugin of installation.plugins) {
+      this.toInstall.push(plugin);
+    }
+
+    return true;
+  }
+
+  /**
+   * Prepares the plugin to installing:
+   *   - analizes che-theia-plugin.yaml
+   *   - checks .vsix existence
+   *   - recursively handles dependencies
+   *
+   * All the necessary informaion will be stored inside Installation object
+   *
+   * @param pluginId plugin to install, should be in format ${publisher}/${name}/${version}
+   * @param installation storage for changes
+   * @param vsixCheck if true, each .vsix resource will be checked on existence
+   * @returns true, if plugin with its dependencies can be installed
+   *          false, if plugin contains some dependecnices, but the user rejected the installation
+   *
+   * Will throw an error with user-friendly message in case of failures.
+   */
+  async prepareToInstall(pluginId: string, installation: Installation, vsixCheck: boolean): Promise<void> {
+    // check for existence in this.installedPlugins
+    if (this.installedPlugins.find(value => value === pluginId)) {
+      // do nothing
+      return;
+    }
+
+    // check for existence in this.toBeInstalled
+    if (this.toInstall.find(value => value === pluginId)) {
+      // do nothing
+      return;
+    }
+
+    // check for existence in ${installation.plugins}
+    if (installation.plugins.find(value => value === pluginId)) {
+      // do nothing
+      return;
+    }
+
+    const yaml = await this.fetchCheTheiaPluginYaml(pluginId);
+    installation.plugins.push(pluginId);
+    installation.cache[pluginId] = yaml;
+
+    if (vsixCheck) {
+      // check existence of all .vsix files
+      if (yaml.extensions) {
+        for (const extension of yaml.extensions) {
+          if (!(await this.httpService.head(extension))) {
+            throw new Error(`Extension ${extension} does not exist.`);
+          }
+        }
+      }
+    }
+
+    // handle dependencies
+    if (yaml.dependencies && yaml.dependencies.length) {
+      for (const dependency of yaml.dependencies) {
+        const parts = dependency.split('/');
+        const dependencyId = `${parts[0]}/${parts[1]}/${parts.length === 3 ? parts[2] : 'latest'}`;
+        await this.prepareToInstall(dependencyId, installation, vsixCheck);
+      }
+    }
+  }
+
+  async removePlugin(pluginToRemove: string): Promise<void> {
+    // check for existence in this.toBeRemoved
+    if (this.toRemove.find(value => value === pluginToRemove)) {
+      return;
+    }
+
+    // do nothing if the plugin is not installed, and not marked for installation
+    if (
+      !this.installedPlugins.find(value => value === pluginToRemove) &&
+      !this.toInstall.find(value => value === pluginToRemove)
+    ) {
+      return;
+    }
+
+    const allPlugins = await this.getPlugins();
+
+    const dependentPlugins: string[] = [];
+
+    const toCheck: string[] = [];
+    toCheck.push(...this.installedPlugins);
+    toCheck.push(...this.toInstall);
+
+    for (const plugin of toCheck) {
+      if (plugin === pluginToRemove) {
+        continue;
+      }
+
+      const yaml = await this.fetchCheTheiaPluginYaml(plugin);
+      if (yaml.dependencies) {
+        for (const dependency of yaml.dependencies) {
+          const parts = dependency.split('/');
+          const version = parts.length === 3 ? parts[2] : 'latest';
+          const dependencyId = `${parts[0]}/${parts[1]}/${version}`;
+
+          if (dependencyId === pluginToRemove) {
+            dependentPlugins.push(plugin);
+          }
+        }
+      }
+    }
+
+    const autoRemove: string[] = [];
+
+    const filteredDependentPlugins: string[] = dependentPlugins.filter(dep => {
+      if (allPlugins.find(value => dep === `${value.publisher}/${value.name}/${value.version}`)) {
+        return true;
+      } else {
+        autoRemove.push(dep);
+        return false;
+      }
+    });
+
+    if (filteredDependentPlugins.length === 0) {
+      if (this.toInstall.find(value => value === pluginToRemove)) {
+        this.toInstall = this.toInstall.filter(value => value !== pluginToRemove);
+      } else {
+        this.toRemove.push(pluginToRemove);
+      }
+
+      for (const plugin of autoRemove) {
+        if (!this.toRemove.find(value => value === plugin)) {
+          this.toRemove.push(plugin);
+        }
+      }
+      return;
+    }
+
+    const plugins = filteredDependentPlugins.map((value, index) => `${index > 0 ? ' ' : ''}'${value}'`);
+
+    const error = `Cannot remove '${pluginToRemove}'. ${
+      plugins.length === 1 ? 'Plugin' : 'Plugins'
+    } ${plugins.toString()} ${plugins.length === 1 ? 'depends' : 'depend'} on this.`;
+    throw new Error(error);
+  }
+
+  async getUnpersistedChanges(): Promise<Changes | undefined> {
+    return {
+      toInstall: this.toInstall,
+      toRemove: this.toRemove,
+    };
+  }
+
+  async persist(): Promise<void> {
+    if (this.toInstall.length === 0 && this.toRemove.length === 0) {
+      return;
+    }
+
+    // get DevWorkspace template
+    const devfile = await this.devfileService.get(true);
+    const devContainer = this.findDevContainer(devfile);
+
+    const installYamls: CheTheiaPlugin.Plugin[] = [];
+    const removeYamls: CheTheiaPlugin.Plugin[] = [];
+
+    // walk through toInstall list, download all che-theia-plugin.yaml files
+    for (const plugin of this.toInstall) {
+      const yaml = await this.fetchCheTheiaPluginYaml(plugin);
+      installYamls.push(yaml);
+    }
+
+    // walk through toRemove list, download all che-theia-plugin.yaml files
+    for (const plugin of this.toRemove) {
+      const yaml = await this.fetchCheTheiaPluginYaml(plugin);
+      removeYamls.push(yaml);
+    }
+
+    await this.downloadExtensions(installYamls, devContainer.name!);
+
+    await this.cleanupExtensions(removeYamls, devContainer.name!);
+
+    let devContainerChanged = false;
+
+    // walk through toRemove list, remove extensions from the devfile
+    for (const yaml of removeYamls) {
+      if (!yaml.sidecar) {
+        continue;
+      }
+
+      if (await this.removePluginFromDevContainer(yaml, devContainer)) {
+        devContainerChanged = true;
+      }
+    }
+
+    // walk through toInstall list, add extensions to the devfile
+    for (const yaml of installYamls) {
+      if (!yaml.sidecar) {
+        continue;
+      }
+
+      if (await this.addPluginToDevContainer(yaml, devContainer)) {
+        devContainerChanged = true;
+      }
+    }
+
+    // update and persist list of installed plugins ( /plugins/plugins.json )
+    for (const plugin of this.toRemove) {
+      this.installedPlugins = this.installedPlugins.filter(value => value !== plugin);
+    }
+
+    for (const plugin of this.toInstall) {
+      this.installedPlugins.push(plugin);
+    }
+
+    this.toRemove = [];
+    this.toInstall = [];
+
+    await this.persistInstalledPLuginsList();
+
+    if (devContainerChanged) {
+      await this.devfileService.patch('/spec/template/components', devfile.components!);
+    }
+
+    await this.workspaceService.stop();
+  }
+
+  async persistInstalledPLuginsList(): Promise<void> {
+    const pluginList: PluginList = { plugins: [] };
+    for (const plugin of this.installedPlugins) {
+      const parts = plugin.split('/');
+      pluginList.plugins.push(`${parts[0]}.${parts[1]}`);
+    }
+    await this.writeChePluginsJSON(pluginList);
+  }
+
+  async removePluginFromDevContainer(plugin: CheTheiaPlugin.Plugin, devContainer: DevfileComponent): Promise<boolean> {
+    if (!devContainer.attributes) {
+      return false;
+    }
+
+    let extensionsAttribute: string[] = devContainer.attributes['che-theia.eclipse.org/vscode-extensions'];
+    if (!extensionsAttribute) {
+      return false;
+    }
+
+    let changes = false;
+    if (plugin.extensions) {
+      for (const extension of plugin.extensions) {
+        extensionsAttribute = extensionsAttribute.filter(value => value !== extension);
+      }
+
+      devContainer.attributes['che-theia.eclipse.org/vscode-extensions'] = extensionsAttribute;
+      changes = true;
+    }
+
+    return changes;
+  }
+
+  async addPluginToDevContainer(plugin: CheTheiaPlugin.Plugin, devContainer: DevfileComponent): Promise<boolean> {
+    let changes = false;
+
+    if (!devContainer.attributes) {
+      devContainer['attributes'] = {};
+    }
+
+    if (plugin.extensions) {
+      if (!devContainer.attributes['che-theia.eclipse.org/vscode-extensions']) {
+        devContainer.attributes['che-theia.eclipse.org/vscode-extensions'] = [];
+      }
+
+      const extensionsAttribute: string[] = devContainer.attributes['che-theia.eclipse.org/vscode-extensions'];
+      for (const extension of plugin.extensions) {
+        if (!extensionsAttribute.find(value => value === extension)) {
+          extensionsAttribute.push(extension);
+
+          changes = true;
+        }
+      }
+    }
+
+    if (plugin.preferences) {
+      if (!devContainer.attributes['che-theia.eclipse.org/vscode-preferences']) {
+        devContainer.attributes['che-theia.eclipse.org/vscode-preferences'] = {};
+      }
+
+      const preferencesAttribute: { [preferenceName: string]: string } =
+        devContainer.attributes['che-theia.eclipse.org/vscode-preferences'];
+      for (const prefName of Object.keys(plugin.preferences)) {
+        const prefValue = plugin.preferences[prefName];
+        preferencesAttribute[prefName] = prefValue;
+
+        changes = true;
+      }
+    }
+
+    return changes;
+  }
+
+  async downloadExtensions(installYamls: CheTheiaPlugin.Plugin[], devContainerName: string): Promise<string[]> {
+    const downloadedExtensions: string[] = [];
+
+    for (const yaml of installYamls) {
+      // download .vsix files
+      if (yaml.extensions) {
+        for (const uri of yaml.extensions) {
+          const sidecar = yaml.sidecar ? devContainerName : undefined;
+          if (await this.isExtensionAlreadyDownloaded(uri, sidecar)) {
+            continue;
+          }
+
+          try {
+            const extensionFile = await this.downloadExtensionToPluginsDirectory(uri, sidecar);
+            downloadedExtensions.push(extensionFile);
+          } catch (error) {
+            // rollback the installation
+            for (const file of downloadedExtensions) {
+              if (await fs.pathExists(file)) {
+                await fs.remove(file);
+              }
+            }
+
+            throw error;
+          }
+        }
+      }
+    }
+
+    return downloadedExtensions;
+  }
+
+  async cleanupExtensions(removeYamls: CheTheiaPlugin.Plugin[], devContainerName: string): Promise<string[]> {
+    const removedExtensions: string[] = [];
+
+    for (const yaml of removeYamls) {
+      if (yaml.sidecar) {
+        // remove extension(s) from ${SIDECAR_PLUGINS_DIR}/{devContainerName} directory
+        if (yaml.extensions) {
+          for (const uri of yaml.extensions) {
+            const fileName = path.basename(uri);
+            const file = `${SIDECAR_PLUGINS_DIR}/${devContainerName}/${fileName}`;
+            if (await fs.pathExists(file)) {
+              await fs.remove(file);
+            }
+          }
+        }
+      } else {
+        // remove extension(s) from ${PLUGINS_DIR} directory
+        if (yaml.extensions) {
+          for (const uri of yaml.extensions) {
+            const fileName = path.basename(uri);
+            const file = `${PLUGINS_DIR}/${fileName}`;
+            if (await fs.pathExists(file)) {
+              await fs.remove(file);
+            }
+          }
+        }
+      }
+    }
+
+    return removedExtensions;
+  }
+
+  async isExtensionAlreadyDownloaded(url: string, sidecar?: string): Promise<boolean> {
+    const target = sidecar
+      ? `${SIDECAR_PLUGINS_DIR}/${sidecar}/${path.basename(url)}`
+      : `${PLUGINS_DIR}/${path.basename(url)}`;
+    return fs.pathExists(target);
+  }
+
+  async downloadExtensionToPluginsDirectory(url: string, sidecar?: string): Promise<string> {
+    let target;
+
+    if (sidecar) {
+      const directoryName = `${SIDECAR_PLUGINS_DIR}/${sidecar}`;
+      await fs.ensureDir(directoryName);
+      target = `${SIDECAR_PLUGINS_DIR}/${sidecar}/${path.basename(url)}`;
+    } else {
+      target = `${PLUGINS_DIR}/${path.basename(url)}`;
+    }
+
+    const response = await this.httpService.get(url, 'arraybuffer');
+    if (response) {
+      await fs.writeFile(target, response, { encoding: 'binary' });
+      return target;
+    }
+
+    throw new Error(`Failure to download ${url}`);
+  }
+
+  findDevContainer(devfile: Devfile): DevfileComponent {
+    // need to find definition
+    const devContainerAttribute = 'che-theia.eclipse.org/dev-container';
+
+    // first search if we have an optional annotated container
+    const annotatedContainers = devfile.components?.filter(
+      component =>
+        component.attributes &&
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (component.attributes as any)[devContainerAttribute] === true
+    );
+    if (annotatedContainers) {
+      if (annotatedContainers.length === 1) {
+        return annotatedContainers[0];
+      } else if (annotatedContainers.length > 1) {
+        throw new Error(`Only one container can be annotated with ${devContainerAttribute}: true`);
+      }
+    }
+
+    // search in main devWorkspace (exclude theia as component name)
+    const devComponents = devfile.components
+      ?.filter(component => component.container && component.name !== 'theia-ide')
+      .filter(
+        // we should ignore component that do not mount the sources
+        component => component.container && component.container.mountSources !== false
+      )
+      .filter(
+        component =>
+          !(component.attributes && component.attributes['app.kubernetes.io/part-of'] === 'che-theia.eclipse.org')
+      );
+
+    // only one, fine, else error
+    if (!devComponents || devComponents.length === 0) {
+      throw new Error('Not able to find any dev container component in DevWorkspace');
+    } else if (devComponents.length === 1) {
+      return devComponents[0];
+    } else {
+      console.warn(
+        `More than one dev container component has been potentially found, taking the first one of ${devComponents.map(
+          component => component.name
+        )}`
+      );
+      return devComponents[0];
+    }
+  }
+
+  async updatePlugin(oldPluginKey: string, newPluginKey: string): Promise<void> {
+    console.log('Method [ updatePlugin ] not implemented.');
+    throw new Error('Method not implemented.');
+  }
+
+  async deferredInstallation(): Promise<boolean> {
+    return true;
+  }
+}

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/devworkspace-template.json
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/devworkspace-template.json
@@ -1,0 +1,143 @@
+{
+    "commands": [
+        {
+            "exec": {
+                "commandLine": "java -jar -Dspring-boot.run.profiles=mysql \\\n-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 \\\ntarget/*.jar\n",
+                "component": "tools",
+                "group": {
+                    "isDefault": true,
+                    "kind": "run"
+                },
+                "workingDir": "${PROJECTS_ROOT}/java-spring-petclinic"
+            },
+            "id": "run-with-mysql"
+        },
+        {
+            "exec": {
+                "commandLine": "java -jar -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 target/*.jar",
+                "component": "tools",
+                "group": {
+                    "isDefault": true,
+                    "kind": "run"
+                },
+                "workingDir": "${PROJECTS_ROOT}/java-spring-petclinic"
+            },
+            "id": "run-debug"
+        }
+    ],
+    "components": [
+        {
+            "container": {
+                "args": [
+                    "sh",
+                    "-c",
+                    "${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}"
+                ],
+                "endpoints": [
+                    {
+                        "exposure": "none",
+                        "name": "debug",
+                        "protocol": "tcp",
+                        "targetPort": 5005
+                    },
+                    {
+                        "exposure": "public",
+                        "name": "8080-tcp",
+                        "protocol": "http",
+                        "targetPort": 8080
+                    }
+                ],
+                "env": [
+                    {
+                        "name": "PLUGIN_REMOTE_ENDPOINT_EXECUTABLE",
+                        "value": "/remote-endpoint/plugin-remote-endpoint"
+                    },
+                    {
+                        "name": "THEIA_PLUGINS",
+                        "value": "local-dir:///plugins/sidecars/tools"
+                    }
+                ],
+                "image": "quay.io/devfile/universal-developer-image:ubi8-d433ed6",
+                "memoryLimit": "3Gi",
+                "sourceMapping": "/projects",
+                "volumeMounts": [
+                    {
+                        "name": "m2",
+                        "path": "/home/user/.m2"
+                    },
+                    {
+                        "name": "remote-endpoint",
+                        "path": "/remote-endpoint"
+                    },
+                    {
+                        "name": "plugins",
+                        "path": "/plugins"
+                    }
+                ]
+            },
+            "name": "tools"
+        },
+        {
+            "name": "m2",
+            "volume": {
+                "size": "1G"
+            }
+        },
+        {
+            "container": {
+                "endpoints": [
+                    {
+                        "exposure": "internal",
+                        "name": "db",
+                        "protocol": "tcp",
+                        "targetPort": 3306
+                    }
+                ],
+                "env": [
+                    {
+                        "name": "MYSQL_USER",
+                        "value": "petclinic"
+                    },
+                    {
+                        "name": "MYSQL_PASSWORD",
+                        "value": "petclinic"
+                    },
+                    {
+                        "name": "MYSQL_DATABASE",
+                        "value": "petclinic"
+                    },
+                    {
+                        "name": "PS1",
+                        "value": "$(echo ${0})\\\\$"
+                    }
+                ],
+                "image": "quay.io/eclipse/che--centos--mysql-57-centos7:latest-e08ee4d43b7356607685b69bde6335e27cf20c020f345b6c6c59400183882764",
+                "memoryLimit": "300Mi",
+                "sourceMapping": "/projects"
+            },
+            "name": "mysql"
+        },
+        {
+            "name": "theia-ide-workspace63092f2f66734133",
+            "plugin": {
+                "kubernetes": {
+                    "name": "theia-ide-workspace63092f2f66734133",
+                    "namespace": "admin-che"
+                }
+            }
+        }
+    ],
+    "projects": [
+        {
+            "git": {
+                "checkoutFrom": {
+                    "revision": "devfilev2"
+                },
+                "remotes": {
+                    "origin": "https://github.com/vitaliy-guliy/java-spring-petclinic.git"
+                }
+            },
+            "name": "java-spring-petclinic"
+        }
+    ]
+}

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/node/k8s-plugin-service-impl.spec.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/node/k8s-plugin-service-impl.spec.ts
@@ -1,0 +1,1722 @@
+/**********************************************************************
+ * Copyright (c) 2021-2022 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import 'reflect-metadata';
+
+import * as fs from 'fs-extra';
+import * as p from 'path';
+
+import { CHE_PLUGINS_JSON, K8sPluginServiceImpl } from '../../src/node/k8s-plugin-service-impl';
+import { ChePluginMetadata, PluginDependencies } from '@eclipse-che/theia-remote-api/lib/common/plugin-service';
+import { Devfile, DevfileService } from '@eclipse-che/theia-remote-api/lib/common/devfile-service';
+
+import { Container } from 'inversify';
+import { HttpService } from '@eclipse-che/theia-remote-api/lib/common/http-service';
+import { K8sDevWorkspaceEnvVariables } from '../../src/node/k8s-devworkspace-env-variables';
+import { K8sDevfileServiceImpl } from '../../src/node/k8s-devfile-service-impl';
+import { K8sWorkspaceServiceImpl } from '../../src/node/k8s-workspace-service-impl';
+import { WorkspaceService } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
+
+const EXTENSIONS_JSON_WITH_JAVA_EXTENSION: string = `{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": [
+    "redhat.java"
+  ]
+}
+`;
+
+const PLUGINS_JSON_WITH_THREE_JAVA_PLUGINS = `{
+  "plugins": [
+    "redhat.java",
+    "vscjava.vscode-java-debug",
+    "vscjava.vscode-java-test"
+  ]
+}
+`;
+
+const EMPTY_PLUGINS_JSON = `{
+  "plugins": []
+}
+`;
+
+export const PLUGINS_JSON_WITH_MERMAID_MARKDOWN_SYNTAX_HIGHLIGHTING_PLUGIN = `{
+  "plugins": [
+    "goddard.mermaid-markdown-syntax-highlighting"
+  ]
+}
+`;
+
+// goddard/mermaid-markdown-syntax-highlighting/latest
+export const MERMAID_MARKDOWN_SYNTAX_HIGHLIGHTING_CHE_THEIA_PLUGIN_YAML = `
+schemaVersion: 1.0.0
+metadata:
+  id: goddard/mermaid-markdown-syntax-highlighting
+  publisher: goddard
+  name: mermaid-markdown-syntax-highlighting
+  version: latest
+  displayName: Mermaid Markdown Syntax Highlighting
+  description: Markdown syntax support for the Mermaid charting language
+  repository: 'https://github.com/bpruitt-goddard/vscode-mermaid-syntax-highlight.git'
+  categories:
+    - Other
+  icon: /images/default.png
+dependencies: []
+extensions:
+  - 'https://somehost/vscode-mermaid-syntax-highlight.vsix'
+`;
+
+// bierner/markdown-mermaid/latest
+export const MARKDOWN_MERMAID_CHE_THEIA_PLUGIN_YAML = `
+schemaVersion: 1.0.0
+metadata:
+  id: bierner/markdown-mermaid
+  publisher: bierner
+  name: markdown-mermaid
+  version: latest
+  displayName: Markdown Preview Mermaid Support
+  description: Adds Mermaid diagram and flowchart support to VS Code's builtin markdown preview
+  repository: 'https://github.com/mjbvz/vscode-markdown-mermaid.git'
+  categories:
+    - Other
+  icon: /images/bierner-markdown-mermaid-icon.png
+dependencies:
+  - goddard/mermaid-markdown-syntax-highlighting
+extensions:
+  - 'https://somehost/vscode-markdown-mermaid-1.9.2.vsix'
+`;
+
+// ex/markdown-mermaid-templates/latest
+export const MARKDOWN_MERMAID_TEMPLATES_CHE_THEIA_PLUGIN_YAML = `
+schemaVersion: 1.0.0
+metadata:
+  id: ex/markdown-mermaid-templates
+  publisher: ex
+  name: markdown-mermaid-templates
+  version: latest
+  displayName: Templates for Markdown Preview Mermaid Support
+  description: Provides Templates for Mermaid plugin
+  repository: 'https://ex/vscode-markdown-templates.git'
+  categories:
+    - Other
+  icon: /images/ex-markdown-mermaid-templates-icon.png
+dependencies:
+  - bierner/markdown-mermaid
+  - goddard/mermaid-markdown-syntax-highlighting
+extensions:
+  - 'https://somehost/vscode-markdown-mermaid-templates-0.6.1.vsix'
+`;
+
+// redhat/java/latest
+export const JAVA_CHE_THEIA_PLUGIN_YAML = `
+schemaVersion: 1.0.0
+metadata:
+  id: redhat/java
+  publisher: redhat
+  name: java
+  version: latest
+  displayName: Language Support for Java(TM) by Red Hat
+  description: Java Linting, Intellisense, formatting, refactoring, Maven/Gradle support and more...
+  repository: https://github.com/redhat-developer/vscode-java
+  categories:
+    - Programming Languages
+    - Linters
+    - Formatters
+    - Snippets
+  icon: /images/redhat-java-icon.png
+sidecar:
+  name: vscode-java
+  memoryLimit: 1500Mi
+  memoryRequest: 20Mi
+  cpuLimit: 800m
+  cpuRequest: 30m
+  volumeMounts:
+    - name: m2
+      path: /home/theia/.m2
+  image: quay.io/eclipse/che-plugin-sidecar:java-23e57d6
+preferences:
+  java.server.launchMode: Standard
+dependencies:
+  - vscjava/vscode-java-debug
+  - vscjava/vscode-java-test
+extensions:
+  - https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.82.0-369.vsix
+`;
+
+// vscjava/vscode-java-test/latest
+export const VSCODE_JAVA_TEST_CHE_THEIA_PLUGIN = `
+schemaVersion: 1.0.0
+metadata:
+  id: vscjava/vscode-java-test
+  publisher: vscjava
+  name: vscode-java-test
+  version: latest
+  displayName: Java Test Runner
+  description: Run and debug JUnit or TestNG test cases
+  repository: https://github.com/Microsoft/vscode-java-test
+  categories:
+    - Other
+  icon: /images/vscjava-vscode-java-test-icon.png
+sidecar:
+  name: vscode-java
+  memoryLimit: 1500Mi
+  memoryRequest: 20Mi
+  cpuLimit: 800m
+  cpuRequest: 30m
+  image: quay.io/eclipse/che-plugin-sidecar:java-23e57d6
+dependencies:
+  - redhat/java
+  - vscjava/vscode-java-debug
+extensions:
+  - https://open-vsx.org/api/vscjava/vscode-java-test/0.28.1/file/vscjava.vscode-java-test-0.28.1.vsix
+`;
+
+// vscjava/vscode-java-debug/latest
+export const VSCODE_JAVA_DEBUG_CHE_THEIA_PLUGIN = `
+schemaVersion: 1.0.0
+metadata:
+  id: vscjava/vscode-java-debug
+  publisher: vscjava
+  name: vscode-java-debug
+  version: latest
+  displayName: Debugger for Java
+  description: A lightweight Java debugger for Visual Studio Code
+  repository: https://github.com/Microsoft/vscode-java-debug.git
+  categories:
+    - Debuggers
+    - Programming Languages
+    - Other
+  icon: /images/vscjava-vscode-java-debug-icon.png
+sidecar:
+  name: vscode-java
+  memoryLimit: 1500Mi
+  memoryRequest: 20Mi
+  cpuLimit: 800m
+  cpuRequest: 30m
+  image: quay.io/eclipse/che-plugin-sidecar:java-23e57d6
+dependencies: []
+extensions:
+  - https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix
+`;
+
+class TestDevfileService extends K8sDevfileServiceImpl {}
+
+class TestWorkspaceService extends K8sWorkspaceServiceImpl {}
+
+describe('Test K8sPluginServiceImpl', () => {
+  let container: Container;
+
+  const mockGet = jest.fn();
+  const mockHead = jest.fn();
+
+  const httpServiceMock: HttpService = {
+    get: mockGet,
+    post: jest.fn(),
+    head: mockHead,
+  };
+
+  let devfileService: TestDevfileService;
+  let workspaceService: TestWorkspaceService;
+
+  const ORIGINAL_ENV = { ...process.env };
+
+  let devWorkspaceTemplateContent: string;
+
+  beforeAll(async () => {
+    const devWorkspaceTemplatePath = p.resolve(__dirname, '..', '_data', 'devworkspace-template.json');
+    devWorkspaceTemplateContent = await fs.readFile(devWorkspaceTemplatePath, 'utf-8');
+  });
+
+  beforeEach(async () => {
+    jest.resetModules();
+
+    process.env = { ...ORIGINAL_ENV };
+    process.env.PROJECTS_ROOT = '/projects';
+
+    // stubs
+    process.env.CHE_DASHBOARD_URL = '.';
+    process.env.DEVWORKSPACE_FLATTENED_DEVFILE = '.';
+    process.env.DEVWORKSPACE_NAME = '.';
+    process.env.DEVWORKSPACE_NAMESPACE = '.';
+    process.env.DEVWORKSPACE_ID = '.';
+    process.env.CHE_PLUGIN_REGISTRY_URL = '.';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = '.';
+
+    jest.resetAllMocks();
+    jest.resetModules();
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => path === '/projects',
+      readdir: async (path: string): Promise<string[]> => [],
+      stat: async (path: string): Promise<fs.Stats> => Promise.reject(),
+      readFile: async (path: string): Promise<string> => Promise.reject(),
+      writeFile: async (path: string, data: string): Promise<void> => {},
+    });
+
+    container = new Container();
+    container.bind(HttpService).toConstantValue(httpServiceMock);
+
+    devfileService = new TestDevfileService();
+    workspaceService = new TestWorkspaceService();
+
+    container.bind(DevfileService).toConstantValue(devfileService);
+    container.bind(K8sDevfileServiceImpl).toConstantValue(devfileService);
+
+    container.bind(WorkspaceService).toConstantValue(workspaceService);
+    container.bind(K8sWorkspaceServiceImpl).toConstantValue(workspaceService);
+
+    container.bind(K8sDevWorkspaceEnvVariables).toSelf().inSingletonScope();
+    container.bind(K8sPluginServiceImpl).toSelf().inSingletonScope();
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  test('initialize :: should create /plugins/che-plugins.json with empty plugin list', async () => {
+    let testContent = '';
+
+    const writeFileMock = jest.fn();
+    writeFileMock.mockImplementation(async (path: string, data: string): Promise<void> => {
+      if (path === CHE_PLUGINS_JSON) {
+        testContent = data;
+        return;
+      }
+
+      return Promise.reject();
+    });
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => path === '/projects',
+
+      readdir: async (path: string): Promise<string[]> => {
+        if (path === '/projects') {
+          return ['project1'];
+        }
+
+        return Promise.reject();
+      },
+
+      writeFile: writeFileMock,
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(testContent)).toEqual(JSON.parse(EMPTY_PLUGINS_JSON));
+  });
+
+  /**
+   * - extensions.json contains only redhat.java extension
+   * - redhat/java/latest che plugin depends on vscjava/vscode-java-debug and vscjava/vscode-java-test
+   * - after initializing, file /plugins/che-plugins.json should contain all there plugins
+   */
+  test('initialize :: should handle all the plugin dependencies', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    let testContent = '';
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> =>
+        path === '/projects' || path === '/projects/project1/.vscode/extensions.json',
+
+      readdir: async (path: string): Promise<string[]> => {
+        if (path === '/projects') {
+          return ['project1'];
+        }
+
+        return Promise.reject();
+      },
+
+      stat: async (path: string): Promise<fs.Stats> => {
+        if (path === '/projects/project1/.vscode/extensions.json') {
+          return {
+            isFile: () => true,
+          } as fs.Stats;
+        }
+
+        return Promise.reject();
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === '/projects/project1/.vscode/extensions.json') {
+          return EXTENSIONS_JSON_WITH_JAVA_EXTENSION;
+        }
+
+        return Promise.reject();
+      },
+
+      writeFile: async (path: string, data: string): Promise<void> => {
+        if (path === CHE_PLUGINS_JSON) {
+          testContent = data;
+          return;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    mockGet.mockImplementation(async (url: string): Promise<string | undefined> => {
+      switch (url) {
+        case 'http://internal.uri/v3/plugins/redhat/java/latest/che-theia-plugin.yaml':
+          return JAVA_CHE_THEIA_PLUGIN_YAML;
+
+        case 'http://internal.uri/v3/plugins/vscjava/vscode-java-debug/latest/che-theia-plugin.yaml':
+          return VSCODE_JAVA_DEBUG_CHE_THEIA_PLUGIN;
+
+        case 'http://internal.uri/v3/plugins/vscjava/vscode-java-test/latest/che-theia-plugin.yaml':
+          return VSCODE_JAVA_TEST_CHE_THEIA_PLUGIN;
+      }
+
+      return undefined;
+    });
+
+    mockHead.mockImplementation(
+      async (url: string): Promise<boolean> =>
+        url === 'https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.82.0-369.vsix' ||
+        url ===
+          'https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix' ||
+        url === 'https://open-vsx.org/api/vscjava/vscode-java-test/0.28.1/file/vscjava.vscode-java-test-0.28.1.vsix'
+    );
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    expect(JSON.parse(testContent)).toEqual(JSON.parse(PLUGINS_JSON_WITH_THREE_JAVA_PLUGINS));
+  });
+
+  test('initialize :: /plugins/che-plugins.json must not be overwritten if exists', async () => {
+    const writeFileMock = jest.fn();
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return EMPTY_PLUGINS_JSON;
+        }
+
+        return Promise.reject();
+      },
+
+      writeFile: writeFileMock,
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+
+    await pluginService.deferred.promise;
+
+    expect(writeFileMock).toBeCalledTimes(0);
+  });
+
+  test('get default registry', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+
+    const defaultRegistry = await pluginService.getDefaultRegistry();
+
+    expect(defaultRegistry.name).toBe('Eclipse Che plugins');
+    expect(defaultRegistry.publicURI).toBe('http://public.uri/v3');
+    expect(defaultRegistry.internalURI).toBe('http://internal.uri/v3');
+  });
+
+  test('get default registry :: failed on missing CHE_PLUGIN_REGISTRY_URL', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = undefined;
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+
+    try {
+      await pluginService.getDefaultRegistry();
+      fail();
+    } catch (err) {
+      expect(err.message).toBe('Plugin registry URL is not configured.');
+    }
+  });
+
+  test('get default registry :: failed on missing CHE_PLUGIN_REGISTRY_INTERNAL_URL', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = undefined;
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+
+    try {
+      await pluginService.getDefaultRegistry();
+      fail();
+    } catch (err) {
+      expect(err.message).toBe('Plugin registry internal URL is not configured.');
+    }
+  });
+
+  test('get installed plugins :: should return three plugins', async () => {
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return PLUGINS_JSON_WITH_THREE_JAVA_PLUGINS;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    const plugins = await pluginService.getInstalledPlugins();
+    expect(plugins).toEqual([
+      'redhat/java/latest',
+      'vscjava/vscode-java-debug/latest',
+      'vscjava/vscode-java-test/latest',
+    ]);
+  });
+
+  test('install plugin :: must skip if the plugin is already installed', async () => {
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return PLUGINS_JSON_WITH_MERMAID_MARKDOWN_SYNTAX_HIGHLIGHTING_PLUGIN;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    const prepareToInstallMock = jest.spyOn(pluginService, 'prepareToInstall');
+    const fetchCheTheiaPluginYamlMock = jest.spyOn(pluginService, 'fetchCheTheiaPluginYaml');
+
+    await pluginService.installPlugin('goddard/mermaid-markdown-syntax-highlighting/latest');
+
+    expect(pluginService.installedPlugins).toEqual(['goddard/mermaid-markdown-syntax-highlighting/latest']);
+    expect(pluginService.toInstall).toEqual([]);
+    expect(pluginService.toRemove).toEqual([]);
+
+    expect(prepareToInstallMock).toHaveBeenCalledTimes(1);
+    expect(fetchCheTheiaPluginYamlMock).toHaveBeenCalledTimes(0);
+  });
+
+  test('install plugin :: must remove from toRemove list if the plugin has been marked for removal', async () => {
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return PLUGINS_JSON_WITH_MERMAID_MARKDOWN_SYNTAX_HIGHLIGHTING_PLUGIN;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    pluginService.toRemove.push('goddard/mermaid-markdown-syntax-highlighting/latest');
+
+    await pluginService.installPlugin('goddard/mermaid-markdown-syntax-highlighting/latest');
+
+    const prepareToInstallMock = jest.spyOn(pluginService, 'prepareToInstall');
+    const fetchCheTheiaPluginYamlMock = jest.spyOn(pluginService, 'fetchCheTheiaPluginYaml');
+
+    expect(pluginService.installedPlugins).toEqual(['goddard/mermaid-markdown-syntax-highlighting/latest']);
+    expect(pluginService.toInstall).toEqual([]);
+    expect(pluginService.toRemove).toEqual([]);
+
+    expect(prepareToInstallMock).toHaveBeenCalledTimes(0);
+    expect(fetchCheTheiaPluginYamlMock).toHaveBeenCalledTimes(0);
+  });
+
+  test('install plugin :: should add plugin toInstall list', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return EMPTY_PLUGINS_JSON;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    mockGet.mockImplementation(async (url: string): Promise<string | undefined> => {
+      if (
+        url ===
+        'http://internal.uri/v3/plugins/goddard/mermaid-markdown-syntax-highlighting/latest/che-theia-plugin.yaml'
+      ) {
+        return MERMAID_MARKDOWN_SYNTAX_HIGHLIGHTING_CHE_THEIA_PLUGIN_YAML;
+      }
+
+      return undefined;
+    });
+
+    mockHead.mockImplementation(async (url: string): Promise<boolean> => {
+      if (url === 'https://somehost/vscode-mermaid-syntax-highlight.vsix') {
+        return true;
+      }
+
+      return false;
+    });
+
+    const result = await pluginService.installPlugin('goddard/mermaid-markdown-syntax-highlighting/latest');
+    expect(result).toBe(true);
+
+    expect(pluginService.toInstall).toEqual(['goddard/mermaid-markdown-syntax-highlighting/latest']);
+  });
+
+  test('install plugin :: should handle plugin dependencies and add both plugins toInstall list', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return EMPTY_PLUGINS_JSON;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    mockGet.mockImplementation(async (url: string): Promise<string | undefined> => {
+      if (url === 'http://internal.uri/v3/plugins/bierner/markdown-mermaid/latest/che-theia-plugin.yaml') {
+        return MARKDOWN_MERMAID_CHE_THEIA_PLUGIN_YAML;
+      }
+
+      if (
+        url ===
+        'http://internal.uri/v3/plugins/goddard/mermaid-markdown-syntax-highlighting/latest/che-theia-plugin.yaml'
+      ) {
+        return MERMAID_MARKDOWN_SYNTAX_HIGHLIGHTING_CHE_THEIA_PLUGIN_YAML;
+      }
+
+      return undefined;
+    });
+
+    mockHead.mockImplementation(async (url: string): Promise<boolean> => {
+      if (
+        url === 'https://somehost/vscode-markdown-mermaid-1.9.2.vsix' ||
+        url === 'https://somehost/vscode-mermaid-syntax-highlight.vsix'
+      ) {
+        return true;
+      }
+
+      return false;
+    });
+
+    let askedDependencies;
+
+    const askToInstallDependenciesMock = jest.fn();
+    askToInstallDependenciesMock.mockImplementation(async (dependencies: PluginDependencies): Promise<boolean> => {
+      askedDependencies = dependencies.plugins;
+      return true;
+    });
+
+    pluginService.setClient({
+      notifyPluginCacheSizeChanged: jest.fn(),
+      notifyPluginCached: jest.fn(),
+      notifyCachingComplete: jest.fn(),
+      invalidRegistryFound: jest.fn(),
+      invalidPluginFound: jest.fn(),
+      askToInstallDependencies: askToInstallDependenciesMock,
+    });
+
+    const getPluginsMock = jest.spyOn(pluginService, 'getPlugins');
+    getPluginsMock.mockImplementation(
+      async (): Promise<ChePluginMetadata[]> => [
+        {
+          publisher: 'goddard',
+          name: 'mermaid-markdown-syntax-highlighting',
+          version: 'latest',
+        } as ChePluginMetadata,
+      ]
+    );
+
+    const result = await pluginService.installPlugin('bierner/markdown-mermaid/latest');
+    expect(result).toBe(true);
+
+    expect(askedDependencies).toEqual(['goddard/mermaid-markdown-syntax-highlighting/latest']);
+
+    expect(pluginService.toInstall).toEqual([
+      'bierner/markdown-mermaid/latest',
+      'goddard/mermaid-markdown-syntax-highlighting/latest',
+    ]);
+  });
+
+  test('install plugin :: should cancel the installation if the user rejected installing the dependencies', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return EMPTY_PLUGINS_JSON;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    mockGet.mockImplementation(async (url: string): Promise<string | undefined> => {
+      if (url === 'http://internal.uri/v3/plugins/bierner/markdown-mermaid/latest/che-theia-plugin.yaml') {
+        return MARKDOWN_MERMAID_CHE_THEIA_PLUGIN_YAML;
+      }
+
+      if (
+        url ===
+        'http://internal.uri/v3/plugins/goddard/mermaid-markdown-syntax-highlighting/latest/che-theia-plugin.yaml'
+      ) {
+        return MERMAID_MARKDOWN_SYNTAX_HIGHLIGHTING_CHE_THEIA_PLUGIN_YAML;
+      }
+
+      return undefined;
+    });
+
+    mockHead.mockImplementation(
+      async (url: string): Promise<boolean> =>
+        url === 'https://somehost/vscode-markdown-mermaid-1.9.2.vsix' ||
+        url === 'https://somehost/vscode-mermaid-syntax-highlight.vsix'
+    );
+
+    let askedDependencies;
+
+    const askToInstallDependenciesMock = jest.fn();
+    askToInstallDependenciesMock.mockImplementation(async (dependencies: PluginDependencies): Promise<boolean> => {
+      askedDependencies = dependencies.plugins;
+      return false;
+    });
+
+    pluginService.setClient({
+      notifyPluginCacheSizeChanged: jest.fn(),
+      notifyPluginCached: jest.fn(),
+      notifyCachingComplete: jest.fn(),
+      invalidRegistryFound: jest.fn(),
+      invalidPluginFound: jest.fn(),
+      askToInstallDependencies: askToInstallDependenciesMock,
+    });
+
+    const getPluginsMock = jest.spyOn(pluginService, 'getPlugins');
+    getPluginsMock.mockImplementation(
+      async (): Promise<ChePluginMetadata[]> => [
+        {
+          publisher: 'goddard',
+          name: 'mermaid-markdown-syntax-highlighting',
+          version: 'latest',
+        } as ChePluginMetadata,
+      ]
+    );
+
+    const result = await pluginService.installPlugin('bierner/markdown-mermaid/latest');
+    expect(result).toBe(false);
+
+    expect(askedDependencies).toEqual(['goddard/mermaid-markdown-syntax-highlighting/latest']);
+
+    expect(pluginService.toInstall).toEqual([]);
+  });
+
+  test('install plugin :: should NOT ask the user if the required dependency is already installed', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return EMPTY_PLUGINS_JSON;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    // add the required dependency to list of installed plugins
+    pluginService.installedPlugins.push('goddard/mermaid-markdown-syntax-highlighting/latest');
+
+    mockGet.mockImplementation(async (url: string): Promise<string | undefined> => {
+      if (url === 'http://internal.uri/v3/plugins/bierner/markdown-mermaid/latest/che-theia-plugin.yaml') {
+        return MARKDOWN_MERMAID_CHE_THEIA_PLUGIN_YAML;
+      }
+
+      return undefined;
+    });
+
+    mockHead.mockImplementation(
+      async (url: string): Promise<boolean> =>
+        url === 'https://somehost/vscode-markdown-mermaid-1.9.2.vsix' ||
+        url === 'https://somehost/vscode-mermaid-syntax-highlight.vsix'
+    );
+
+    const askToInstallDependenciesMock = jest.fn();
+
+    pluginService.setClient({
+      notifyPluginCacheSizeChanged: jest.fn(),
+      notifyPluginCached: jest.fn(),
+      notifyCachingComplete: jest.fn(),
+      invalidRegistryFound: jest.fn(),
+      invalidPluginFound: jest.fn(),
+      askToInstallDependencies: askToInstallDependenciesMock,
+    });
+
+    const getPluginsMock = jest.spyOn(pluginService, 'getPlugins');
+    getPluginsMock.mockImplementation(
+      async (): Promise<ChePluginMetadata[]> => [
+        {
+          publisher: 'goddard',
+          name: 'mermaid-markdown-syntax-highlighting',
+          version: 'latest',
+        } as ChePluginMetadata,
+        {
+          publisher: 'bierner',
+          name: 'markdown-mermaid',
+          version: 'latest',
+        } as ChePluginMetadata,
+      ]
+    );
+
+    // install plugin
+    const result = await pluginService.installPlugin('bierner/markdown-mermaid/latest');
+    expect(result).toBe(true);
+
+    expect(askToInstallDependenciesMock).toHaveBeenCalledTimes(0);
+
+    expect(pluginService.toInstall).toEqual(['bierner/markdown-mermaid/latest']);
+
+    // list of installed plugins should not be changed
+    expect(pluginService.installedPlugins).toEqual(['goddard/mermaid-markdown-syntax-highlighting/latest']);
+  });
+
+  test('install plugin :: should handle chain of dependencies', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return EMPTY_PLUGINS_JSON;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    mockGet.mockImplementation(async (url: string): Promise<string | undefined> => {
+      switch (url) {
+        case 'http://internal.uri/v3/plugins/ex/markdown-mermaid-templates/latest/che-theia-plugin.yaml':
+          return MARKDOWN_MERMAID_TEMPLATES_CHE_THEIA_PLUGIN_YAML;
+
+        case 'http://internal.uri/v3/plugins/bierner/markdown-mermaid/latest/che-theia-plugin.yaml':
+          return MARKDOWN_MERMAID_CHE_THEIA_PLUGIN_YAML;
+
+        case 'http://internal.uri/v3/plugins/goddard/mermaid-markdown-syntax-highlighting/latest/che-theia-plugin.yaml':
+          return MERMAID_MARKDOWN_SYNTAX_HIGHLIGHTING_CHE_THEIA_PLUGIN_YAML;
+      }
+
+      return undefined;
+    });
+
+    mockHead.mockImplementation(
+      async (url: string): Promise<boolean> =>
+        url === 'https://somehost/vscode-markdown-mermaid-1.9.2.vsix' ||
+        url === 'https://somehost/vscode-mermaid-syntax-highlight.vsix' ||
+        url === 'https://somehost/vscode-markdown-mermaid-templates-0.6.1.vsix'
+    );
+
+    let askedDependencies;
+
+    const askToInstallDependenciesMock = jest.fn();
+    askToInstallDependenciesMock.mockImplementation(async (dependencies: PluginDependencies): Promise<boolean> => {
+      askedDependencies = dependencies.plugins;
+      return true;
+    });
+
+    pluginService.setClient({
+      notifyPluginCacheSizeChanged: jest.fn(),
+      notifyPluginCached: jest.fn(),
+      notifyCachingComplete: jest.fn(),
+      invalidRegistryFound: jest.fn(),
+      invalidPluginFound: jest.fn(),
+      askToInstallDependencies: askToInstallDependenciesMock,
+    });
+
+    const getPluginsMock = jest.spyOn(pluginService, 'getPlugins');
+    getPluginsMock.mockImplementation(
+      async (): Promise<ChePluginMetadata[]> => [
+        {
+          publisher: 'goddard',
+          name: 'mermaid-markdown-syntax-highlighting',
+          version: 'latest',
+        } as ChePluginMetadata,
+        {
+          publisher: 'bierner',
+          name: 'markdown-mermaid',
+          version: 'latest',
+        } as ChePluginMetadata,
+      ]
+    );
+
+    // install plugin
+    const result = await pluginService.installPlugin('ex/markdown-mermaid-templates/latest');
+    expect(result).toBe(true);
+
+    expect(askedDependencies).toEqual([
+      'bierner/markdown-mermaid/latest',
+      'goddard/mermaid-markdown-syntax-highlighting/latest',
+    ]);
+
+    expect(pluginService.toInstall).toEqual([
+      'ex/markdown-mermaid-templates/latest',
+      'bierner/markdown-mermaid/latest',
+      'goddard/mermaid-markdown-syntax-highlighting/latest',
+    ]);
+  });
+
+  test('install plugin :: should ask to install only ONE dependent plugin (another one is not listed in plugin registry index)', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return EMPTY_PLUGINS_JSON;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    mockGet.mockImplementation(async (url: string): Promise<string | undefined> => {
+      switch (url) {
+        case 'http://internal.uri/v3/plugins/ex/markdown-mermaid-templates/latest/che-theia-plugin.yaml':
+          return MARKDOWN_MERMAID_TEMPLATES_CHE_THEIA_PLUGIN_YAML;
+
+        case 'http://internal.uri/v3/plugins/bierner/markdown-mermaid/latest/che-theia-plugin.yaml':
+          return MARKDOWN_MERMAID_CHE_THEIA_PLUGIN_YAML;
+
+        case 'http://internal.uri/v3/plugins/goddard/mermaid-markdown-syntax-highlighting/latest/che-theia-plugin.yaml':
+          return MERMAID_MARKDOWN_SYNTAX_HIGHLIGHTING_CHE_THEIA_PLUGIN_YAML;
+      }
+
+      return undefined;
+    });
+
+    mockHead.mockImplementation(
+      async (url: string): Promise<boolean> =>
+        url === 'https://somehost/vscode-markdown-mermaid-1.9.2.vsix' ||
+        url === 'https://somehost/vscode-mermaid-syntax-highlight.vsix' ||
+        url === 'https://somehost/vscode-markdown-mermaid-templates-0.6.1.vsix'
+    );
+
+    let askedDependencies;
+
+    const askToInstallDependenciesMock = jest.fn();
+    askToInstallDependenciesMock.mockImplementation(async (dependencies: PluginDependencies): Promise<boolean> => {
+      askedDependencies = dependencies.plugins;
+      return true;
+    });
+
+    pluginService.setClient({
+      notifyPluginCacheSizeChanged: jest.fn(),
+      notifyPluginCached: jest.fn(),
+      notifyCachingComplete: jest.fn(),
+      invalidRegistryFound: jest.fn(),
+      invalidPluginFound: jest.fn(),
+      askToInstallDependencies: askToInstallDependenciesMock,
+    });
+
+    const getPluginsMock = jest.spyOn(pluginService, 'getPlugins');
+    getPluginsMock.mockImplementation(
+      async (): Promise<ChePluginMetadata[]> => [
+        {
+          publisher: 'bierner',
+          name: 'markdown-mermaid',
+          version: 'latest',
+        } as ChePluginMetadata,
+      ]
+    );
+
+    // install plugin
+    const result = await pluginService.installPlugin('ex/markdown-mermaid-templates/latest');
+    expect(result).toBe(true);
+
+    expect(askedDependencies).toEqual(['bierner/markdown-mermaid/latest']);
+    expect(askToInstallDependenciesMock).toHaveBeenCalledTimes(1);
+
+    expect(pluginService.toInstall).toEqual([
+      'ex/markdown-mermaid-templates/latest',
+      'bierner/markdown-mermaid/latest',
+      'goddard/mermaid-markdown-syntax-highlighting/latest',
+    ]);
+  });
+
+  test('remove plugin :: must do nothing if the plugin is missing', async () => {
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return EMPTY_PLUGINS_JSON;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    await pluginService.removePlugin('goddard/mermaid-markdown-syntax-highlighting/latest');
+
+    expect(pluginService.installedPlugins).toEqual([]);
+    expect(pluginService.toInstall).toEqual([]);
+    expect(pluginService.toRemove).toEqual([]);
+  });
+
+  test('remove plugin :: must do nothing if the plugin is already marked for removal', async () => {
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return PLUGINS_JSON_WITH_MERMAID_MARKDOWN_SYNTAX_HIGHLIGHTING_PLUGIN;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    pluginService.toRemove.push('goddard/mermaid-markdown-syntax-highlighting/latest');
+
+    await pluginService.removePlugin('goddard/mermaid-markdown-syntax-highlighting/latest');
+
+    expect(pluginService.installedPlugins).toEqual(['goddard/mermaid-markdown-syntax-highlighting/latest']);
+    expect(pluginService.toInstall).toEqual([]);
+    expect(pluginService.toRemove).toEqual(['goddard/mermaid-markdown-syntax-highlighting/latest']);
+  });
+
+  test('remove plugin :: must cancel the installation if the plugin is going to be intalled', async () => {
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return EMPTY_PLUGINS_JSON;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    pluginService.toInstall.push('goddard/mermaid-markdown-syntax-highlighting/latest');
+
+    await pluginService.removePlugin('goddard/mermaid-markdown-syntax-highlighting/latest');
+
+    expect(pluginService.installedPlugins).toEqual([]);
+    expect(pluginService.toInstall).toEqual([]);
+    expect(pluginService.toRemove).toEqual([]);
+  });
+
+  test('remove plugin :: must cancel the removal if there are several plugin dependencies', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return EMPTY_PLUGINS_JSON;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    mockGet.mockImplementation(async (url: string): Promise<string | undefined> => {
+      if (url === 'http://internal.uri/v3/plugins/bierner/markdown-mermaid/latest/che-theia-plugin.yaml') {
+        return MARKDOWN_MERMAID_CHE_THEIA_PLUGIN_YAML;
+      }
+
+      if (url === 'http://internal.uri/v3/plugins/ex/markdown-mermaid-templates/latest/che-theia-plugin.yaml') {
+        return MARKDOWN_MERMAID_TEMPLATES_CHE_THEIA_PLUGIN_YAML;
+      }
+
+      return undefined;
+    });
+
+    pluginService.installedPlugins.push('goddard/mermaid-markdown-syntax-highlighting/latest');
+    pluginService.installedPlugins.push('bierner/markdown-mermaid/latest');
+
+    pluginService.toInstall.push('ex/markdown-mermaid-templates/latest');
+
+    const getPluginsMock = jest.spyOn(pluginService, 'getPlugins');
+    getPluginsMock.mockImplementation(
+      async (): Promise<ChePluginMetadata[]> => [
+        {
+          publisher: 'goddard',
+          name: 'mermaid-markdown-syntax-highlighting',
+          version: 'latest',
+        } as ChePluginMetadata,
+        {
+          publisher: 'bierner',
+          name: 'markdown-mermaid',
+          version: 'latest',
+        } as ChePluginMetadata,
+        {
+          publisher: 'ex',
+          name: 'markdown-mermaid-templates',
+          version: 'latest',
+        } as ChePluginMetadata,
+      ]
+    );
+
+    try {
+      await pluginService.removePlugin('goddard/mermaid-markdown-syntax-highlighting/latest');
+    } catch (error) {
+      expect(error.message).toBe(
+        "Cannot remove 'goddard/mermaid-markdown-syntax-highlighting/latest'. Plugins 'bierner/markdown-mermaid/latest', 'ex/markdown-mermaid-templates/latest' depend on this."
+      );
+
+      expect(pluginService.installedPlugins).toEqual([
+        'goddard/mermaid-markdown-syntax-highlighting/latest',
+        'bierner/markdown-mermaid/latest',
+      ]);
+      expect(pluginService.toInstall).toEqual(['ex/markdown-mermaid-templates/latest']);
+      expect(pluginService.toRemove).toEqual([]);
+
+      return;
+    }
+
+    fail();
+  });
+
+  test('remove plugin :: must reject the removal of the plugin if it is required for successful installation', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return EMPTY_PLUGINS_JSON;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    mockGet.mockImplementation(async (url: string): Promise<string | undefined> => {
+      if (url === 'http://internal.uri/v3/plugins/bierner/markdown-mermaid/latest/che-theia-plugin.yaml') {
+        return MARKDOWN_MERMAID_CHE_THEIA_PLUGIN_YAML;
+      }
+
+      if (
+        url ===
+        'http://internal.uri/v3/plugins/goddard/mermaid-markdown-syntax-highlighting/latest/che-theia-plugin.yaml'
+      ) {
+        return MERMAID_MARKDOWN_SYNTAX_HIGHLIGHTING_CHE_THEIA_PLUGIN_YAML;
+      }
+
+      return undefined;
+    });
+
+    pluginService.toInstall.push('bierner/markdown-mermaid/latest');
+    pluginService.toInstall.push('goddard/mermaid-markdown-syntax-highlighting/latest');
+
+    const getPluginsMock = jest.spyOn(pluginService, 'getPlugins');
+    getPluginsMock.mockImplementation(
+      async (): Promise<ChePluginMetadata[]> => [
+        {
+          publisher: 'goddard',
+          name: 'mermaid-markdown-syntax-highlighting',
+          version: 'latest',
+        } as ChePluginMetadata,
+        {
+          publisher: 'bierner',
+          name: 'markdown-mermaid',
+          version: 'latest',
+        } as ChePluginMetadata,
+      ]
+    );
+
+    try {
+      await pluginService.removePlugin('goddard/mermaid-markdown-syntax-highlighting/latest');
+    } catch (error) {
+      expect(error.message).toBe(
+        "Cannot remove 'goddard/mermaid-markdown-syntax-highlighting/latest'. Plugin 'bierner/markdown-mermaid/latest' depends on this."
+      );
+
+      expect(pluginService.toInstall).toEqual([
+        'bierner/markdown-mermaid/latest',
+        'goddard/mermaid-markdown-syntax-highlighting/latest',
+      ]);
+
+      expect(pluginService.installedPlugins).toEqual([]);
+      expect(pluginService.toRemove).toEqual([]);
+
+      return;
+    }
+
+    fail();
+  });
+
+  test('remove plugin :: must autoremove dependent plugin if it is not present in plugin registry index', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return PLUGINS_JSON_WITH_THREE_JAVA_PLUGINS;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    mockGet.mockImplementation(async (url: string): Promise<string | undefined> => {
+      if (url === 'http://internal.uri/v3/plugins/redhat/java/latest/che-theia-plugin.yaml') {
+        return JAVA_CHE_THEIA_PLUGIN_YAML;
+      }
+
+      if (url === 'http://internal.uri/v3/plugins/vscjava/vscode-java-debug/latest/che-theia-plugin.yaml') {
+        return VSCODE_JAVA_DEBUG_CHE_THEIA_PLUGIN;
+      }
+
+      if (url === 'http://internal.uri/v3/plugins/vscjava/vscode-java-test/latest/che-theia-plugin.yaml') {
+        return VSCODE_JAVA_TEST_CHE_THEIA_PLUGIN;
+      }
+
+      return undefined;
+    });
+
+    const getPluginsMock = jest.spyOn(pluginService, 'getPlugins');
+    getPluginsMock.mockImplementation(
+      async (): Promise<ChePluginMetadata[]> => [
+        {
+          publisher: 'redhat',
+          name: 'java',
+          version: 'latest',
+        } as ChePluginMetadata,
+      ]
+    );
+
+    await pluginService.removePlugin('redhat/java/latest');
+    expect(pluginService.toRemove).toEqual(['redhat/java/latest', 'vscjava/vscode-java-test/latest']);
+  });
+
+  test('persist :: do nothing if there is nothing to do', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return EMPTY_PLUGINS_JSON;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    pluginService.installedPlugins.push('bierner/markdown-mermaid/latest');
+    pluginService.installedPlugins.push('goddard/mermaid-markdown-syntax-highlighting/latest');
+
+    const fetchCheTheiaPluginYamlMock = jest.spyOn(pluginService, 'fetchCheTheiaPluginYaml');
+
+    await pluginService.persist();
+
+    expect(pluginService.installedPlugins).toEqual([
+      'bierner/markdown-mermaid/latest',
+      'goddard/mermaid-markdown-syntax-highlighting/latest',
+    ]);
+    expect(pluginService.toInstall).toEqual([]);
+    expect(pluginService.toRemove).toEqual([]);
+
+    expect(fetchCheTheiaPluginYamlMock).toHaveBeenCalledTimes(0);
+  });
+
+  test('persist :: must download two extensions into /plugins directory without patching devworkspace object', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return EMPTY_PLUGINS_JSON;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    pluginService.toInstall.push('bierner/markdown-mermaid/latest');
+    pluginService.toInstall.push('goddard/mermaid-markdown-syntax-highlighting/latest');
+
+    const askedPluginYamls: string[] = [];
+    const askedExtensions: string[] = [];
+
+    mockGet.mockImplementation(async (url: string): Promise<string | undefined> => {
+      switch (url) {
+        case 'http://internal.uri/v3/plugins/bierner/markdown-mermaid/latest/che-theia-plugin.yaml':
+          askedPluginYamls.push('http://internal.uri/v3/plugins/bierner/markdown-mermaid/latest/che-theia-plugin.yaml');
+          return MARKDOWN_MERMAID_CHE_THEIA_PLUGIN_YAML;
+
+        case 'http://internal.uri/v3/plugins/goddard/mermaid-markdown-syntax-highlighting/latest/che-theia-plugin.yaml':
+          askedPluginYamls.push(
+            'http://internal.uri/v3/plugins/goddard/mermaid-markdown-syntax-highlighting/latest/che-theia-plugin.yaml'
+          );
+          return MERMAID_MARKDOWN_SYNTAX_HIGHLIGHTING_CHE_THEIA_PLUGIN_YAML;
+
+        case 'https://somehost/vscode-markdown-mermaid-1.9.2.vsix':
+          askedExtensions.push('https://somehost/vscode-markdown-mermaid-1.9.2.vsix');
+          return 'content of vscode-markdown-mermaid-1.9.2.vsix';
+
+        case 'https://somehost/vscode-mermaid-syntax-highlight.vsix':
+          askedExtensions.push('https://somehost/vscode-mermaid-syntax-highlight.vsix');
+          return 'content of vscode-mermaid-syntax-highlight.vsix';
+      }
+
+      return undefined;
+    });
+
+    let vscodeMarkdownMermaidContent;
+    let vscodeMermaidSyntaxHighlightContent;
+
+    let chePLuginsJsonContent = '';
+
+    const writeFileMock = jest.fn();
+    writeFileMock.mockImplementation(async (path: string, data: string): Promise<void> => {
+      if (path === '/plugins/vscode-markdown-mermaid-1.9.2.vsix') {
+        vscodeMarkdownMermaidContent = data;
+        return;
+      }
+
+      if (path === '/plugins/vscode-mermaid-syntax-highlight.vsix') {
+        vscodeMermaidSyntaxHighlightContent = data;
+        return;
+      }
+
+      if (path === '/plugins/che-plugins.json') {
+        chePLuginsJsonContent = data;
+        return;
+      }
+
+      throw new Error(`Failure to write ${path}`);
+    });
+
+    Object.assign(fs, {
+      writeFile: writeFileMock,
+    });
+
+    const fetchCheTheiaPluginYamlMock = jest.spyOn(pluginService, 'fetchCheTheiaPluginYaml');
+    const downloadExtensionsMock = jest.spyOn(pluginService, 'downloadExtensions');
+
+    const devWorkspaceTemplate: Devfile = JSON.parse(devWorkspaceTemplateContent) as Devfile;
+    const getDevfileMock = jest.spyOn(devfileService, 'get');
+    getDevfileMock.mockImplementation(async () => devWorkspaceTemplate);
+
+    const patchDevfileMock = jest.spyOn(devfileService, 'patch');
+    patchDevfileMock.mockImplementation(async (): Promise<void> => {});
+
+    const stopWorkspaceMock = jest.spyOn(workspaceService, 'stop');
+    stopWorkspaceMock.mockImplementation(async (): Promise<void> => {});
+
+    await pluginService.persist();
+
+    expect(fetchCheTheiaPluginYamlMock).toHaveBeenCalledTimes(2);
+    expect(downloadExtensionsMock).toHaveBeenCalled();
+
+    expect(patchDevfileMock).toHaveBeenCalledTimes(0);
+    expect(stopWorkspaceMock).toHaveBeenCalledTimes(1);
+
+    expect(writeFileMock).toHaveBeenCalledTimes(3);
+
+    expect(askedPluginYamls).toEqual([
+      'http://internal.uri/v3/plugins/bierner/markdown-mermaid/latest/che-theia-plugin.yaml',
+      'http://internal.uri/v3/plugins/goddard/mermaid-markdown-syntax-highlighting/latest/che-theia-plugin.yaml',
+    ]);
+
+    expect(askedExtensions).toEqual([
+      'https://somehost/vscode-markdown-mermaid-1.9.2.vsix',
+      'https://somehost/vscode-mermaid-syntax-highlight.vsix',
+    ]);
+
+    expect(vscodeMarkdownMermaidContent).toBe('content of vscode-markdown-mermaid-1.9.2.vsix');
+    expect(vscodeMermaidSyntaxHighlightContent).toBe('content of vscode-mermaid-syntax-highlight.vsix');
+
+    expect(JSON.parse(chePLuginsJsonContent)).toEqual(
+      JSON.parse(`
+    {
+      "plugins": [
+        "bierner.markdown-mermaid",
+        "goddard.mermaid-markdown-syntax-highlighting"
+      ]
+    }
+    `)
+    );
+  });
+
+  test('persist :: must download three extensions into /plugins/sidecars/tools directory and update devworkspace object', async () => {
+    process.env.CHE_PLUGIN_REGISTRY_URL = 'http://public.uri/v3/';
+    process.env.CHE_PLUGIN_REGISTRY_INTERNAL_URL = 'http://internal.uri/v3/';
+
+    Object.assign(fs, {
+      pathExists: async (path: string): Promise<boolean> => {
+        if (path === '/projects' || path === CHE_PLUGINS_JSON) {
+          return true;
+        }
+
+        return false;
+      },
+
+      readFile: async (path: string): Promise<string> => {
+        if (path === CHE_PLUGINS_JSON) {
+          return EMPTY_PLUGINS_JSON;
+        }
+
+        return Promise.reject();
+      },
+    });
+
+    const pluginService = container.get(K8sPluginServiceImpl);
+    await pluginService.deferred.promise;
+
+    pluginService.toInstall.push('redhat/java/latest');
+    pluginService.toInstall.push('vscjava/vscode-java-debug/latest');
+    pluginService.toInstall.push('vscjava/vscode-java-test/latest');
+
+    const askedPluginYamls: string[] = [];
+    const askedExtensions: string[] = [];
+
+    mockGet.mockImplementation(async (url: string): Promise<string | undefined> => {
+      switch (url) {
+        case 'http://internal.uri/v3/plugins/redhat/java/latest/che-theia-plugin.yaml':
+          askedPluginYamls.push('http://internal.uri/v3/plugins/redhat/java/latest/che-theia-plugin.yaml');
+          return JAVA_CHE_THEIA_PLUGIN_YAML;
+
+        case 'http://internal.uri/v3/plugins/vscjava/vscode-java-debug/latest/che-theia-plugin.yaml':
+          askedPluginYamls.push(
+            'http://internal.uri/v3/plugins/vscjava/vscode-java-debug/latest/che-theia-plugin.yaml'
+          );
+          return VSCODE_JAVA_DEBUG_CHE_THEIA_PLUGIN;
+
+        case 'http://internal.uri/v3/plugins/vscjava/vscode-java-test/latest/che-theia-plugin.yaml':
+          askedPluginYamls.push('http://internal.uri/v3/plugins/vscjava/vscode-java-test/latest/che-theia-plugin.yaml');
+          return VSCODE_JAVA_TEST_CHE_THEIA_PLUGIN;
+
+        case 'https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.82.0-369.vsix':
+          askedExtensions.push('https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.82.0-369.vsix');
+          return 'content of java-0.82.0-369.vsix';
+
+        case 'https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix':
+          askedExtensions.push(
+            'https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix'
+          );
+          return 'content of vscode-java-debug-0.26.0.vsix';
+
+        case 'https://open-vsx.org/api/vscjava/vscode-java-test/0.28.1/file/vscjava.vscode-java-test-0.28.1.vsix':
+          askedExtensions.push(
+            'https://open-vsx.org/api/vscjava/vscode-java-test/0.28.1/file/vscjava.vscode-java-test-0.28.1.vsix'
+          );
+          return 'content of vscjava.vscode-java-test-0.28.1.vsix';
+      }
+
+      return undefined;
+    });
+
+    const devWorkspaceTemplate: Devfile = JSON.parse(devWorkspaceTemplateContent) as Devfile;
+    const getDevfileMock = jest.spyOn(devfileService, 'get');
+    getDevfileMock.mockImplementation(async () => devWorkspaceTemplate);
+
+    let patchPath;
+    let patchValue;
+
+    const patchDevfileMock = jest.spyOn(devfileService, 'patch');
+    patchDevfileMock.mockImplementation(async (path, value): Promise<void> => {
+      patchPath = path;
+      patchValue = value;
+    });
+
+    let javaExtensionContent;
+    let javaTestExtensionContent;
+    let javaDebugExtensionContent;
+
+    let chePLuginsJsonContent = '';
+
+    Object.assign(fs, {
+      ensureDir: async (path: string) => {},
+      writeFile: async (path: string, data: string): Promise<void> => {
+        if (path === '/plugins/sidecars/tools/java-0.82.0-369.vsix') {
+          javaExtensionContent = data;
+          return;
+        }
+
+        if (path === '/plugins/sidecars/tools/vscjava.vscode-java-test-0.28.1.vsix') {
+          javaTestExtensionContent = data;
+          return;
+        }
+
+        if (path === '/plugins/sidecars/tools/vscode-java-debug-0.26.0.vsix') {
+          javaDebugExtensionContent = data;
+          return;
+        }
+
+        if (path === '/plugins/che-plugins.json') {
+          chePLuginsJsonContent = data;
+          return;
+        }
+
+        throw new Error(`Failure to write ${path}`);
+      },
+    });
+
+    const stopWorkspaceMock = jest.spyOn(workspaceService, 'stop');
+    stopWorkspaceMock.mockImplementation(async (): Promise<void> => {});
+
+    await pluginService.persist();
+
+    expect(askedPluginYamls).toEqual([
+      'http://internal.uri/v3/plugins/redhat/java/latest/che-theia-plugin.yaml',
+      'http://internal.uri/v3/plugins/vscjava/vscode-java-debug/latest/che-theia-plugin.yaml',
+      'http://internal.uri/v3/plugins/vscjava/vscode-java-test/latest/che-theia-plugin.yaml',
+    ]);
+
+    expect(askedExtensions).toEqual([
+      'https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.82.0-369.vsix',
+      'https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix',
+      'https://open-vsx.org/api/vscjava/vscode-java-test/0.28.1/file/vscjava.vscode-java-test-0.28.1.vsix',
+    ]);
+
+    expect(patchDevfileMock).toHaveBeenCalled();
+    expect(stopWorkspaceMock).toHaveBeenCalled();
+
+    expect(patchPath).toBe('/spec/template/components');
+
+    const toolsContainer = pluginService.findDevContainer({
+      components: patchValue,
+    } as Devfile);
+
+    expect(toolsContainer).toBeDefined();
+
+    expect(toolsContainer.name).toBe('tools');
+
+    expect(toolsContainer.attributes).toBeDefined();
+
+    const extensionsAttribute = toolsContainer.attributes!['che-theia.eclipse.org/vscode-extensions'];
+    expect(extensionsAttribute).toBeDefined();
+
+    const preferencesAttribute = toolsContainer.attributes!['che-theia.eclipse.org/vscode-preferences'];
+    expect(preferencesAttribute).toBeDefined();
+
+    expect(extensionsAttribute).toEqual([
+      'https://download.jboss.org/jbosstools/static/jdt.ls/stable/java-0.82.0-369.vsix',
+      'https://download.jboss.org/jbosstools/vscode/3rdparty/vscode-java-debug/vscode-java-debug-0.26.0.vsix',
+      'https://open-vsx.org/api/vscjava/vscode-java-test/0.28.1/file/vscjava.vscode-java-test-0.28.1.vsix',
+    ]);
+
+    expect(preferencesAttribute).toEqual({
+      'java.server.launchMode': 'Standard',
+    });
+
+    expect(javaExtensionContent).toBe('content of java-0.82.0-369.vsix');
+    expect(javaTestExtensionContent).toBe('content of vscjava.vscode-java-test-0.28.1.vsix');
+    expect(javaDebugExtensionContent).toBe('content of vscode-java-debug-0.26.0.vsix');
+
+    expect(JSON.parse(chePLuginsJsonContent)).toEqual(
+      JSON.parse(`
+    {
+      "plugins": [
+        "redhat.java",
+        "vscjava.vscode-java-debug",
+        "vscjava.vscode-java-test"
+      ]
+    }
+    `)
+    );
+  });
+});

--- a/extensions/eclipse-che-theia-workspace/package.json
+++ b/extensions/eclipse-che-theia-workspace/package.json
@@ -18,7 +18,8 @@
     "@eclipse-che/api": "latest",
     "@theia/workspace": "next",
     "@eclipse-che/theia-remote-api": "^0.0.1",
-    "js-yaml": "3.13.1"
+    "js-yaml": "3.13.1",
+    "react": "^16.8.0"
   },
   "devDependencies": {
     "@types/js-yaml": "3.11.2",


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Allows to manage che-theia plugins for devworkspaces by Che-Theia Plugins view.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

![Screenshot from 2022-01-31 13-56-11](https://user-images.githubusercontent.com/1655894/151789855-fdbe5651-b834-465b-9b1a-ba7408d41171.png)

![Screenshot from 2022-01-31 13-56-23](https://user-images.githubusercontent.com/1655894/151789873-fd556fea-4a8b-44c1-8b91-9281488653eb.png)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20638

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Create a workspace from this repository https://github.com/vitaliy-guliy/java-spring-petclinic/tree/devfilev2-plugin-installation

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=next
