### PR TITLE
fix: Unpack Che-Theia plugins at building image step

### DIFF
--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -52,6 +52,7 @@ init() {
   TAG="next"
   DRY_RUN=false
   DOCKER_BUILD_TARGET=""
+  UNPACK_CHE_THEIA_PLUGINS="true"
   SKIP_TESTS=false
   NAME="che"
   ARGS=""
@@ -95,6 +96,9 @@ init() {
         shift ;;
       --skip-tests)
         SKIP_TESTS=true
+        shift ;;
+      --compressed-plugins)
+        prepare_build_args UNPACK_CHE_THEIA_PLUGINS="false"
         shift ;;
       --dockerfile:*)
         DOCKERFILE="${1#*:}"

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -30,6 +30,9 @@ ENV NODE_OPTIONS="--max-old-space-size=4096"
 # avoid any linter/formater/unit test
 ENV SKIP_LINT=true SKIP_FORMAT=true SKIP_TEST=true
 
+# if true - then unpack che-theia plugins at building image step
+ENV UNPACK_CHE_THEIA_PLUGINS=true
+
 #{IF:DO_REMOTE_CHECK}
 # Invalidate cache if any source code has changed
 ADD https://${GITHUB_TOKEN}:x-oauth-basic@api.github.com/repos/${THEIA_GITHUB_REPO}/git/${GIT_REF} /tmp/branch_info.json
@@ -95,6 +98,8 @@ RUN if [ -z $GITHUB_TOKEN ]; then unset GITHUB_TOKEN; fi && \
 # Add yeoman generator & vscode git plug-ins
 COPY asset-untagged-theia_yeoman_plugin.theia /home/theia-dev/theia-source-code/production/plugins/theia_yeoman_plugin.theia
 
+# unpack che-theia plugins at building image step to avoid unpacking the plugins at starting IDE step and reduce Che-Theia start time
+RUN if [ "$UNPACK_CHE_THEIA_PLUGINS" = "true" ]; then cd plugins && ./unpack_che-theia_plugins; fi
 
 # Use node image
 #{INCLUDE:docker/${BUILD_IMAGE_TARGET}/build-result-from.dockerfile}

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -31,7 +31,7 @@ ENV NODE_OPTIONS="--max-old-space-size=4096"
 ENV SKIP_LINT=true SKIP_FORMAT=true SKIP_TEST=true
 
 # if true - then unpack che-theia plugins at building image step
-ENV UNPACK_CHE_THEIA_PLUGINS=true
+ARG UNPACK_CHE_THEIA_PLUGINS="true"
 
 #{IF:DO_REMOTE_CHECK}
 # Invalidate cache if any source code has changed

--- a/dockerfiles/theia/README.md
+++ b/dockerfiles/theia/README.md
@@ -35,7 +35,7 @@ This script will build new docker image `eclipse/che-theia:next`. The image will
 General command to build Che-Theia with all possible argiments:
 
 ```bash
-./build.sh --build-args:GITHUB_TOKEN=${GITHUB_TOKEN},THEIA_VERSION=${THEIA_VERSION} --tag:${IMAGE_TAG} --branch:${THEIA_BRANCH} --git-ref:${THEIA_GIT_REFS} --skip-tests
+./build.sh --build-args:GITHUB_TOKEN=${GITHUB_TOKEN},THEIA_VERSION=${THEIA_VERSION} --tag:${IMAGE_TAG} --branch:${THEIA_BRANCH} --git-ref:${THEIA_GIT_REFS} --skip-tests --compressed-plugins
 ```
 
 ### GitHub Token
@@ -107,6 +107,14 @@ This parameter is optional. Default value is `'refs\\/heads\\/master'`.
 Add this parameter to the build command to have a quick build and to skip running tests in dedicated container.
 
 By default tests are turned on.
