### PR TITLE
chore: Add public root crt to the list to use it in Axios  

### DIFF
--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-certificate-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-certificate-service-impl.ts
@@ -11,7 +11,7 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
-import { PUBLIC_CRT_PATH, SS_CRT_PATH } from './k8s-server-https';
+import { PUBLIC_CRT_PATH, PUBLIC_ROOT_CRT_PATH, SS_CRT_PATH } from './k8s-server-https';
 
 import { CertificateService } from '@eclipse-che/theia-remote-api/lib/common/certificate-service';
 import { injectable } from 'inversify';
@@ -36,6 +36,12 @@ export class K8sCertificateServiceImpl implements CertificateService {
           certificateAuthority.push(content);
         }
       }
+    }
+
+    const existsPublicRootCrt = await fs.pathExists(PUBLIC_ROOT_CRT_PATH);
+    if (existsPublicRootCrt) {
+      const content = await fs.readFile(PUBLIC_ROOT_CRT_PATH);
+      certificateAuthority.push(content);
     }
 
     return certificateAuthority.length > 0 ? certificateAuthority : undefined;

--- a/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-server-https.ts
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/src/node/k8s-server-https.ts
@@ -10,3 +10,4 @@
 
 export const SS_CRT_PATH = '/tmp/che/secret/ca.crt';
 export const PUBLIC_CRT_PATH = '/public-certs';
+export const PUBLIC_ROOT_CRT_PATH = '/etc/ssl/certs/ca-certificates.crt';


### PR DESCRIPTION
Signed-off-by: Fake Name <fake@example.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds `/etc/ssl/certs/ca-certificates.crt` certificate to the list of certificates of authority. 
It solves a problem with making requests to  the public resources like https://github.com/golang/vscode-go/releases/download/v0.23.0/go-0.23.0.vsix

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://user-images.githubusercontent.com/1271546/168074941-c7ee0409-48a0-41ae-b159-c6fea5491791.mp4

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21381


### How to test this PR?
  - The test platform minikube
  - Installation method: chectl
  - Start the workspace via https://github.com/che-samples/bash/tree/devfilev2?che-editor=https://gist.githubusercontent.com/svor/afbea8fc7bad0d318f23c9491a5b2bde/raw/778e95e4b3ae2b7759a0da5589f05001f088b63c/che-theia.yaml
  - Try to install plugins from the Plugin view

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [x] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
