### PR TITLE
chore(refactor): rename fields for ChePluginRegistry

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-command-contribution.ts
@@ -75,8 +75,8 @@ export class ChePluginCommandContribution implements CommandContribution {
 
     const registry: ChePluginRegistry = {
       name,
-      uri,
-      publicUri: uri,
+      internalURI: uri,
+      publicURI: uri,
     };
 
     this.chePluginManager.addRegistry(registry);

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-manager.ts
@@ -94,7 +94,7 @@ export class ChePluginManager {
       const oldPrefs = event.oldValue;
       if (oldPrefs) {
         for (const repoName of Object.keys(oldPrefs)) {
-          const registry = this.registryList.find(r => r.name === repoName && r.uri === oldPrefs[repoName]);
+          const registry = this.registryList.find(r => r.name === repoName && r.internalURI === oldPrefs[repoName]);
           if (registry) {
             this.registryList.splice(this.registryList.indexOf(registry), 1);
           }
@@ -103,7 +103,7 @@ export class ChePluginManager {
       const newPrefs = event.newValue;
       if (newPrefs) {
         for (const repoName of Object.keys(newPrefs)) {
-          this.registryList.push({ name: repoName, uri: newPrefs[repoName], publicUri: newPrefs[repoName] });
+          this.registryList.push({ name: repoName, internalURI: newPrefs[repoName], publicURI: newPrefs[repoName] });
         }
       }
       // notify that plugin registry list has been changed
@@ -111,7 +111,7 @@ export class ChePluginManager {
     });
     this.chePluginServiceClient.onInvalidRegistryFound(async registry => {
       const result = await this.messageService.warn(
-        `Invalid plugin registry URL: "${registry.uri}" is detected`,
+        `Invalid plugin registry URL: "${registry.internalURI}" is detected`,
         'Open settings.json'
       );
       if (result) {
@@ -154,12 +154,12 @@ export class ChePluginManager {
       Object.keys(prefs).forEach(repoName => {
         const uri = prefs[repoName];
 
-        const registry = this.registryList.find(r => r.uri === uri);
+        const registry = this.registryList.find(r => r.internalURI === uri);
         if (registry === undefined) {
           this.registryList.push({
             name: repoName,
-            uri: uri,
-            publicUri: uri,
+            internalURI: uri,
+            publicURI: uri,
           });
         }
       });
@@ -189,7 +189,7 @@ export class ChePluginManager {
     const prefs: { [index: string]: string } = {};
     this.registryList.forEach(r => {
       if (r.name !== 'Default') {
-        prefs[r.name] = r.uri;
+        prefs[r.name] = r.internalURI;
       }
     });
 
@@ -200,7 +200,7 @@ export class ChePluginManager {
   }
 
   removeRegistry(registry: ChePluginRegistry): void {
-    this.registryList = this.registryList.filter(r => r.uri !== registry.uri);
+    this.registryList = this.registryList.filter(r => r.internalURI !== registry.internalURI);
   }
 
   getRegistryList(): ChePluginRegistry[] {
@@ -236,7 +236,7 @@ export class ChePluginManager {
         .forEach(component => {
           const registryUrl = component.plugin?.registryUrl!;
           const name = component.plugin?.id!;
-          registries[name] = { name, uri: registryUrl, publicUri: registryUrl };
+          registries[name] = { name, internalURI: registryUrl, publicURI: registryUrl };
         });
     }
 
@@ -354,8 +354,8 @@ export class ChePluginManager {
     // we need to remove the registry URI from the start of the plugin
     const registries: string[] = [];
     this.registryList.forEach(registry => {
-      let uri = registry.uri;
-      if (uri === this.defaultRegistry.uri) {
+      let uri = registry.internalURI;
+      if (uri === this.defaultRegistry.internalURI) {
         return;
       }
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-service-client.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/plugin/che-plugin-service-client.ts
@@ -75,7 +75,7 @@ export class ChePluginServiceClientImpl implements ChePluginServiceClient {
 
   async invalidRegistryFound(registry: ChePluginRegistry): Promise<void> {
     this.onInvalidRegistryFoundEmitter.fire(registry);
-    console.log('Unable to read plugin registry', registry.uri);
+    console.log('Unable to read plugin registry', registry.internalURI);
   }
 
   async invalidPluginFound(pluginYaml: string): Promise<void> {

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-plugin-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-plugin-protocol.ts
@@ -13,11 +13,10 @@ import { JsonRpcServer } from '@theia/core';
 export interface ChePluginRegistry {
   // Display name
   name: string;
-  // Registry URI
-  // For default registry it's internal URI, taken from workspace settings
-  uri: string;
-  // Public URI to access the registry resources from browser
-  publicUri: string;
+  // Registry internal URI, is used for cross-container comnmunication.
+  internalURI: string;
+  // Public URI to access the registry resources from browser.
+  publicURI: string;
 }
 
 export interface ChePlugin {


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Renames some fields in ChePluginRegistry interface.

This PR contains some decoupled changes, introduced by https://github.com/eclipse-che/che-theia/pull/1267
Merging of this PR will simplify the reviewing of https://github.com/eclipse-che/che-theia/pull/1267

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
None

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
No issue


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
