### PR TITLE
feat: Use of nodejs 14 for the runtime

### DIFF
--- a/.github/workflows/check-theia-branch.yml
+++ b/.github/workflows/check-theia-branch.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/setup-node@v1
       name: Configuring nodejs 12.x version
       with:
-        node-version: '12.x'
+        node-version: '14.x'
     - name: build
       run: |
         docker image prune -a -f

--- a/.github/workflows/happy-path-tests.yaml
+++ b/.github/workflows/happy-path-tests.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-node@v1
         name: Configuring nodejs 12.x version
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: build
         run: |
           docker image prune -a -f

--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/setup-node@v1
       name: Configuring nodejs 12.x version
       with:
-        node-version: '12.x'
+        node-version: '14.x'
     - name: Login to docker.io
       uses: docker/login-action@v1
       with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/setup-node@v1
       name: Configuring nodejs 10.x version
       with:
-        node-version: '12.x'
+        node-version: '14.x'
     - name: build
       run: yarn
     - name: Test Coverage
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/setup-node@v1
       name: Configuring nodejs 10.x version
       with:
-        node-version: '12.x'
+        node-version: '14.x'
     - name: build
       run: |
         docker image prune -a -f

--- a/.github/workflows/publish-built-in-extension-report.yaml
+++ b/.github/workflows/publish-built-in-extension-report.yaml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: '12'
+        node-version: '14.x'
     - name: Get current time
       uses: 1466587594/get-current-time@v1
       id: current-date-time

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     - uses: actions/setup-node@v1
       name: Configuring nodejs 12.x version
       with:
-        node-version: '12.x'
+        node-version: '14.x'
     - name: Login to docker.io
       uses: docker/login-action@v1
       with:

--- a/dockerfiles/theia-dev/docker/alpine/builder-image-from.dockerfile
+++ b/dockerfiles/theia-dev/docker/alpine/builder-image-from.dockerfile
@@ -1,1 +1,1 @@
-FROM node:12.20.1-alpine3.12
+FROM node:14.19.0-alpine3.15

--- a/dockerfiles/theia-dev/docker/ubi8/builder-image-from.dockerfile
+++ b/dockerfiles/theia-dev/docker/ubi8/builder-image-from.dockerfile
@@ -1,2 +1,2 @@
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-12
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-107.1645821200
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14
+FROM registry.access.redhat.com/ubi8/nodejs-14:1-56.1645816874

--- a/dockerfiles/theia-endpoint-runtime-binary/Dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/Dockerfile
@@ -22,7 +22,7 @@ ENV PATH=${HOME}/.yarn/bin:${PATH}
 #{INCLUDE:docker/${BUILD_IMAGE_TARGET}/builder-nexe-setup.dockerfile}
 
 RUN /tmp/nexe/index.js -v && \
-    # Build remote binary with node runtime 12.x and che-theia node dependencies. nexe icludes to the binary only
+    # Build remote binary with node runtime 14.x and che-theia node dependencies. nexe icludes to the binary only
     # necessary dependencies.
     eval /tmp/nexe/index.js -i node_modules/@eclipse-che/theia-remote/lib/node/plugin-remote.js ${NEXE_FLAGS} -o ${HOME}/plugin-remote-endpoint
 

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/builder-from.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/builder-from.dockerfile
@@ -1,2 +1,2 @@
-FROM quay.io/eclipse/che-custom-nodejs-deasync:12.20.1 as custom-nodejs
+FROM quay.io/eclipse/che-custom-nodejs-deasync:14.19.0 as custom-nodejs
 FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia:${BUILD_TAG} as builder

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/builder-setup.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/alpine/builder-setup.dockerfile
@@ -1,3 +1,3 @@
-ENV NEXE_FLAGS="--target 'alpine-x64-12' --temp /tmp/nexe-cache"
+ENV NEXE_FLAGS="--target 'alpine-x64-14' --temp /tmp/nexe-cache"
 
