### PR TITLE
chore: Rework GitHub authentication flow

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-frontend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-frontend-module.ts
@@ -11,15 +11,17 @@
 import '../../src/browser/style/che-plugins.css';
 import '../../src/browser/style/tasks.css';
 
-import { CHE_PLUGIN_SERVICE_PATH, ChePluginService, ChePluginServiceClient } from '../common/che-plugin-protocol';
 import {
+  CHE_GITHUB_SERVICE_PATH,
   CHE_PRODUCT_SERVICE_PATH,
   CHE_TASK_SERVICE_PATH,
+  CheGitHubService,
   CheProductService,
   CheSideCarContentReaderRegistry,
   CheTaskClient,
   CheTaskService,
 } from '../common/che-protocol';
+import { CHE_PLUGIN_SERVICE_PATH, ChePluginService, ChePluginServiceClient } from '../common/che-plugin-protocol';
 import { CheSideCarContentReaderRegistryImpl, CheSideCarResourceResolver } from './che-sidecar-resource';
 import { CommandContribution, ResourceResolver } from '@theia/core/lib/common';
 import { ContainerModule, interfaces } from 'inversify';
@@ -100,6 +102,13 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     .toDynamicValue(ctx => {
       const provider = ctx.container.get(WebSocketConnectionProvider);
       return provider.createProxy<CheProductService>(CHE_PRODUCT_SERVICE_PATH);
+    })
+    .inSingletonScope();
+
+  bind(CheGitHubService)
+    .toDynamicValue(ctx => {
+      const provider = ctx.container.get(WebSocketConnectionProvider);
+      return provider.createProxy<CheGitHubService>(CHE_GITHUB_SERVICE_PATH);
     })
     .inSingletonScope();
 

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-github-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-github-main.ts
@@ -24,9 +24,7 @@ export class CheGithubMainImpl implements CheGithubMain {
   }
 
   async $uploadPublicSshKey(publicKey: string): Promise<void> {
-    if (!this.token) {
-      throw new Error('GitHub authentication token is not setup');
-    }
+    this.checkToken();
     try {
       await this.axiosInstance.post(
         'https://api.github.com/user/keys',

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-github-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-github-main.ts
@@ -8,95 +8,56 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
+import { CheGitHubService, CheGithubMain } from '../common/che-protocol';
 import axios, { AxiosInstance } from 'axios';
 
-import { CheGithubMain } from '../common/che-protocol';
 import { GithubUser } from '@eclipse-che/plugin';
-import { OauthUtils } from '@eclipse-che/theia-remote-api/lib/browser/oauth-utils';
 import { interfaces } from 'inversify';
 
 export class CheGithubMainImpl implements CheGithubMain {
   private axiosInstance: AxiosInstance = axios;
   private token: string | undefined;
-  private readonly oAuthUtils: OauthUtils;
 
   constructor(container: interfaces.Container) {
-    this.oAuthUtils = container.get(OauthUtils);
+    const cheGitHubService: CheGitHubService = container.get(CheGitHubService);
+    cheGitHubService.getToken().then(token => (this.token = token));
   }
 
   async $uploadPublicSshKey(publicKey: string): Promise<void> {
+    if (!this.token) {
+      throw new Error('GitHub authentication token is not setup');
+    }
     try {
-      await this.fetchToken();
-      await this.uploadKey(publicKey);
+      await this.axiosInstance.post(
+        'https://api.github.com/user/keys',
+        {
+          title: 'che-theia',
+          key: publicKey,
+        },
+        { headers: { Authorization: `Bearer ${this.token}` } }
+      );
     } catch (error) {
       console.error(error.message);
       throw error;
     }
   }
 
-  async uploadKey(publicKey: string): Promise<void> {
-    await this.axiosInstance.post(
-      'https://api.github.com/user/keys',
-      {
-        title: 'che-theia',
-        key: publicKey,
-      },
-      { headers: { Authorization: `Bearer ${this.token}` } }
-    );
-  }
-
   async $getToken(): Promise<string> {
-    await this.fetchToken();
-    if (this.token) {
-      return this.token;
-    } else {
-      throw new Error('Failed to get GitHub authentication token');
-    }
+    this.checkToken();
+    return this.token ? this.token : '';
   }
 
   async $getUser(): Promise<GithubUser> {
-    await this.fetchToken();
-    return this.getUser();
-  }
-
-  private async getUser(): Promise<GithubUser> {
+    this.checkToken();
     const result = await this.axiosInstance.get<GithubUser>('https://api.github.com/user', {
       headers: { Authorization: `Bearer ${this.token}` },
     });
     return result.data;
   }
 
-  private async fetchToken(): Promise<void> {
+  checkToken(): void {
     if (!this.token) {
-      await this.updateToken();
-    } else {
-      try {
-        // Validate the GitHub token.
-        await this.getUser();
-      } catch (e) {
-        await this.updateToken();
-      }
-    }
-  }
-
-  private async updateToken(): Promise<void> {
-    const oAuthProvider = 'github';
-    const authenticateAndUpdateToken: () => Promise<void> = async () => {
-      await this.oAuthUtils.authenticate(oAuthProvider, ['repo', 'user', 'write:public_key']);
-      this.token = await this.oAuthUtils.getToken(oAuthProvider);
-    };
-
-    if (await this.oAuthUtils.isAuthenticated(oAuthProvider)) {
-      try {
-        // Validate the GitHub token.
-        await this.getUser();
-      } catch (e) {
-        if (/Request failed with status code 401/g.test(e.message)) {
-          await authenticateAndUpdateToken();
-        }
-      }
-    } else {
-      await authenticateAndUpdateToken();
+      throw new Error('GitHub authentication token is not setup');
     }
   }
 }

--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-github-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-github-main.ts
@@ -53,7 +53,7 @@ export class CheGithubMainImpl implements CheGithubMain {
     return result.data;
   }
 
-  checkToken(): void {
+  private checkToken(): void {
     if (!this.token) {
       throw new Error('GitHub authentication token is not setup');
     }

--- a/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/common/che-protocol.ts
@@ -535,6 +535,14 @@ export interface CheProductService {
   getProduct(): Promise<Product>;
 }
 
+export const CHE_GITHUB_SERVICE_PATH = '/che-github-service';
+
+export const CheGitHubService = Symbol('CheGitHubService');
+
+export interface CheGitHubService {
+  getToken(): Promise<string | undefined>;
+}
+
 export interface Product {
   // Product icon
   icon: string;

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-backend-module.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-backend-module.ts
@@ -8,19 +8,22 @@
  * SPDX-License-Identifier: EPL-2.0
  ***********************************************************************/
 
-import { CHE_PLUGIN_SERVICE_PATH, ChePluginService, ChePluginServiceClient } from '../common/che-plugin-protocol';
 import {
+  CHE_GITHUB_SERVICE_PATH,
   CHE_PRODUCT_SERVICE_PATH,
   CHE_TASK_SERVICE_PATH,
+  CheGitHubService,
   CheProductService,
   CheTaskClient,
   CheTaskService,
 } from '../common/che-protocol';
+import { CHE_PLUGIN_SERVICE_PATH, ChePluginService, ChePluginServiceClient } from '../common/che-plugin-protocol';
 import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core';
 
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
 import { CheClientIpServiceContribution } from './che-client-ip-service';
 import { CheEnvVariablesServerImpl } from './che-env-variables-server';
+import { CheGithubServiceImpl } from './che-github-service';
 import { ChePluginApiContribution } from './che-plugin-script-service';
 import { ChePluginApiProvider } from './che-plugin-api-provider';
 import { ChePluginServiceImpl } from './che-plugin-service';
@@ -80,6 +83,13 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(ConnectionHandler)
     .toDynamicValue(
       ctx => new JsonRpcConnectionHandler(CHE_PRODUCT_SERVICE_PATH, () => ctx.container.get(CheProductService))
+    )
+    .inSingletonScope();
+
+  bind(CheGitHubService).to(CheGithubServiceImpl).inSingletonScope();
+  bind(ConnectionHandler)
+    .toDynamicValue(
+      ctx => new JsonRpcConnectionHandler(CHE_GITHUB_SERVICE_PATH, () => ctx.container.get(CheGitHubService))
     )
     .inSingletonScope();
 });

--- a/extensions/eclipse-che-theia-plugin-ext/src/node/che-github-service.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/node/che-github-service.ts
@@ -1,0 +1,26 @@
+/**********************************************************************
+ * Copyright (c) 2018-2022 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ***********************************************************************/
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+
+import { CheGitHubService } from '../common/che-protocol';
+import { injectable } from 'inversify';
+
+@injectable()
+export class CheGithubServiceImpl implements CheGitHubService {
+  async getToken(): Promise<string | undefined> {
+    const credentialsPath = path.resolve(os.homedir(), '.git-credentials', 'credentials');
+    if (fs.existsSync(credentialsPath)) {
+      const token = fs.readFileSync(credentialsPath).toString();
+      return token.substring(token.lastIndexOf(':') + 1, token.indexOf('@'));
+    }
+  }
+}

--- a/plugins/github-auth-plugin/src/github-auth-plugin.ts
+++ b/plugins/github-auth-plugin/src/github-auth-plugin.ts
@@ -23,10 +23,13 @@ export async function start(context: theia.PluginContext): Promise<void> {
     onDidChangeSessions: onDidChangeSessions.event,
     getSessions: async () => sessions,
     login: async (scopes: string[]) => {
-      if (!(await che.oAuth.isRegistered('github'))) {
+      let token = '';
+      try {
+        token = await che.github.getToken();
+      } catch (e) {
         if (
           await theia.window.showWarningMessage(
-            'Che could not authenticate to your Github account. The setup for Github OAuth provider is not complete.',
+            'Github token is not setup. Try to create a factory with a private project and try again',
             'Setup instructions'
           )
         ) {
@@ -35,12 +38,11 @@ export async function start(context: theia.PluginContext): Promise<void> {
             'https://www.eclipse.org/che/docs/che-7/administration-guide/configuring-authorization/#configuring-github-oauth_che'
           );
         }
-        return;
       }
       const githubUser = await che.github.getUser();
       const session = {
         id: v4(),
-        accessToken: await che.github.getToken(),
+        accessToken: token,
         account: { label: githubUser.login, id: githubUser.id.toString() },
         scopes,
       };

--- a/plugins/github-auth-plugin/src/github-auth-plugin.ts
+++ b/plugins/github-auth-plugin/src/github-auth-plugin.ts
@@ -29,7 +29,7 @@ export async function start(context: theia.PluginContext): Promise<void> {
       } catch (e) {
         if (
           await theia.window.showWarningMessage(
-            'Github token is not setup. Try to create a factory with a private project and try again',
+            'Che could not authenticate to your Github account. The setup for Github OAuth provider is not complete.',
             'Setup instructions'
           )
         ) {


### PR DESCRIPTION
Signed-off-by: Igor Vinokur <ivinokur@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Exclude che-server requests from the GitHub authentication flow, instead read credentials file, mounted from the `github-credentials-secret` and extract the GitHub token.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->

fixes https://github.com/eclipse/che/issues/20995
fixes https://github.com/eclipse/che/issues/20788
### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

1. Make sure that the GitHub is configured: https://www.eclipse.org/che/docs/next/administration-guide/configuring-authorization/#enabling-authentication-with-social-accounts-and-brokering_che
2. Create a factory with a private repo e.g. `<che-url>/#https://github.com/vinokurig/test-extension/tree/devfile2` to authenticate GitHub for the user namespace.
3. Run `Git: Clone` and input a git url to a private repo e.g. `https://github.com/vinokurig/test-extension.git`:
![screenshot-192 168 64 128 nip io-2022 01 17-13_37_02](https://user-images.githubusercontent.com/7668752/149763046-13eab33e-bcdd-4411-91e5-b6067c16a0b7.png)
4. Choose a folder to clone and click `Allow' button in the notification:
![screenshot-192 168 64 128 nip io-2022 01 17-13_37_44](https://user-images.githubusercontent.com/7668752/149763201-d96863a9-db26-49d8-8c24-83118e5d8482.png)
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