+
+## Use compressed Che-Theia plugins
+
+**`--compressed-plugins`**
+
+Che-Theia plugins are unpacked at building image step by default. It allows to reduce a delay at starting IDE step, but the side effect is - enlarged docker image. Add this parameter to reduce docker image size and skip unpacking Che-Theia plugins at building docker image step.
+
+This parameter is optional. 
 
 ## Build only for specific type of Docker images (Alpine, UBI8, etc.)
 

--- a/generator/src/foreach_yarn
+++ b/generator/src/foreach_yarn
@@ -13,7 +13,7 @@ const path = require('path');
 const spawnSync = require('child_process').spawnSync;
 
 const currentDir = __dirname;
-const targetDir = `${__dirname}/../production/plugins`
+const targetDir = `${__dirname}/../production/plugins`;
 
 mkdirSyncRecursive(targetDir);
 

--- a/generator/src/init.ts
+++ b/generator/src/init.ts
@@ -48,6 +48,10 @@ export class Init {
         // copy build all plugins scripts
         await fs.ensureDir(this.pluginsFolder);
         await fs.copy(path.resolve(__dirname, '../src/foreach_yarn'), path.join(this.pluginsFolder, 'foreach_yarn'));
+        await fs.copy(
+            path.resolve(__dirname, '../src/unpack_che-theia_plugins'),
+            path.join(this.pluginsFolder, 'unpack_che-theia_plugins')
+        );
     }
 
     async updadeBuildConfiguration(extensions: ISource[]): Promise<void> {

--- a/generator/src/unpack_che-theia_plugins
+++ b/generator/src/unpack_che-theia_plugins
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/*********************************************************************
+* Copyright (c) 2022 Red Hat, Inc.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+**********************************************************************/
+const fs = require('fs');
+const decompress = require('decompress');
+const pluginsDir = `${__dirname}/../production/plugins`;
+
+fs.readdirSync(`${pluginsDir}`).forEach(async (pluginEntry) => {
+    if (pluginEntry.endsWith('.theia')) {
+        console.log(`\n✍️  Trying to decompress ${pluginEntry} package to ${pluginsDir}/${pluginEntry}`);
+
+        const unpackedPluginFolderName = pluginEntry.substring(0, pluginEntry.lastIndexOf('.theia'));
+        const decompressPromise = decompress(`${pluginsDir}/${pluginEntry}`, `${pluginsDir}/${unpackedPluginFolderName}`);
+
+        decompressPromise.then(() => {
+            console.log(`\n✍️  Removing ${pluginsDir}/${pluginEntry} after decompressing`);
+            fs.unlink(`${pluginsDir}/${pluginEntry}`, () => { });
+        }, error => {
+            console.error(`\n✍️  Decompressing ${pluginEntry} package to ${pluginsDir}/${pluginEntry} failed: `, error);
+        });
+    }
+});


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
At the moment `Che-Theia` plugins are unpacked at starting IDE step. As result - we have a delay at that step. Please see https://github.com/eclipse/che/issues/20861#issuecomment-1018632823.

The PR allows:
- unpack `Che-Theia` plugins at building images step by default
- reduce the delay at starting IDE step
- ability to turn On and turn Off unpacking `Che-Theia` plugins at building images step

The side effect is - enlarged docker image.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
Please see videos [here](https://github.com/eclipse/che/issues/20861#issuecomment-1018632823)

https://user-images.githubusercontent.com/5676062/151932025-b20be7d8-b9c3-444a-a792-00b630f1c559.mp4



### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/20861

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Try to build `eclipse/che-theia:next`image as usual, like `./build.sh --dockerfile:Dockerfile.alpine` from the root.
By default it should unpack `Che-Theia` plugins at building an image step. 

As result:
- no delay at starting IDE step
- but enlarged docker image
2. Try to build `eclipse/che-theia:next`image using `--compressed-plugins`parameter, like `./build.sh --dockerfile:Dockerfile.alpine --compressed-plugins` from the root. 

As result:
- a delay at starting IDE step
- but docker image should have usual size

So, the second use case should have the the same behaviour as we have right now for the `main` branch.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