-COPY --from=custom-nodejs /alpine-x64-12 /tmp/nexe-cache/alpine-x64-12
+COPY --from=custom-nodejs /alpine-x64-14 /tmp/nexe-cache/alpine-x64-14

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/builder-from.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/builder-from.dockerfile
@@ -1,2 +1,2 @@
-FROM quay.io/eclipse/che-custom-nodejs-deasync:12.20.1 as custom-nodejs
+FROM quay.io/eclipse/che-custom-nodejs-deasync:14.19.0 as custom-nodejs
 FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia:${BUILD_TAG} as builder

--- a/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/builder-setup.dockerfile
+++ b/dockerfiles/theia-endpoint-runtime-binary/docker/ubi8/builder-setup.dockerfile
@@ -1,5 +1,5 @@
-ENV NEXE_FLAGS="--target 'alpine-x64-12' --temp /tmp/nexe-cache"
+ENV NEXE_FLAGS="--target 'alpine-x64-14' --temp /tmp/nexe-cache"
 
-COPY --from=custom-nodejs /alpine-x64-12 /tmp/nexe-cache/alpine-x64-12
+COPY --from=custom-nodejs /alpine-x64-14 /tmp/nexe-cache/alpine-x64-14
 
 USER root

--- a/dockerfiles/theia/docker/alpine/build-result-from.dockerfile
+++ b/dockerfiles/theia/docker/alpine/build-result-from.dockerfile
@@ -1,1 +1,1 @@
-FROM node:12.20.1-alpine3.12 as build-result
+FROM node:14.19.0-alpine3.15 as build-result

--- a/dockerfiles/theia/docker/alpine/runtime-from.dockerfile
+++ b/dockerfiles/theia/docker/alpine/runtime-from.dockerfile
@@ -1,1 +1,1 @@
-FROM node:12.20.1-alpine3.12 as runtime
+FROM node:14.19.0-alpine3.15 as runtime

--- a/dockerfiles/theia/docker/ubi8/build-result-from.dockerfile
+++ b/dockerfiles/theia/docker/ubi8/build-result-from.dockerfile
@@ -1,3 +1,3 @@
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-12
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-107.1645821200 as build-result
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14
+FROM registry.access.redhat.com/ubi8/nodejs-14:1-56.1645816874 as build-result
 USER root

--- a/dockerfiles/theia/docker/ubi8/runtime-from.dockerfile
+++ b/dockerfiles/theia/docker/ubi8/runtime-from.dockerfile
@@ -1,2 +1,2 @@
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-12
-FROM registry.access.redhat.com/ubi8/nodejs-12:1-107.1645821200 as runtime
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/nodejs-14
+FROM registry.access.redhat.com/ubi8/nodejs-14:1-56.1645816874 as runtime

--- a/generator/src/init.ts
+++ b/generator/src/init.ts
@@ -101,6 +101,10 @@ export class Init {
                 }
             })
         );
+        // make theia minimum version nodejs 12 or higher
+        if (theiaPackage.engines) {
+            theiaPackage.engines.node = '>=12.14.1';
+        }
         // grab all prettier, eslint stuff
         theiaPackage.prettier = prettierConfiguration;
         theiaPackage.importSort = importSortConfiguration;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "engines": {
-    "node": ">=10.11.0 <13"
+    "node": ">=12.14.1"
   },
   "devDependencies": {
     "@types/jest": "27.0.2",


### PR DESCRIPTION
### What does this PR do?
Che should use nodejs 14 as 12 is not maintained anymore
Also VS Code default node version is now v14


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/21150


### How to test this PR?
Try to run a plug-in and theia
Like checking with a sample

example:
https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2?che-editor=https://gist.githubusercontent.com/benoitf/e67f1be6ebad92ce7c7ae0c7a37cc5fe/raw/d43052559db5252571bf316bd674ef86d7f6a910/theia-editor.yaml

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [x] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable


Change-Id: I4c05de54ad3d539f6602dbbbc510e8188497152b
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
