### PR TITLE
[WIP] fix: Prevent overwriting the DevWorkspace in-cluster object by a flattened Devfile

### DIFF
--- a/extensions/eclipse-che-theia-plugin-ext/src/browser/che-devfile-main.ts
+++ b/extensions/eclipse-che-theia-plugin-ext/src/browser/che-devfile-main.ts
@@ -42,8 +42,8 @@ export class CheDevfileMainImpl implements CheDevfileMain {
     await this.openFactoryWindow(factoryURI);
   }
 
-  async $get(): Promise<Devfile> {
-    return this.devfileService.get();
+  async $get(onCluster?: boolean): Promise<Devfile> {
+    return this.devfileService.get(onCluster);
   }
 
   async $update(updatedDevfile: Devfile): Promise<void> {

--- a/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
+++ b/extensions/eclipse-che-theia-plugin/src/che-proposed.d.ts
@@ -214,7 +214,7 @@ declare module '@eclipse-che/plugin' {
             sparseCheckoutDirs?: string[];
         }
         export function update(updatedDevfile: Devfile): Promise<void>;
-        export function get(): Promise<Devfile>;
+        export function get(onCluster?: boolean): Promise<Devfile>;
         export function getComponentStatuses(): Promise<DevfileComponentStatus[]>;
         export function createWorkspace(devfilePath: string): Promise<void>;
     }

--- a/extensions/eclipse-che-theia-remote-api/src/common/devfile-service.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/common/devfile-service.ts
@@ -180,10 +180,20 @@ export interface DevfileProject {
 }
 
 export interface DevfileService {
-  // Provides raw content of the devfile as a string
+  // Provides raw content of the flattened devfile as a string
   getRaw(): Promise<string>;
-  // Get structured object of the devfile
-  get(): Promise<Devfile>;
+
+  /**
+   * Get the structured object of the devfile.
+   * Typical use of the in-cluster devfile is operating on it and updating the DevWorkspace afterwards.
+   * Typical use of the flattened devfile is geting a complete intormation about the DevWorkspace.
+   * Since the flattened devfile defines everything in the workspace explicitly.
+   *
+   * @param onCluster if true - returns the original (on-cluster) devfile,
+   * if false - returns the flattened devfile.
+   */
+  get(onCluster?: boolean): Promise<Devfile>;
+
   getComponentStatuses(): Promise<DevfileComponentStatus[]>;
 
   // Update the devfile based on the given content

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-devfile-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-devfile-service-impl.ts
@@ -39,8 +39,8 @@ export class K8sDevfileServiceImpl implements DevfileService {
     return devfileContent;
   }
 
-  async get(fromCustomObject?: boolean): Promise<Devfile> {
-    if (fromCustomObject) {
+  async get(onCluster?: boolean): Promise<Devfile> {
+    if (onCluster) {
       const customObjectsApi = this.k8SService.makeApiClient(k8s.CustomObjectsApi);
       const group = 'workspace.devfile.io';
       const version = 'v1alpha2';

--- a/plugins/workspace-plugin/src/devfile-service.ts
+++ b/plugins/workspace-plugin/src/devfile-service.ts
@@ -37,7 +37,7 @@ export class DevfileServiceImpl {
         })
         .then(async () => {
           try {
-            const devfile = await che.devfile.get();
+            const devfile = await che.devfile.get(true);
 
             this.updateOrCreateGitProject(
               devfile,
@@ -77,7 +77,7 @@ export class DevfileServiceImpl {
           try {
             const relativePath = fileUri.toRelativePath(projectPath, this.projectsRoot);
 
-            const devfile = await che.devfile.get();
+            const devfile = await che.devfile.get(true);
             const devfileChanged = this.deleteGitProject(devfile, relativePath);
             if (devfileChanged) {
               await che.devfile.update(devfile);


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
The PR fixes the problem of overwriting the DevWorkspace in-cluster object by a flattened Devfile
when adding/removing a project or changing a project's git configuration, e.g. adding another remote repository.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
fixes https://github.com/eclipse/che/issues/21244

### How to test this PR?
1. Start a workspace via factory link `che-url/#https://github.com/che-samples/golang-example/tree/devfilev2`
2. Use `ctrl+shift+p` to `Git: Add Remote...` and enter e.g. `https://github.com/golang/example.git`
3. Check the DevWorkspace. It should not be changed

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
