### PR TITLE
fix: ensure names are not > 63 characters

### DIFF
--- a/tools/devworkspace-handler/src/devfile/devworkspace-updater.ts
+++ b/tools/devworkspace-handler/src/devfile/devworkspace-updater.ts
@@ -80,7 +80,7 @@ export class DevWorkspaceUpdater {
 
     // finally, update dev container component with extensions to be deployed there
     if (extensionsForDevContainer) {
-      this.devContainerComponentUpdater.insert(devfileContext, extensionsForDevContainer);
+      await this.devContainerComponentUpdater.insert(devfileContext, extensionsForDevContainer);
     }
 
     // and add them

--- a/tools/devworkspace-handler/src/devfile/sidecar-components-creator.ts
+++ b/tools/devworkspace-handler/src/devfile/sidecar-components-creator.ts
@@ -27,7 +27,9 @@ export class SidecarComponentsCreator {
   ): Promise<V1alpha2DevWorkspaceSpecTemplateComponents[]> {
     // ok now add sidecar components
     return extensionsWithSidecars.map(entry => {
-      const sidecarName = entry.sidecarName || `sidecar-${entry.id.replace(/[^\w\s]/gi, '-')}`;
+      // ensure it's max 63 characters
+      const sidecarName = (entry.sidecarName || `sidecar-${entry.id.replace(/[^\w\s]/gi, '-')}`).substring(0, 63);
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const attributes: { [key: string]: any } = {
         'app.kubernetes.io/part-of': 'che-theia.eclipse.org',

--- a/tools/devworkspace-handler/tests/devfile/sidecar-components-creator.spec.ts
+++ b/tools/devworkspace-handler/tests/devfile/sidecar-components-creator.spec.ts
@@ -63,18 +63,25 @@ describe('Test SidecarComponentsCreator', () => {
 
   test('basics no sidecarname and preferences', async () => {
     const entry: VSCodeExtensionEntryWithSidecar = {
-      id: 'plugin',
+      id: 'merged-registry-redhat-io-codeready-workspaces-plugin-java8-rhel8-sha256-f0ecc1812888611407c23ede1d3952dfb7b9bd597c336f22995cc4d8d9c23edd',
       resolved: true,
       extensions: ['http://first.vsix'],
       sidecar: {
-        image: 'my-image',
+        image:
+          'registry.redhat.io/codeready-workspaces/plugin-java8-rhel8@sha256:f0ecc1812888611407c23ede1d3952dfb7b9bd597c336f22995cc4d8d9c23edd',
       },
     };
     const components = await sidecarComponentsCreator.create([entry]);
-    expect(containerPluginRemoteUpdaterUpdateMethod).toBeCalledWith(`sidecar-${entry.id}`, entry.sidecar);
+    expect(containerPluginRemoteUpdaterUpdateMethod).toBeCalledWith(
+      'sidecar-merged-registry-redhat-io-codeready-workspaces-plugin-j',
+      entry.sidecar
+    );
     expect(components.length).toBe(1);
     const component = components[0];
-    expect(component.name).toBe(`sidecar-${entry.id}`);
+    expect(component.name).toBe('sidecar-merged-registry-redhat-io-codeready-workspaces-plugin-j');
+    // check length is cut to 63 characters
+    expect(component.name.length).toBe(63);
+
     expect(component.container).toBe(entry.sidecar);
     const componentAttributes = component.attributes || ({} as any);
     expect(componentAttributes['app.kubernetes.io/part-of']).toBe('che-theia.eclipse.org');


### PR DESCRIPTION
### What does this PR do?
Make sure generated names are not greater than 63 characters

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21040
https://issues.redhat.com/browse/CRW-2651

### How to test this PR?
1. Launch CRW registry 
docker run --rm -it -p 8080:8080 quay.io/crw/pluginregistry-rhel8:2.14

2. Launch the command
```
$ npx @eclipse-che/che-theia-devworkspace-handler --devfile-url:https://github.com/crw-samples/nodejs-configmap/tree/devfilev2 --editor:eclipse/che-theia/latest --plugin-registry-url:http://localhost:8080/v3 --output-file:/tmp/foo.yaml --sidecar-policy:mergeImage
```

3. now, create a devWorkspace from the /tmp/foo.yam file
oc apply -f /tmp/foo.yaml

and it's failing with 
```
The DevWorkspace "nodejs-configmap" is invalid: spec.template.components.name: Invalid value: "sidecar-merged-registry-redhat-io-codeready-workspaces-plugin-java8-rhel8-2-14": spec.template.components.name in body should be at most 63 chars long
```

4, now check that with this PR it's fixing the issue
go to tools/devworkspace-handler and run `yarn`

then: 
```
node lib/entrypoint.js --devfile-url:https://github.com/crw-samples/nodejs-configmap/tree/devfilev2 --editor:eclipse/che-theia/latest --plugin-registry-url:http://localhost:8080/v3 --output-file:/tmp/foo2.yaml --sidecar-policy:mergeImage
```

and create a DevWorkspace from foo2.yaml
```
$ oc apply -f /tmp/foo2.yaml
devworkspacetemplate.workspace.devfile.io/theia-ide-nodejs-configmap configured
devworkspace.workspace.devfile.io/nodejs-configmap created
```

and check that there is no more error

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [x] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable

Change-Id: I7d60970285e7405698f8528fa447b97920c6b517
Signed-off-by: Florent Benoit <fbenoit@redhat.com>