### PR TITLE
fix: CRW-2656 - include BOTH node-addon-api 1.7.2 and 3.1.0; remove refs to keytar 7.2.0 since we include 7.6.0

### DIFF
--- a/generator/tests/init-sources/templates/theia-core-package.json
+++ b/generator/tests/init-sources/templates/theia-core-package.json
@@ -47,7 +47,7 @@
     "iconv-lite": "^0.6.0",
     "inversify": "^5.1.1",
     "jschardet": "^2.1.1",
-    "keytar": "7.2.0",
+    "keytar": "7.6.0",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "nsfw": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "if-env": "^1.0.4",
     "import-sort-style-eslint": "^6.0.0",
     "lerna": "^2.11.0",
-    "node-addon-api": "3.1.0",
+    "node-addon-api": "1.7.2",
+    "node-addon-api-latest": "npm:node-addon-api@3.1.0",
     "prettier": "^2.2.0",
     "prettier-plugin-import-sort": "^0.0.6",
     "rimraf": "3.0.2",
@@ -42,6 +43,8 @@
   "resolutions": {
     "dot-prop": "^5.2.0",
     "elliptic": "^6.5.3",
+    "node-addon-api": "1.7.2",
+    "node-addon-api-latest": "npm:node-addon-api@3.1.0",
     "serialize-javascript": "^3.1.0",
     "**/**/@types/node": "^12.0.0",
     "**/**/minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,6 @@
   "resolutions": {
     "dot-prop": "^5.2.0",
     "elliptic": "^6.5.3",
-    "node-addon-api": "1.7.2",
-    "node-addon-api-latest": "npm:node-addon-api@3.1.0",
     "serialize-javascript": "^3.1.0",
     "**/**/@types/node": "^12.0.0",
     "**/**/minimist": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1771,7 +1771,7 @@
     iconv-lite "^0.6.0"
     inversify "^5.1.1"
     jschardet "^2.1.1"
-    keytar "7.2.0"
+    keytar "7.6.0"
     lodash.debounce "^4.0.8"
     lodash.throttle "^4.1.1"
     nsfw "^2.1.2"
@@ -1840,7 +1840,7 @@
     iconv-lite "^0.6.0"
     inversify "^5.1.1"
     jschardet "^2.1.1"
-    keytar "7.2.0"
+    keytar "7.6.0"
     lodash.debounce "^4.0.8"
     lodash.throttle "^4.1.1"
     nsfw "^2.1.2"
@@ -10693,12 +10693,12 @@ jszip@^3.1.5:
     readable-stream "~2.3.6"
     set-immediate-shim "~1.0.1"
 
-keytar@7.2.0, keytar@7.6.0:
+keytar@7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/keytar/-/keytar-7.6.0.tgz#498e796443cb543d31722099443f29d7b5c44100"
   integrity sha512-H3cvrTzWb11+iv0NOAnoNAPgEapVZnYLVHZQyxmh7jdmVfR/c0jNNFEZ6AI38W/4DeTGTaY66ZX4Z1SbfKPvCQ==
   dependencies:
-    node-addon-api "3.1.0"
+    node-addon-api-latest "3.1.0"
     prebuild-install "^6.0.0"
 
 keyv@3.0.0:
@@ -11707,7 +11707,7 @@ node-addon-api@^1.7.1:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
-node-addon-api@3.1.0:
+node-addon-api-latest@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.1.0.tgz#98b21931557466c6729e51cb77cd39c965f42239"
   integrity sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==


### PR DESCRIPTION
### What does this PR do?

fix: CRW-2656 - include BOTH node-addon-api 1.7.2 and 3.1.0; remove refs to keytar 7.2.0 since we include 7.6.0

Change-Id: I833f9afc910c6ff986b8dd50775eec97d03542e1
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

https://issues.redhat.com/browse/CRW-2656?focusedCommentId=19630563&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-19630563

According to https://medium.com/weekly-webtips/how-to-install-multiple-versions-of-the-same-package-in-npm-71c29b12e253 this is a reasonable way to hard-include two versions of a js package dependency.

### How to test this PR?

See https://github.com/eclipse-che/che-theia/pull/1303

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.