### PR TITLE
chore: [theia-devworkspace handler] store projects section when generating templates

### DIFF
--- a/tools/devworkspace-handler/src/generate.ts
+++ b/tools/devworkspace-handler/src/generate.ts
@@ -60,7 +60,7 @@ export class Generate {
       editorDevfile.projects = [
         {
           name: githubUrl.getRepoName(),
-          git: { remotes: { origin: githubUrl.getCloneUrl(), checkoutFrom: githubUrl.getBranchName() } },
+          git: { remotes: { origin: githubUrl.getCloneUrl() }, checkoutFrom: { revision: githubUrl.getBranchName() } },
         },
       ];
     }

--- a/tools/devworkspace-handler/src/generate.ts
+++ b/tools/devworkspace-handler/src/generate.ts
@@ -40,7 +40,7 @@ export class Generate {
     editorEntry: string,
     sidecarPolicy: SidecarPolicy,
     outputFile: string,
-    projects: { name: string; location: string }[]
+    project?: { name: string; location: string }
   ): Promise<void> {
     // gets the github URL
     const githubUrl = this.githubResolver.resolve(devfileUrl);
@@ -54,11 +54,8 @@ export class Generate {
     // devfile of the editor
     const editorDevfile = await this.pluginRegistryResolver.loadDevfilePlugin(editorEntry);
 
-    editorDevfile.projects = [];
-    if (projects.length > 0) {
-      projects.forEach(p => {
-        editorDevfile.projects.push({ name: p.name, zip: { location: p.location } });
-      });
+    if (project) {
+      editorDevfile.projects = [{ name: project.name, zip: { location: project.location } }];
     } else {
       editorDevfile.projects = [
         {

--- a/tools/devworkspace-handler/src/generate.ts
+++ b/tools/devworkspace-handler/src/generate.ts
@@ -39,7 +39,8 @@ export class Generate {
     devfileUrl: string,
     editorEntry: string,
     sidecarPolicy: SidecarPolicy,
-    outputFile: string
+    outputFile: string,
+    projects: { name: string; location: string }[]
   ): Promise<void> {
     // gets the github URL
     const githubUrl = this.githubResolver.resolve(devfileUrl);
@@ -52,6 +53,20 @@ export class Generate {
 
     // devfile of the editor
     const editorDevfile = await this.pluginRegistryResolver.loadDevfilePlugin(editorEntry);
+
+    editorDevfile.projects = [];
+    if (projects.length > 0) {
+      projects.forEach(p => {
+        editorDevfile.projects.push({ name: p.name, zip: { location: p.location } });
+      });
+    } else {
+      editorDevfile.projects = [
+        {
+          name: githubUrl.getRepoName(),
+          git: { remotes: { origin: githubUrl.getCloneUrl(), checkoutFrom: githubUrl.getBranchName() } },
+        },
+      ];
+    }
 
     // transform it into a devWorkspace template
     const metadata = editorDevfile.metadata;

--- a/tools/devworkspace-handler/src/github/github-url.ts
+++ b/tools/devworkspace-handler/src/github/github-url.ts
@@ -32,4 +32,16 @@ export class GithubUrl {
   getUrl(): string {
     return `https://github.com/${this.repoUser}/${this.repoName}/tree/${this.branchName}/${this.subFolder}`;
   }
+
+  getCloneUrl(): string {
+    return `https://github.com/${this.repoUser}/${this.repoName}.git`;
+  }
+
+  getRepoName(): string {
+    return this.repoName;
+  }
+
+  getBranchName(): string {
+    return this.branchName;
+  }
 }

--- a/tools/devworkspace-handler/src/main.ts
+++ b/tools/devworkspace-handler/src/main.ts
@@ -21,7 +21,7 @@ export class Main {
     let pluginRegistryUrl: string | undefined;
     let editor: string | undefined;
     let sidecarPolicy: SidecarPolicy | undefined;
-    let projects: { name: string; location: string }[] = [];
+    let project: { name: string; location: string } | undefined;
     const args = process.argv.slice(2);
     args.forEach(arg => {
       if (arg.startsWith('--devfile-url:')) {
@@ -51,7 +51,7 @@ export class Main {
       if (arg.startsWith('--project.')) {
         const name = arg.substring('--project.'.length, arg.indexOf('='));
         const location = arg.substring(arg.indexOf('=') + 1);
-        projects.push({ name, location });
+        project = { name, location };
       }
     });
     if (!pluginRegistryUrl) {
@@ -83,7 +83,7 @@ export class Main {
     container.bind(Generate).toSelf().inSingletonScope();
 
     const generate = container.get(Generate);
-    return generate.generate(devfileUrl, editor, sidecarPolicy, outputFile, projects);
+    return generate.generate(devfileUrl, editor, sidecarPolicy, outputFile, project);
   }
 
   async start(): Promise<boolean> {

--- a/tools/devworkspace-handler/src/main.ts
+++ b/tools/devworkspace-handler/src/main.ts
@@ -21,6 +21,7 @@ export class Main {
     let pluginRegistryUrl: string | undefined;
     let editor: string | undefined;
     let sidecarPolicy: SidecarPolicy | undefined;
+    let projects: { name: string; location: string }[] = [];
     const args = process.argv.slice(2);
     args.forEach(arg => {
       if (arg.startsWith('--devfile-url:')) {
@@ -46,6 +47,11 @@ export class Main {
             `${policy} is not a valid sidecar policy. Available values are ${Object.values(SidecarPolicy)}`
           );
         }
+      }
+      if (arg.startsWith('--project.')) {
+        const name = arg.substring('--project.'.length, arg.indexOf('='));
+        const location = arg.substring(arg.indexOf('=') + 1);
+        projects.push({ name, location });
       }
     });
     if (!pluginRegistryUrl) {
@@ -77,7 +83,7 @@ export class Main {
     container.bind(Generate).toSelf().inSingletonScope();
 
     const generate = container.get(Generate);
-    return generate.generate(devfileUrl, editor, sidecarPolicy, outputFile);
+    return generate.generate(devfileUrl, editor, sidecarPolicy, outputFile, projects);
   }
 
   async start(): Promise<boolean> {

--- a/tools/devworkspace-handler/tests/generate.spec.ts
+++ b/tools/devworkspace-handler/tests/generate.spec.ts
@@ -102,7 +102,7 @@ describe('Test Generate', () => {
     getContentUrlMethod.mockReturnValue(rawDevfileUrl);
     getBranchNameMethod.mockReturnValue('HEAD');
 
-    await generate.generate(devfileUrl, editor, SidecarPolicy.USE_DEV_CONTAINER, fakeoutputDir, []);
+    await generate.generate(devfileUrl, editor, SidecarPolicy.USE_DEV_CONTAINER, fakeoutputDir);
     expect(urlFetcherFetchTextMethod).toBeCalledWith(rawDevfileUrl);
 
     // expect to write the file
@@ -119,7 +119,7 @@ describe('Test Generate', () => {
     getBranchNameMethod.mockReturnValue('test-branch');
 
     //when
-    await generate.generate(devfileUrl, editor, SidecarPolicy.USE_DEV_CONTAINER, fakeoutputDir, []);
+    await generate.generate(devfileUrl, editor, SidecarPolicy.USE_DEV_CONTAINER, fakeoutputDir);
 
     //then
     expect((editorDevfile as V1alpha2DevWorkspaceTemplateSpec).projects).toStrictEqual([
@@ -130,21 +130,20 @@ describe('Test Generate', () => {
     ]);
   });
 
-  test('generate template with defined projects', async () => {
+  test('generate template with defined project', async () => {
     //given
     const pluginRegistryResolverSpy = jest.spyOn(pluginRegistryResolver, 'loadDevfilePlugin');
     pluginRegistryResolverSpy.mockResolvedValue(editorDevfile);
 
     //when
-    await generate.generate(devfileUrl, editor, SidecarPolicy.USE_DEV_CONTAINER, fakeoutputDir, [
-      { name: 'test-name', location: 'test-location' },
-      { name: 'test-name-1', location: 'test-location-1' },
-    ]);
+    await generate.generate(devfileUrl, editor, SidecarPolicy.USE_DEV_CONTAINER, fakeoutputDir, {
+      name: 'test-name',
+      location: 'test-location',
+    });
 
     //then
     expect((editorDevfile as V1alpha2DevWorkspaceTemplateSpec).projects).toStrictEqual([
       { name: 'test-name', zip: { location: 'test-location' } },
-      { name: 'test-name-1', zip: { location: 'test-location-1' } },
     ]);
   });
 });

--- a/tools/devworkspace-handler/tests/generate.spec.ts
+++ b/tools/devworkspace-handler/tests/generate.spec.ts
@@ -125,7 +125,7 @@ describe('Test Generate', () => {
     expect((editorDevfile as V1alpha2DevWorkspaceTemplateSpec).projects).toStrictEqual([
       {
         name: 'test-repo',
-        git: { remotes: { origin: 'https://github.com/org/repo.git', checkoutFrom: 'test-branch' } },
+        git: { remotes: { origin: 'https://github.com/org/repo.git' }, checkoutFrom: { revision: 'test-branch' } },
       },
     ]);
   });

--- a/tools/devworkspace-handler/tests/generate.spec.ts
+++ b/tools/devworkspace-handler/tests/generate.spec.ts
@@ -20,6 +20,7 @@ import { GithubResolver } from '../src/github/github-resolver';
 import { PluginRegistryResolver } from '../src/plugin-registry/plugin-registry-resolver';
 import { SidecarPolicy } from '../src/api/devfile-context';
 import { UrlFetcher } from '../src/fetch/url-fetcher';
+import { V1alpha2DevWorkspaceTemplateSpec } from '@devfile/api/model/v1alpha2DevWorkspaceTemplateSpec';
 
 describe('Test Generate', () => {
   let container: Container;
@@ -27,8 +28,14 @@ describe('Test Generate', () => {
   let generate: Generate;
 
   const getContentUrlMethod = jest.fn();
+  const getCloneUrlMethod = jest.fn();
+  const getRepoNameMethod = jest.fn();
+  const getBranchNameMethod = jest.fn();
   const githubUrlMock = {
     getContentUrl: getContentUrlMethod,
+    getCloneUrl: getCloneUrlMethod,
+    getRepoName: getRepoNameMethod,
+    getBranchName: getBranchNameMethod,
   };
 
   const urlFetcherFetchTextMethod = jest.fn();
@@ -53,6 +60,15 @@ describe('Test Generate', () => {
     loadDevfilePlugin: pluginRegistryResolverLoadDevfilePluginMethod,
   } as any;
 
+  let editorDevfile = {};
+
+  const devfileUrl = 'https://github.com/org/devfile-repo/tree/branch';
+  const fakeoutputDir = '/fake-output';
+  const editor = 'my/editor/latest';
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  let fsWriteFileSpy: any;
+
   beforeEach(() => {
     jest.restoreAllMocks();
     jest.resetAllMocks();
@@ -64,34 +80,71 @@ describe('Test Generate', () => {
     container.bind(GithubResolver).toConstantValue(githubResolver);
     githubResolverResolveMethod.mockReturnValue(githubUrlMock);
 
-    generate = container.get(Generate);
-  });
-
-  test('basics', async () => {
-    pluginRegistryResolverLoadDevfilePluginMethod.mockResolvedValue({
+    editorDevfile = {
       schemaVersion: '2.1.0',
       metadata: {
         name: 'theia-ide',
       },
       commands: [],
-    });
+    };
 
-    const devfileUrl = 'http://my-devfile-url';
-    const fakeoutputDir = '/fake-output';
-    const editor = 'my/editor/latest';
-
-    const fsWriteFileSpy = jest.spyOn(fs, 'writeFile');
+    urlFetcherFetchTextMethod.mockResolvedValue(jsYaml.dump({ metadata: {} }));
+    fsWriteFileSpy = jest.spyOn(fs, 'writeFile');
     fsWriteFileSpy.mockReturnValue();
+
+    generate = container.get(Generate);
+  });
+
+  test('basics', async () => {
+    pluginRegistryResolverLoadDevfilePluginMethod.mockResolvedValue(editorDevfile);
 
     const rawDevfileUrl = 'https://content-of-devfile.url';
     getContentUrlMethod.mockReturnValue(rawDevfileUrl);
+    getBranchNameMethod.mockReturnValue('HEAD');
 
-    urlFetcherFetchTextMethod.mockResolvedValue(jsYaml.dump({ metadata: {} }));
-
-    await generate.generate(devfileUrl, editor, SidecarPolicy.USE_DEV_CONTAINER, fakeoutputDir);
+    await generate.generate(devfileUrl, editor, SidecarPolicy.USE_DEV_CONTAINER, fakeoutputDir, []);
     expect(urlFetcherFetchTextMethod).toBeCalledWith(rawDevfileUrl);
 
     // expect to write the file
     expect(fsWriteFileSpy).toBeCalled();
+  });
+
+  test('generate template with default project', async () => {
+    //given
+    const pluginRegistryResolverSpy = jest.spyOn(pluginRegistryResolver, 'loadDevfilePlugin');
+    pluginRegistryResolverSpy.mockResolvedValue(editorDevfile);
+
+    getCloneUrlMethod.mockReturnValue('https://github.com/org/repo.git');
+    getRepoNameMethod.mockReturnValue('test-repo');
+    getBranchNameMethod.mockReturnValue('test-branch');
+
+    //when
+    await generate.generate(devfileUrl, editor, SidecarPolicy.USE_DEV_CONTAINER, fakeoutputDir, []);
+
+    //then
+    expect((editorDevfile as V1alpha2DevWorkspaceTemplateSpec).projects).toStrictEqual([
+      {
+        name: 'test-repo',
+        git: { remotes: { origin: 'https://github.com/org/repo.git', checkoutFrom: 'test-branch' } },
+      },
+    ]);
+  });
+
+  test('generate template with defined projects', async () => {
+    //given
+    const pluginRegistryResolverSpy = jest.spyOn(pluginRegistryResolver, 'loadDevfilePlugin');
+    pluginRegistryResolverSpy.mockResolvedValue(editorDevfile);
+
+    //when
+    await generate.generate(devfileUrl, editor, SidecarPolicy.USE_DEV_CONTAINER, fakeoutputDir, [
+      { name: 'test-name', location: 'test-location' },
+      { name: 'test-name-1', location: 'test-location-1' },
+    ]);
+
+    //then
+    expect((editorDevfile as V1alpha2DevWorkspaceTemplateSpec).projects).toStrictEqual([
+      { name: 'test-name', zip: { location: 'test-location' } },
+      { name: 'test-name-1', zip: { location: 'test-location-1' } },
+    ]);
   });
 });

--- a/tools/devworkspace-handler/tests/github/github-resolver.spec.ts
+++ b/tools/devworkspace-handler/tests/github/github-resolver.spec.ts
@@ -37,6 +37,17 @@ describe('Test PluginRegistryResolver', () => {
     expect(githubResolver.resolve('http://github.com/eclipse/che').getContentUrl('README.md')).toBe(
       'https://raw.githubusercontent.com/eclipse/che/HEAD/README.md'
     );
+
+    expect(githubResolver.resolve('http://github.com/eclipse/che').getCloneUrl()).toBe(
+      'https://github.com/eclipse/che.git'
+    );
+
+    expect(githubResolver.resolve('https://github.com/eclipse/che').getRepoName()).toBe('che');
+
+    expect(githubResolver.resolve('http://github.com/eclipse/che').getBranchName()).toBe('HEAD');
+    expect(githubResolver.resolve('https://github.com/eclipse/che/tree/test-branch').getBranchName()).toBe(
+      'test-branch'
+    );
   });
 
   test('error', async () => {

--- a/tools/devworkspace-handler/tests/main.spec.ts
+++ b/tools/devworkspace-handler/tests/main.spec.ts
@@ -54,7 +54,7 @@ describe('Test Main with stubs', () => {
     pluginRegistryUrl: string | undefined,
     editor: string | undefined,
     sidecarPolicy: string | undefined,
-    projects: { name: string; location: string }[] | undefined
+    project: { name: string; location: string } | undefined
   ) {
     // empty args
     process.argv = ['', ''];
@@ -73,10 +73,8 @@ describe('Test Main with stubs', () => {
     if (sidecarPolicy) {
       process.argv.push(`--sidecar-policy:${sidecarPolicy}`);
     }
-    if (projects) {
-      projects.forEach(p => {
-        process.argv.push(`--project.${p.name}=${p.location}`);
-      });
+    if (project) {
+      process.argv.push(`--project.${project.name}=${project.location}`);
     }
   }
 
@@ -107,7 +105,7 @@ describe('Test Main with stubs', () => {
     const main = new Main();
     const returnCode = await main.start();
     expect(returnCode).toBeTruthy();
-    expect(generateMethod).toBeCalledWith(FAKE_DEVFILE_URL, FAKE_EDITOR, SIDECAR_POLICY, FAKE_OUTPUT_FILE, []);
+    expect(generateMethod).toBeCalledWith(FAKE_DEVFILE_URL, FAKE_EDITOR, SIDECAR_POLICY, FAKE_OUTPUT_FILE, undefined);
     expect(mockedConsoleError).toBeCalledTimes(0);
   });
 
@@ -119,7 +117,7 @@ describe('Test Main with stubs', () => {
       FAKE_PLUGIN_REGISTRY_URL,
       FAKE_EDITOR,
       SidecarPolicy.USE_DEV_CONTAINER.toString(),
-      [{ name: 'test', location: 'test-location' }]
+      { name: 'test', location: 'test-location' }
     );
     const returnCode = await main.start();
     expect(returnCode).toBeTruthy();
@@ -128,7 +126,7 @@ describe('Test Main with stubs', () => {
       FAKE_EDITOR,
       SidecarPolicy.USE_DEV_CONTAINER.toString(),
       FAKE_OUTPUT_FILE,
-      [{ name: 'test', location: 'test-location' }]
+      { name: 'test', location: 'test-location' }
     );
     expect(mockedConsoleError).toBeCalledTimes(0);
   });


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Add an optional parameter `--project.<project name>=<project location>`
If defined, project section in a zip format is added to the devfile template:
```yaml
projects:
    - name: project-name
      zip:
        location: '{{DEVFILE_REGISTRY_URL}}/project-name.zip'
```
If not defined, project section in a git format is added to the devfile template:
```yaml
projects:
  - name: java-spring-petclinic
    git:
      remotes:
        origin: https://github.com/che-samples/java-spring-petclinic.git
      checkoutFrom:
        revision: devfilev2
```
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20877

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Build the `devworkspace-handler` package
2. Run `node lib/entrypoint.js --devfile-url:https://github.com/che-samples/java-spring-petclinic/tree/devfilev2 --output-file:/Users/ivinokur/projects/che-theia/tools/devworkspace-handler/a.yaml` in the package root and see the default projects section in the generated template.
3. Run `node lib/entrypoint.js --devfile-url:https://github.com/che-samples/java-spring-petclinic/tree/devfilev2 --output-file:/Users/ivinokur/projects/che-theia/tools/devworkspace-handler/a.yaml --project.name={{DEVFILE_REGISTRY_URL}}/project.zip` and see the projects section with the specified projects in the zip format.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
