### PR TITLE
Prevent overwriting the DevWorkspace in-cluster object by a flattened Devfile

### DIFF
--- a/plugins/workspace-plugin/src/workspace-projects-manager.ts
+++ b/plugins/workspace-plugin/src/workspace-projects-manager.ts
@@ -80,8 +80,11 @@ export class WorkspaceProjectsManager {
       }
     }
 
-    await this.watchWorkspaceProjects();
-    await this.watchMultiRootProjects();
+    // Quick fix for https://github.com/eclipse/che/issues/21244
+    // Considering 99% of the workspaces are single-project,
+    // there is no need to update the Devfile automatically.
+    // await this.watchWorkspaceProjects();
+    // await this.watchMultiRootProjects();
   }
 
   async buildCloneCommands(projects: che.devfile.DevfileProject[]): Promise<TheiaImportCommand[]> {

--- a/plugins/workspace-plugin/tests/workspace-projects-manager.spec.ts
+++ b/plugins/workspace-plugin/tests/workspace-projects-manager.spec.ts
@@ -372,13 +372,13 @@ describe('Test Workspace Projects Manager', () => {
 
     await fireFileSystemChangedEvent(PROJECTS_ROOT, 'create', 'test-project-to-add');
 
-    expect(addWorkspaceFolderMock).toBeCalledTimes(1);
+    expect(addWorkspaceFolderMock).toBeCalledTimes(0);
     expect(removeWorkspaceFolderMock).toBeCalledTimes(0);
 
-    expect(onProjectChangedSpy).toBeCalledTimes(1);
+    expect(onProjectChangedSpy).toBeCalledTimes(0);
     expect(onProjectRemovedSpy).toBeCalledTimes(0);
 
-    expect(updateProjectMock).toBeCalledTimes(1);
+    expect(updateProjectMock).toBeCalledTimes(0);
     expect(deleteProjectMock).toBeCalledTimes(0);
   });
 
@@ -407,10 +407,10 @@ describe('Test Workspace Projects Manager', () => {
 
     await fireFileSystemChangedEvent(PROJECTS_ROOT, 'create', 'test-project-to-add');
 
-    expect(addWorkspaceFolderMock).toBeCalledTimes(1);
+    expect(addWorkspaceFolderMock).toBeCalledTimes(0);
     expect(removeWorkspaceFolderMock).toBeCalledTimes(0);
 
-    expect(onProjectChangedSpy).toBeCalledTimes(1);
+    expect(onProjectChangedSpy).toBeCalledTimes(0);
     expect(onProjectRemovedSpy).toBeCalledTimes(0);
 
     expect(updateProjectMock).toBeCalledTimes(0);
@@ -441,13 +441,13 @@ describe('Test Workspace Projects Manager', () => {
     await fireFileSystemChangedEvent(PROJECTS_ROOT, 'create', 'test-project-to-add');
 
     expect(addWorkspaceFolderMock).toBeCalledTimes(0);
-    expect(removeWorkspaceFolderMock).toBeCalledTimes(1);
+    expect(removeWorkspaceFolderMock).toBeCalledTimes(0);
 
     expect(onProjectChangedSpy).toBeCalledTimes(0);
-    expect(onProjectRemovedSpy).toBeCalledTimes(1);
+    expect(onProjectRemovedSpy).toBeCalledTimes(0);
 
     expect(updateProjectMock).toBeCalledTimes(0);
-    expect(deleteProjectMock).toBeCalledTimes(1);
+    expect(deleteProjectMock).toBeCalledTimes(0);
   });
 
   test('test rejecting in workspaceProjectsManager.onProjectChanged for non-git project', async () => {


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
It's a backport of https://github.com/eclipse-che/che-theia/pull/1346 from 7.48.x to 7.46.x

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
