### PR TITLE
fix: [devworkpsce-handler] Move project section from editor devfile to user devfile

### DIFF
--- a/tools/devworkspace-handler/src/generate.ts
+++ b/tools/devworkspace-handler/src/generate.ts
@@ -55,9 +55,9 @@ export class Generate {
     const editorDevfile = await this.pluginRegistryResolver.loadDevfilePlugin(editorEntry);
 
     if (project) {
-      editorDevfile.projects = [{ name: project.name, zip: { location: project.location } }];
+      devfile.projects = [{ name: project.name, zip: { location: project.location } }];
     } else {
-      editorDevfile.projects = [
+      devfile.projects = [
         {
           name: githubUrl.getRepoName(),
           git: { remotes: { origin: githubUrl.getCloneUrl() }, checkoutFrom: { revision: githubUrl.getBranchName() } },


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Move the generated `projects` section from the editor devfile to the user devfile.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
eclipse/che#20877

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Build the `devworkspace-handler` package
2. Run `node lib/entrypoint.js --devfile-url:https://github.com/che-samples/java-spring-petclinic/tree/devfilev2 --output-file:/Users/ivinokur/projects/che-theia/tools/devworkspace-handler/a.yaml` in the package root and see the default projects section exists in the user devfile of thegenerated template.
3. Run `node lib/entrypoint.js --devfile-url:https://github.com/che-samples/java-spring-petclinic/tree/devfilev2 --output-file:/Users/ivinokur/projects/che-theia/tools/devworkspace-handler/a.yaml --project.name={{DEVFILE_REGISTRY_URL}}/project.zip` and see the projects section with the specified projects in the zip format exists in the user devfile of thegenerated template.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
