### PR TITLE
feat(terminal): Filter the containers list at a terminal creation

### DIFF
--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-workspace-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-workspace-service-impl.ts
@@ -132,7 +132,7 @@ export class K8sWorkspaceServiceImpl implements WorkspaceService {
       const devfile = await this.devfileService.get();
       (devfile.components || []).forEach(component => {
         if (component.container && component.name) {
-          const container: Container = { name: component.name };
+          const container: Container = { name: component.name, attributes: component.attributes };
           containers.push(container);
         }
       });

--- a/extensions/eclipse-che-theia-terminal/src/browser/contribution/exec-terminal-contribution.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/contribution/exec-terminal-contribution.ts
@@ -36,20 +36,11 @@ import { filterDevContainers } from './terminal-command-filter';
 import { isOSX } from '@theia/core/lib/common/os';
 
 /**
- * The command should display all containers at a terminal creation,
- * {@link NewTerminal} should be used to display only developer containers
+ * The command creates a terminal in the given container.
+ * Only developer containers are displayed as quick-pick items if no container is passed for the command execution.
  */
 export const NewTerminalInSpecificContainer = {
   id: 'terminal-in-specific-container:new',
-  label: 'New Terminal in specific container',
-};
-
-/**
- * The command should display only developer containers at a terminal creation,
- * {@link NewTerminalInSpecificContainer} should be used to display all containers
- */
-export const NewTerminal = {
-  id: 'che-terminal:new',
   label: 'New Terminal',
 };
 
@@ -87,18 +78,6 @@ export class ExecTerminalFrontendContribution extends TerminalFrontendContributi
     const serverUrl = await this.termApiEndPointProvider();
     if (serverUrl) {
       registry.registerCommand(NewTerminalInSpecificContainer, {
-        execute: (containerNameToExecute: string) => {
-          if (containerNameToExecute) {
-            this.openTerminalByContainerName(containerNameToExecute);
-          } else {
-            this.terminalQuickOpen.displayAllContainers(containerName => {
-              this.openTerminalByContainerName(containerName);
-            });
-          }
-        },
-      });
-
-      registry.registerCommand(NewTerminal, {
         execute: (containerNameToExecute: string) => {
           if (containerNameToExecute) {
             this.openTerminalByContainerName(containerNameToExecute);
@@ -321,8 +300,8 @@ export class ExecTerminalFrontendContribution extends TerminalFrontendContributi
     if (serverUrl) {
       menus.registerSubmenu(TerminalMenus.TERMINAL, 'Terminal');
       menus.registerMenuAction(TerminalMenus.TERMINAL_NEW, {
-        commandId: NewTerminal.id,
-        label: NewTerminal.label,
+        commandId: NewTerminalInSpecificContainer.id,
+        label: NewTerminalInSpecificContainer.label,
       });
     } else {
       super.registerMenus(menus);
@@ -349,13 +328,8 @@ export class ExecTerminalFrontendContribution extends TerminalFrontendContributi
     const serverUrl = await this.termApiEndPointProvider();
     if (serverUrl) {
       registry.registerKeybinding({
-        command: NewTerminal.id,
-        keybinding: isOSX ? 'ctrl+shift+`' : 'ctrl+`',
-      });
-
-      registry.registerKeybinding({
         command: NewTerminalInSpecificContainer.id,
-        keybinding: 'shift+alt+`',
+        keybinding: isOSX ? 'ctrl+shift+`' : 'ctrl+`',
       });
 
       registry.registerKeybinding({

--- a/extensions/eclipse-che-theia-terminal/src/browser/contribution/terminal-command-filter.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/contribution/terminal-command-filter.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (c) 2018-2020 Red Hat, Inc.
+ * Copyright (c) 2018-2022 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,20 +10,53 @@
 
 import { Container } from '@eclipse-che/theia-remote-api/lib/common/workspace-service';
 
+/**
+ * @deprecated There is not anymore such value for attributes
+ */
 export const RECIPE_CONTAINER_SOURCE = 'recipe';
+/**
+ * @deprecated There is not anymore such attribute
+ */
 export const CONTAINER_SOURCE_ATTRIBUTE = 'source';
+
+/** Marker for an attribute like: app.kubernetes.io/part-of */
+const PART_OF_ATTRIBUTE_MARKER = 'part-of';
+/** Value for the attribute app.kubernetes.io/part-of */
+const TOOLING_CONTAINER_MARKER = 'che-theia.eclipse.org';
 
 /**
  * Return list containers with recipe source attribute.
+ *
+ * @deprecated use {@link filterDevContainers()} instead
  */
 export function filterRecipeContainers(containers: Container[]): Container[] {
   return containers.filter(container => isDevContainer(container));
 }
 
 export function isDevContainer(container: Container): boolean {
-  return (
-    container.attributes !== undefined &&
-    (!container.attributes[CONTAINER_SOURCE_ATTRIBUTE] ||
-      container.attributes[CONTAINER_SOURCE_ATTRIBUTE] === RECIPE_CONTAINER_SOURCE)
-  );
+  return !isToolingContainer(container);
+}
+
+/**
+ * Return list Developer containers.
+ */
+export function filterDevContainers(containers: Container[]): Container[] {
+  return containers.filter(container => isDevContainer(container));
+}
+
+export function isToolingContainer(container: Container): boolean {
+  const attribute = findAttributeByAttributeEnding(PART_OF_ATTRIBUTE_MARKER, container.attributes);
+  return !!attribute && attribute === TOOLING_CONTAINER_MARKER;
+}
+
+function findAttributeByAttributeEnding(ending: string, attributes?: { [key: string]: string }): string | undefined {
+  if (!attributes) {
+    return undefined;
+  }
+
+  for (const attribute in attributes) {
+    if (attributes.hasOwnProperty(attribute) && attribute.endsWith(ending)) {
+      return attributes[attribute];
+    }
+  }
 }

--- a/extensions/eclipse-che-theia-terminal/src/browser/contribution/terminal-quick-open.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/contribution/terminal-quick-open.ts
@@ -31,9 +31,6 @@ export class TerminalQuickOpenService {
   @inject(KeybindingRegistry)
   protected readonly keybindingRegistry: KeybindingRegistry;
 
-  @inject('terminal-in-specific-container-command-id')
-  protected readonly terminalInSpecificContainerCommandId: string;
-
   async displayListMachines(doOpen: OpenTerminalHandler): Promise<void> {
     this.items = [];
 
@@ -75,15 +72,5 @@ export class TerminalQuickOpenService {
     this.items.push(...devContainerItems, ...toolingContainerItems);
 
     this.quickInputService.showQuickPick(this.items, { placeholder: 'Select container to create new terminal' });
-  }
-
-  protected getShortCutCommand(): string | undefined {
-    const keyCommand = this.keybindingRegistry.getKeybindingsForCommand(this.terminalInSpecificContainerCommandId);
-    if (keyCommand) {
-      const accel = this.keybindingRegistry.acceleratorFor(keyCommand[0], '+');
-      return accel.join(' ');
-    }
-
-    return undefined;
   }
 }

--- a/extensions/eclipse-che-theia-terminal/src/browser/contribution/terminal-quick-open.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/contribution/terminal-quick-open.ts
@@ -29,44 +29,8 @@ export class TerminalQuickOpenService {
   @inject(KeybindingRegistry)
   protected readonly keybindingRegistry: KeybindingRegistry;
 
-  /** @deprecated use {@link displayContainers} or {@link displayAllContainers} instead */
+  /** @deprecated use {@link displayContainers} instead */
   async displayListMachines(doOpen: OpenTerminalHandler): Promise<void> {
-    return this.displayAllContainers(doOpen);
-  }
-
-  async displayContainers(
-    containers: Container[],
-    doOpen: OpenTerminalHandler,
-    showAllItem: boolean = true
-  ): Promise<void> {
-    if (containers.length < 1) {
-      return;
-    }
-
-    const items: QuickPickItem[] = containers.map(
-      container =>
-        ({
-          label: container.name,
-          execute: () => {
-            setTimeout(() => doOpen(container.name), 0);
-          },
-        } as QuickPickItem)
-    );
-
-    if (showAllItem) {
-      items.push({ type: 'separator', label: '' });
-      items.push({
-        label: 'Show All Containers...',
-        execute: () => {
-          setTimeout(() => this.displayAllContainers(doOpen), 0);
-        },
-      } as QuickPickItem);
-    }
-
-    this.quickInputService.showQuickPick(items, { placeholder: 'Select a container to create a new terminal' });
-  }
-
-  async displayAllContainers(doOpen: OpenTerminalHandler): Promise<void> {
     const items = [];
 
     const containers = await this.workspaceService.getContainerList();
@@ -106,5 +70,23 @@ export class TerminalQuickOpenService {
     items.push(...devContainerItems, ...toolingContainerItems);
 
     this.quickInputService.showQuickPick(items, { placeholder: 'Select container to create a new terminal' });
+  }
+
+  async displayContainers(containers: Container[], doOpen: OpenTerminalHandler): Promise<void> {
+    if (containers.length < 1) {
+      return;
+    }
+
+    const items: QuickPickItem[] = containers.map(
+      container =>
+        ({
+          label: container.name,
+          execute: () => {
+            setTimeout(() => doOpen(container.name), 0);
+          },
+        } as QuickPickItem)
+    );
+
+    this.quickInputService.showQuickPick(items, { placeholder: 'Select a container to create a new terminal' });
   }
 }

--- a/extensions/eclipse-che-theia-terminal/src/browser/terminal-frontend-module.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/terminal-frontend-module.ts
@@ -9,10 +9,6 @@
  ***********************************************************************/
 
 import { Container, ContainerModule, interfaces } from 'inversify';
-import {
-  ExecTerminalFrontendContribution,
-  NewTerminalInSpecificContainer,
-} from './contribution/exec-terminal-contribution';
 import { KeybindingContext, QuickAccessContribution, WidgetFactory } from '@theia/core/lib/browser';
 import {
   REMOTE_TERMINAL_TARGET_SCOPE,
@@ -34,6 +30,7 @@ import { TerminalWidget, TerminalWidgetOptions } from '@theia/terminal/lib/brows
 
 import { EndpointService } from '@eclipse-che/theia-remote-api/lib/common/endpoint-service';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { ExecTerminalFrontendContribution } from './contribution/exec-terminal-contribution';
 import { RemoteTerminaActiveKeybingContext } from './contribution/keybinding-context';
 import { RemoteWebSocketConnectionProvider } from './server-definition/remote-connection';
 import { TerminalFrontendContribution } from '@theia/terminal/lib/browser/terminal-frontend-contribution';

--- a/extensions/eclipse-che-theia-terminal/src/browser/terminal-frontend-module.ts
+++ b/extensions/eclipse-che-theia-terminal/src/browser/terminal-frontend-module.ts
@@ -46,9 +46,6 @@ import { createTerminalSearchFactory } from '@theia/terminal/lib/browser/search/
 
 export default new ContainerModule(
   (bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind) => {
-    // bind this contstant to prevent circle dependency
-    bind('terminal-in-specific-container-command-id').toConstantValue(NewTerminalInSpecificContainer.id);
-
     bind(KeybindingContext).to(RemoteTerminaActiveKeybingContext).inSingletonScope();
 
     bind(RemoteTerminalWidget).toSelf();


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- add attributes of a component to `Container` object
- rename `Open Terminal in specific container` menu item to `New Terminal` - it should display **only** `Developer` containers at a terminal creation. The command creates a terminal in the editor container if there is no a `Developer` container.

![Screenshot 2022-02-17 at 17 50 08](https://user-images.githubusercontent.com/5676062/154518597-046e7ae7-2db7-4d64-96ff-ac73eafa2b0a.png)

- add a new command `New Terminal in specific container` - it should display **all** containers at a terminal creation.
- add a hotkey for the `New Terminal in specific container` command

![Screenshot 2022-02-17 at 17 53 04](https://user-images.githubusercontent.com/5676062/154519325-f1bc32a1-42e2-4561-8eeb-7dc55df84a46.png)

- add `Show All Containers` item at displaying list of `Developer` containers. 

![Screenshot 2022-02-17 at 18 02 33](https://user-images.githubusercontent.com/5676062/154521228-748d24d6-9c09-4e0c-a0e1-78d890af544f.png)

There are few ways to create a terminal in a `Developer` container:
- go to `Terminal` `=>` `New Terminal` menu item
- using a hotkey ``` ctrl+shift+` ```
- using the corresponding command `F1` `=>` `New Terminal` 

There are few ways to create a terminal in a `Tooling` container:
- go to `Terminal` `=>` `New Terminal` menu item `=>` `Show All Containers` item
- using a hotkey ``` shift+alt+` ```
- using the corresponding command `F1` `=>` `New Terminal in specific container` 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
There are no dev containers - a terminal should be created in the editor container, don't ask user which container should be used

https://user-images.githubusercontent.com/5676062/154535958-0a3c35e5-4fc2-457d-b560-4da7723ba779.mp4

There is only one dev container - a terminal should be created in the container, don't ask user which container should be used


https://user-images.githubusercontent.com/5676062/154539637-477b3bfd-25b1-4083-8258-3eb827fe611e.mp4

There are few Dev containers


https://user-images.githubusercontent.com/5676062/154542904-e5305db6-66cf-4747-8974-77b4aedd4403.mp4





### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21117

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
 You can use my images for testing, just add to your instance the following:
 `#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?che-editor=https://raw.githubusercontent.com/RomanNikitenko/che-editor-test/main/.che/che-editor.yaml`,
 like:
 `https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?che-editor=https://raw.githubusercontent.com/RomanNikitenko/che-editor-test/main/.che/che-editor.yaml`
 
1. A workspace has few `Developer` containers and few `Tooling` containers:
- `New Terminal` command should display list of `Developer` containers and `Show All Containers` item
-  click on `Show All Containers` item should display **all** containers
- `New Terminal in specific container` command should display **all** containers

2. A workspace has **only one** `Developer` container:
- `New Terminal` command should create a terminal in the `Developer` container and don't ask user about containers (don't display the list of containers)

3. A workspace doesn't have any `Developer` containers: 
- `New Terminal` command should create a terminal in the editor container and don't ask user about containers (don't display the list of containers)




### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
