### PR TITLE
fix(resource-monitor): get DW Namespace name from ENV variable

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-workspace-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-workspace-main.ts
@@ -41,6 +41,10 @@ export class CheWorkspaceMainImpl implements CheWorkspaceMain {
     );
   }
 
+  $getCurrentNamespace(): Promise<string> {
+    return this.workspaceService.getCurrentNamespace();
+  }
+
   async $getById(workspaceId: string): Promise<cheApi.workspace.Workspace> {
     return this.workspaceService.getWorkspaceById(workspaceId).then(
       workspace => workspace,

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -35,6 +35,7 @@ export interface CheWorkspace {
 
 export interface CheWorkspaceMain {
   $getCurrentWorkspace(): Promise<cheApi.workspace.Workspace>;
+  $getCurrentNamespace(): Promise<string>;
   // getAll(): Promise<Workspace[]>;
   // getAllByNamespace(namespace: string): Promise<Workspace[]>;
   $getById(workspaceId: string): Promise<cheApi.workspace.Workspace>;

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-api.ts
@@ -66,6 +66,9 @@ export function createAPIFactory(rpc: RPCProtocol): CheApiFactory {
       getCurrentWorkspace(): Promise<cheApi.workspace.Workspace> {
         return cheWorkspaceImpl.getCurrentWorkspace();
       },
+      getCurrentNamespace(): Promise<string> {
+        return cheWorkspaceImpl.getCurrentNamespace();
+      },
       getAll(): Promise<cheApi.workspace.Workspace[]> {
         return cheWorkspaceImpl.getAll();
       },

--- a/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-workspace.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/plugin/che-workspace.ts
@@ -64,6 +64,10 @@ export class CheWorkspaceImpl implements CheWorkspace {
     throw new Error('Method not implemented.');
   }
 
+  getCurrentNamespace(): Promise<string> {
+    return this.workspaceMain.$getCurrentNamespace();
+  }
+
   getAll(): Promise<cheApi.workspace.Workspace[]> {
     throw new Error('Method not implemented.');
   }

--- a/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
+++ b/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
@@ -29,6 +29,7 @@ declare module '@eclipse-che/plugin' {
 
     export namespace workspace {
         export function getCurrentWorkspace(): Promise<cheApi.workspace.Workspace>;
+        export function getCurrentNamespace(): Promise<string>;
         export function getAll(): Promise<cheApi.workspace.Workspace[]>;
         export function getAllByNamespace(namespace: string): Promise<cheApi.workspace.Workspace[]>;
         export function getById(workspaceId: string): Promise<cheApi.workspace.Workspace>;

--- a/extensions/eclipse-che-theia-remote-api/src/common/workspace-service.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/common/workspace-service.ts
@@ -55,6 +55,7 @@ export interface WorkspaceSettings {
 
 export const WorkspaceService = Symbol('WorkspaceService');
 export interface WorkspaceService {
+  getCurrentNamespace(): Promise<string>;
   getCurrentWorkspaceId(): Promise<string>;
   currentWorkspace(): Promise<Workspace>;
   getWorkspaceById(workspaceId: string): Promise<Workspace>;

--- a/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-workspace-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-che-server/src/node/che-server-workspace-service-impl.ts
@@ -23,6 +23,8 @@ export class CheServerWorkspaceServiceImpl implements WorkspaceService {
   @inject(CheServerRemoteApiImpl)
   private cheServerRemoteApiImpl: CheServerRemoteApiImpl;
 
+  private INFRASTRUCTURE_NAMESPACE = 'infrastructureNamespace';
+
   /**
    * Workspace client based variables.
    *
@@ -50,6 +52,11 @@ export class CheServerWorkspaceServiceImpl implements WorkspaceService {
 
   public async getCurrentWorkspaceId(): Promise<string> {
     return this.workspaceId;
+  }
+
+  public async getCurrentNamespace(): Promise<string> {
+    const workspace = await this.currentWorkspace();
+    return workspace.attributes?.[this.INFRASTRUCTURE_NAMESPACE] || workspace.namespace || '';
   }
 
   public async currentWorkspace(): Promise<Workspace> {

--- a/plugins/resource-monitor-plugin/__mocks__/@eclipse-che/plugin.ts
+++ b/plugins/resource-monitor-plugin/__mocks__/@eclipse-che/plugin.ts
@@ -16,7 +16,6 @@
  * @author Valerii Svydenko
  */
 const che: any = {};
-che.devfile = {};
-che.devfile.metadata = {};
+che.workspace = {};
 che.k8s = {};
 module.exports = che;

--- a/plugins/resource-monitor-plugin/src/plugin.ts
+++ b/plugins/resource-monitor-plugin/src/plugin.ts
@@ -27,10 +27,5 @@ export async function start(context: theia.PluginContext): Promise<void> {
 }
 
 export async function getNamespace(): Promise<string> {
-  if (process.env.DEVWORKSPACE_NAMESPACE !== undefined) {
-    return process.env.DEVWORKSPACE_NAMESPACE;
-  }
-  // get namespace from devfile service
-  const devfile = await che.devfile.get();
-  return devfile.metadata?.attributes ? devfile.metadata.attributes.infrastructureNamespace : '';
+  return await che.workspace.getCurrentNamespace();
 }

--- a/plugins/resource-monitor-plugin/src/plugin.ts
+++ b/plugins/resource-monitor-plugin/src/plugin.ts
@@ -27,6 +27,9 @@ export async function start(context: theia.PluginContext): Promise<void> {
 }
 
 export async function getNamespace(): Promise<string> {
+  if (process.env.DEVWORKSPACE_NAMESPACE !== undefined) {
+    return process.env.DEVWORKSPACE_NAMESPACE;
+  }
   // get namespace from devfile service
   const devfile = await che.devfile.get();
   return devfile.metadata?.attributes ? devfile.metadata.attributes.infrastructureNamespace : '';

--- a/plugins/resource-monitor-plugin/tests/plugin.spec.ts
+++ b/plugins/resource-monitor-plugin/tests/plugin.spec.ts
@@ -107,6 +107,13 @@ describe('Test Plugin', () => {
       const namespace = await plugin.getNamespace();
       expect(namespace).toBe('che-namespace');
     });
+    test('read che namespace from env variable', async () => {
+      const DEV_WORKSPACE_NAMESPACE_NAME = 'devWorkspaceNamespace';
+      process.env.DEVWORKSPACE_NAMESPACE = DEV_WORKSPACE_NAMESPACE_NAME;
+      const namespace = await plugin.getNamespace();
+      expect(namespace).toBe(DEV_WORKSPACE_NAMESPACE_NAME);
+      process.env.DEVWORKSPACE_NAMESPACE = '';
+    });
     test('read che namespace from workspace service if no infrastructureNamespace attribute in devile metadata', async () => {
       const devfile = {
         metadata: {},

--- a/plugins/resource-monitor-plugin/tests/plugin.spec.ts
+++ b/plugins/resource-monitor-plugin/tests/plugin.spec.ts
@@ -69,20 +69,14 @@ const context: theia.PluginContext = {
 
 describe('Test Plugin', () => {
   jest.mock('../src/inversify-binding');
-  const devfileMock = jest.fn();
+  const getCurrentNamespace = jest.fn();
   let oldBindings: any;
   let initBindings: jest.Mock;
 
   beforeEach(() => {
     // Prepare Namespace
-    che.devfile.get = devfileMock;
-    const attributes = { infrastructureNamespace: 'che-namespace' };
-    const devfile = {
-      metadata: {
-        attributes,
-      },
-    };
-    devfileMock.mockReturnValue(devfile);
+    che.workspace.getCurrentNamespace = getCurrentNamespace;
+    getCurrentNamespace.mockReturnValue('che-namespace');
     oldBindings = InversifyBinding.prototype.initBindings;
     initBindings = jest.fn();
     InversifyBinding.prototype.initBindings = initBindings;
@@ -106,21 +100,6 @@ describe('Test Plugin', () => {
     test('read che namespace from devfile service', async () => {
       const namespace = await plugin.getNamespace();
       expect(namespace).toBe('che-namespace');
-    });
-    test('read che namespace from env variable', async () => {
-      const DEV_WORKSPACE_NAMESPACE_NAME = 'devWorkspaceNamespace';
-      process.env.DEVWORKSPACE_NAMESPACE = DEV_WORKSPACE_NAMESPACE_NAME;
-      const namespace = await plugin.getNamespace();
-      expect(namespace).toBe(DEV_WORKSPACE_NAMESPACE_NAME);
-      process.env.DEVWORKSPACE_NAMESPACE = '';
-    });
-    test('read che namespace from workspace service if no infrastructureNamespace attribute in devile metadata', async () => {
-      const devfile = {
-        metadata: {},
-      };
-      devfileMock.mockReturnValue(devfile);
-      const namespace = await plugin.getNamespace();
-      expect(namespace).toBe('');
     });
   });
 });


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Reads namespace's name form the environment variable

depends on devworkspace-operator 0.12.0 https://github.com/devfile/devworkspace-operator/pull/695

### Screenshot/screencast of this PR
![Screenshot from 2021-12-07 14-48-03](https://user-images.githubusercontent.com/1271546/145036249-b5b6a6d6-8c01-4288-bdc1-1e02fe3c6eed.png)

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20800

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
