### PR TITLE
chore: should be able to uninstall plugins if che-theia-plugins.yaml is inlined in the devfile

### DIFF
--- a/extensions/eclipse-che-theia-remote-api/src/common/plugin-service-impl.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/common/plugin-service-impl.ts
@@ -19,9 +19,6 @@ import {
 import { inject, injectable } from 'inversify';
 
 import { HttpService } from './http-service';
-import URI from '@theia/core/lib/common/uri';
-
-const yaml = require('js-yaml');
 
 /**
  * Describes plugin inside plugin list
@@ -50,7 +47,7 @@ export abstract class PluginServiceImpl implements ChePluginService {
 
   protected defaultRegistry: ChePluginRegistry;
 
-  private cachedPlugins: ChePluginMetadata[] = [];
+  cachedPlugins: ChePluginMetadata[] = [];
 
   setClient(client: ChePluginServiceClient): void {
     this.client = client;
@@ -80,72 +77,7 @@ export abstract class PluginServiceImpl implements ChePluginService {
 
   abstract getDefaultRegistry(): Promise<ChePluginRegistry>;
 
-  /**
-   * Updates the plugin cache
-   *
-   * @param registryList list of plugin registries
-   */
-  async updateCache(registries: ChePluginRegistries): Promise<void> {
-    if (!this.client) {
-      return;
-    }
-
-    // clear cache
-    this.cachedPlugins = [];
-
-    // ensure default plugin registry URI is set
-    if (!this.defaultRegistry) {
-      await this.getDefaultRegistry();
-    }
-
-    let availablePlugins = 0;
-    await this.client.notifyPluginCacheSizeChanged(0);
-
-    for (const registryName in registries) {
-      if (!registries.hasOwnProperty(registryName)) {
-        continue;
-      }
-
-      const registry = registries[registryName];
-      try {
-        // Get list of ChePluginMetadataInternal from plugin registry
-        const registryPlugins = await this.loadPluginList(registry);
-        if (!Array.isArray(registryPlugins)) {
-          await this.client.invalidRegistryFound(registry);
-          continue;
-        }
-        availablePlugins += registryPlugins.length;
-        await this.client.notifyPluginCacheSizeChanged(availablePlugins);
-
-        // Plugin key used to specify a plugin in the devfile.
-        // It can be short:
-        //      {publisher}/{pluginName}/{version}
-        // or long, including the path to plugin meta.yaml
-        //      {http/https}://{host}/{path}/{publisher}/{pluginName}/{version}
-        const longKeyFormat = registry.internalURI !== this.defaultRegistry.internalURI;
-
-        for (let pIndex = 0; pIndex < registryPlugins.length; pIndex++) {
-          const metadataInternal: ChePluginMetadataInternal = registryPlugins[pIndex];
-          const pluginYamlURI = this.getPluginYamlURI(registry, metadataInternal);
-
-          try {
-            const pluginMetadata = await this.loadPluginMetadata(pluginYamlURI, longKeyFormat, registry.publicURI);
-            this.cachedPlugins.push(pluginMetadata);
-            await this.client.notifyPluginCached(this.cachedPlugins.length);
-          } catch (error) {
-            console.log('Unable go get plugin metadata from ' + pluginYamlURI);
-            await this.client.invalidPluginFound(pluginYamlURI);
-          }
-        }
-      } catch (error) {
-        console.log('Cannot access the registry', error);
-        await this.client.invalidRegistryFound(registry);
-      }
-    }
-
-    // notify client that caching the plugins has been finished
-    await this.client.notifyCachingComplete();
-  }
+  abstract updateCache(registries: ChePluginRegistries): Promise<void>;
 
   /**
    * Loads list of plugins from plugin registry.
@@ -153,45 +85,13 @@ export abstract class PluginServiceImpl implements ChePluginService {
    * @param registry ChePluginRegistry plugin registry
    * @return list of available plugins
    */
-  private async loadPluginList(registry: ChePluginRegistry): Promise<ChePluginMetadataInternal[]> {
+  async loadPluginList(registry: ChePluginRegistry): Promise<ChePluginMetadataInternal[]> {
     const registryURI = registry.internalURI + '/plugins/';
     const registryContent = (await this.httpService.get(registryURI)) || '{}';
     return JSON.parse(registryContent) as ChePluginMetadataInternal[];
   }
 
-  /**
-   * Creates an URI to plugin metadata yaml file.
-   *
-   * @param registry: ChePluginRegistry plugin registry
-   * @param plugin plugin metadata
-   * @return uri to plugin yaml file
-   */
-  private getPluginYamlURI(registry: ChePluginRegistry, plugin: ChePluginMetadataInternal): string {
-    if (plugin.links && plugin.links.self) {
-      const self: string = plugin.links.self;
-      if (self.startsWith('/')) {
-        if (registry.internalURI === this.defaultRegistry.internalURI) {
-          // To work in both single host and multi host modes.
-          // In single host mode plugin registry url path is `plugin-registry/v3/plugins`,
-          // for multi host mode the path is `v3/plugins`. So, in both cases plugin registry url
-          // ends with `v3/plugins`, but ${plugin.links.self} starts with `/v3/plugins/${plugin.id}.
-          // See https://github.com/eclipse/che-plugin-registry/blob/master/build/scripts/index.sh#L27
-          // So the correct plugin url for both cases will be plugin registry url + plugin id.
-          return `${registry.internalURI}/plugins/${plugin.id}/`;
-        }
-        const uri = new URI(registry.internalURI);
-        return `${uri.scheme}://${uri.authority}${self}`;
-      } else {
-        const base = this.getBaseDirectory(registry);
-        return `${base}${self}`;
-      }
-    } else {
-      const base = this.getBaseDirectory(registry);
-      return `${base}/${plugin.id}/meta.yaml`;
-    }
-  }
-
-  private getBaseDirectory(registry: ChePluginRegistry): string {
+  getBaseDirectory(registry: ChePluginRegistry): string {
     let uri = registry.internalURI;
 
     if (uri.endsWith('.json')) {
@@ -203,80 +103,6 @@ export abstract class PluginServiceImpl implements ChePluginService {
     }
 
     return uri;
-  }
-
-  private async loadPluginYaml(yamlURI: string): Promise<ChePluginMetadata> {
-    let err;
-    try {
-      const pluginYamlContent = await this.httpService.get(yamlURI);
-      return yaml.safeLoad(pluginYamlContent);
-    } catch (error) {
-      console.error(error);
-      err = error;
-    }
-
-    try {
-      if (!yamlURI.endsWith('/')) {
-        yamlURI += '/';
-      }
-      yamlURI += 'meta.yaml';
-      const pluginYamlContent = await this.httpService.get(yamlURI);
-      return yaml.safeLoad(pluginYamlContent);
-    } catch (error) {
-      console.error(error);
-      return Promise.reject('Unable to load plugin metadata. ' + err.message);
-    }
-  }
-
-  private async loadPluginMetadata(
-    yamlURI: string,
-    longKeyFormat: boolean,
-    pluginRegistryURI: string
-  ): Promise<ChePluginMetadata> {
-    try {
-      const props: ChePluginMetadata = await this.loadPluginYaml(yamlURI);
-
-      let key = `${props.publisher}/${props.name}/${props.version}`;
-      if (longKeyFormat) {
-        if (yamlURI.endsWith(key)) {
-          const uri = yamlURI.substring(0, yamlURI.length - key.length);
-          key = `${uri}${props.publisher}/${props.name}/${props.version}`;
-        } else if (yamlURI.endsWith(`${key}/meta.yaml`)) {
-          const uri = yamlURI.substring(0, yamlURI.length - `${key}/meta.yaml`.length);
-          key = `${uri}${props.publisher}/${props.name}/${props.version}`;
-        }
-      }
-
-      let icon;
-      if (props.icon.startsWith('http://') || props.icon.startsWith('https://')) {
-        // icon refers on external resource
-        icon = props.icon;
-      } else {
-        // icon must be relative to plugin registry ROOT
-        icon = props.icon.startsWith('/') ? pluginRegistryURI + props.icon : pluginRegistryURI + '/' + props.icon;
-      }
-
-      return {
-        publisher: props.publisher,
-        name: props.name,
-        version: props.version,
-        type: props.type,
-        displayName: props.displayName,
-        title: props.title,
-        description: props.description,
-        icon: icon,
-        url: props.url,
-        repository: props.repository,
-        firstPublicationDate: props.firstPublicationDate,
-        category: props.category,
-        latestUpdateDate: props.latestUpdateDate,
-        key: key,
-        builtIn: false,
-      };
-    } catch (error) {
-      console.log(`Cannot get ${yamlURI}`, error);
-      return Promise.reject('Unable to load plugin metadata. ' + error.message);
-    }
   }
 
   /**

--- a/extensions/eclipse-che-theia-remote-api/src/common/plugin-service.ts
+++ b/extensions/eclipse-che-theia-remote-api/src/common/plugin-service.ts
@@ -14,8 +14,10 @@ export interface ChePluginRegistry {
   // Display name
   name: string;
   // Registry internal URI, is used for cross-container comnmunication.
+  // Should not contain a trailing slash.
   internalURI: string;
   // Public URI to access the registry resources from browser.
+  // Should not contain a trailing slash.
   publicURI: string;
 }
 
@@ -40,6 +42,10 @@ export interface ChePluginMetadata {
   // Plugin KEY. Used to set in workpsace configuration
   key: string;
   builtIn: boolean;
+
+  // to be compatible with dev workspaces
+  dependencies?: string[];
+  extensions?: string[];
 }
 
 /**

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/devworkspace-template-with-inlined-che-theia-plugins.yaml
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/devworkspace-template-with-inlined-che-theia-plugins.yaml
@@ -1,0 +1,289 @@
+attributes:
+  .che/che-theia-plugins.yaml: |
+    - id: vscode/typescript-language-features/latest
+    - id: atlassian/atlascode/latest
+    - id: bmewburn/vscode-intelephense-client/latest
+  dw.metadata.annotations:
+    che.eclipse.org/che-editor: https://gist.githubusercontent.com/vitaliy-guliy/bc6ff64a716a30bfc7492cec9314f3cf/raw/abcfeff8ccc9a1992fa9a6d4fe7a7a558dc7b7df/editor.meta.yaml
+    che.eclipse.org/devfile-source: |
+      scm:
+        repo: 'https://github.com/vitaliy-guliy/web-nodejs-sample.git'
+        revision: che-qe-extensions-test
+        fileName: devfile.yaml
+      factory:
+        params: >-
+          url=https://github.com/vitaliy-guliy/web-nodejs-sample/tree/che-qe-extensions-test&che-editor=https://gist.githubusercontent.com/vitaliy-guliy/bc6ff64a716a30bfc7492cec9314f3cf/raw/abcfeff8ccc9a1992fa9a6d4fe7a7a558dc7b7df/editor.meta.yaml
+    che.eclipse.org/last-updated-timestamp: "2022-07-12T11:25:04.110Z"
+commands:
+- apply:
+    component: remote-runtime-injector
+  attributes:
+    controller.devfile.io/imported-by: theia-ide-workspaced740715bb27b4967
+  id: init-container-command
+- exec:
+    commandLine: npm install
+    component: tools
+    group:
+      kind: build
+    label: Download dependencies
+    workingDir: ${PROJECTS_ROOT}/web-nodejs-sample/app
+  id: 1-dependencies
+- exec:
+    commandLine: nodemon app.js
+    component: tools
+    group:
+      kind: run
+    label: Run the web app
+    workingDir: ${PROJECTS_ROOT}/web-nodejs-sample/app
+  id: 2-run
+- exec:
+    commandLine: npm install; nodemon app.js
+    component: tools
+    group:
+      kind: run
+    label: Run the web app (and download dependencies)
+    workingDir: ${PROJECTS_ROOT}/web-nodejs-sample/app
+  id: 3-install-and-run
+- exec:
+    commandLine: nodemon --inspect app.js
+    component: tools
+    group:
+      isDefault: true
+      kind: debug
+    label: Run the web app (debugging enabled)
+    workingDir: ${PROJECTS_ROOT}/web-nodejs-sample/app
+  id: 4-debug
+- exec:
+    commandLine: 'node_server_pids=$(pgrep -fx ''.*nodemon (--inspect )?app.js'' |
+      tr "\\n" " ") && echo "Stopping node server with PIDs: ${node_server_pids}"
+      &&  kill -15 ${node_server_pids} &>/dev/null && echo ''Done.'''
+    component: tools
+    group:
+      kind: run
+    label: Stop the web app
+  id: 5-stopapp
+components:
+- attributes:
+    app.kubernetes.io/component: che-theia
+    app.kubernetes.io/part-of: che-theia.eclipse.org
+    che-theia.eclipse.org/vscode-extensions:
+    - https://open-vsx.org/api/atlassian/atlascode/2.8.6/file/atlassian.atlascode-2.8.6.vsix
+    controller.devfile.io/imported-by: theia-ide-workspaced740715bb27b4967
+  container:
+    cpuLimit: 1500m
+    cpuRequest: 100m
+    endpoints:
+    - attributes:
+        controller.devfile.io/endpoint-url: https://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/3100/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: main
+        urlRewriteSupported: true
+      exposure: public
+      name: theia
+      protocol: https
+      secure: false
+      targetPort: 3100
+    - attributes:
+        controller.devfile.io/endpoint-url: https://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/webviews/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: webview
+        unique: true
+        urlRewriteSupported: true
+      exposure: public
+      name: webviews
+      protocol: https
+      secure: false
+      targetPort: 3100
+    - attributes:
+        controller.devfile.io/endpoint-url: https://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/mini-browser/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: mini-browser
+        unique: true
+        urlRewriteSupported: true
+      exposure: public
+      name: mini-browser
+      protocol: https
+      secure: false
+      targetPort: 3100
+    - attributes:
+        controller.devfile.io/endpoint-url: https://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/3130/
+        discoverable: false
+        type: ide-dev
+        urlRewriteSupported: true
+      exposure: public
+      name: theia-dev
+      protocol: http
+      targetPort: 3130
+    - attributes:
+        controller.devfile.io/endpoint-url: https://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/13131/
+        discoverable: false
+        urlRewriteSupported: true
+      exposure: public
+      name: theia-redirect-1
+      protocol: http
+      targetPort: 13131
+    - attributes:
+        controller.devfile.io/endpoint-url: https://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/13132/
+        discoverable: false
+        urlRewriteSupported: true
+      exposure: public
+      name: theia-redirect-2
+      protocol: http
+      targetPort: 13132
+    - attributes:
+        controller.devfile.io/endpoint-url: https://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/13133/
+        discoverable: false
+        urlRewriteSupported: true
+      exposure: public
+      name: theia-redirect-3
+      protocol: http
+      targetPort: 13133
+    - attributes:
+        controller.devfile.io/endpoint-url: wss://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/3333/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: collocated-terminal
+        urlRewriteSupported: true
+      exposure: public
+      name: terminal
+      protocol: wss
+      secure: false
+      targetPort: 3333
+    env:
+    - name: THEIA_PLUGINS
+      value: local-dir:///plugins
+    - name: HOSTED_PLUGIN_HOSTNAME
+      value: 0.0.0.0
+    - name: HOSTED_PLUGIN_PORT
+      value: "3130"
+    - name: THEIA_HOST
+      value: 127.0.0.1
+    - name: CHE_DASHBOARD_URL
+      value: https://192.168.49.2.nip.io
+    - name: CHE_PLUGIN_REGISTRY_URL
+      value: https://192.168.49.2.nip.io/plugin-registry/v3
+    - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
+      value: http://plugin-registry.eclipse-che.svc:8080/v3
+    image: quay.io/vgulyy/che-theia:check-inlined-plugins
+    memoryLimit: 512M
+    mountSources: true
+    sourceMapping: /projects
+    volumeMounts:
+    - name: plugins
+      path: /plugins
+    - name: theia-local
+      path: /home/theia/.theia
+  name: theia-ide
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspaced740715bb27b4967
+  name: plugins
+  volume: {}
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspaced740715bb27b4967
+  name: theia-local
+  volume: {}
+- attributes:
+    app.kubernetes.io/component: machine-exec
+    app.kubernetes.io/part-of: che-theia.eclipse.org
+    controller.devfile.io/imported-by: theia-ide-workspaced740715bb27b4967
+  container:
+    command:
+    - /go/bin/che-machine-exec
+    - --url
+    - 127.0.0.1:3333
+    env:
+    - name: CHE_DASHBOARD_URL
+      value: https://192.168.49.2.nip.io
+    - name: CHE_PLUGIN_REGISTRY_URL
+      value: https://192.168.49.2.nip.io/plugin-registry/v3
+    - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
+      value: http://plugin-registry.eclipse-che.svc:8080/v3
+    image: quay.io/eclipse/che-machine-exec@sha256:45ac7cf14440ae4a6eceb6a9fba9ded845acf3981fd1c9b0761e994a1cdf0df7
+    sourceMapping: /projects
+  name: che-machine-exec
+- attributes:
+    app.kubernetes.io/component: remote-runtime-injector
+    app.kubernetes.io/part-of: che-theia.eclipse.org
+    controller.devfile.io/imported-by: theia-ide-workspaced740715bb27b4967
+  container:
+    env:
+    - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+      value: /remote-endpoint/plugin-remote-endpoint
+    - name: REMOTE_ENDPOINT_VOLUME_NAME
+      value: remote-endpoint
+    - name: CHE_DASHBOARD_URL
+      value: https://192.168.49.2.nip.io
+    - name: CHE_PLUGIN_REGISTRY_URL
+      value: https://192.168.49.2.nip.io/plugin-registry/v3
+    - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
+      value: http://plugin-registry.eclipse-che.svc:8080/v3
+    image: quay.io/eclipse/che-theia-endpoint-runtime-binary@sha256:e72767d42e745132870ee9a5087774447ecfddcb5d279b877a4bfbf41892b5fd
+    sourceMapping: /projects
+    volumeMounts:
+    - name: plugins
+      path: /plugins
+    - name: remote-endpoint
+      path: /remote-endpoint
+  name: remote-runtime-injector
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspaced740715bb27b4967
+  name: remote-endpoint
+  volume:
+    ephemeral: true
+- attributes:
+    app.kubernetes.io/name: tools
+    che-theia.eclipse.org/vscode-extensions:
+    - https://open-vsx.org/api/vscode/typescript-language-features/1.49.3/file/vscode.typescript-language-features-1.49.3.vsix
+    - https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-intelephense-client-1.5.4.vsix
+    - https://open-vsx.org/api/redhat/vscode-yaml/0.14.0/file/redhat.vscode-yaml-0.14.0.vsix
+  container:
+    args:
+    - sh
+    - -c
+    - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
+    endpoints:
+    - attributes:
+        controller.devfile.io/endpoint-url: http://workspaced740715bb27b4967-1.192.168.49.2.nip.io/
+      exposure: public
+      name: nodejs
+      protocol: http
+      targetPort: 3000
+    env:
+    - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+      value: /remote-endpoint/plugin-remote-endpoint
+    - name: THEIA_PLUGINS
+      value: local-dir:///plugins/sidecars/tools
+    - name: CHE_DASHBOARD_URL
+      value: https://192.168.49.2.nip.io
+    - name: CHE_PLUGIN_REGISTRY_URL
+      value: https://192.168.49.2.nip.io/plugin-registry/v3
+    - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
+      value: http://plugin-registry.eclipse-che.svc:8080/v3
+    image: quay.io/devspaces/udi-rhel8:3.1
+    memoryLimit: 1G
+    mountSources: true
+    sourceMapping: /projects
+    volumeMounts:
+    - name: npm
+      path: /home/user/.npm
+    - name: remote-endpoint
+      path: /remote-endpoint
+    - name: plugins
+      path: /plugins
+  name: tools
+- name: npm
+  volume:
+    size: 1G
+events:
+  preStart:
+  - init-container-command
+projects:
+- git:
+    checkoutFrom:
+      revision: che-qe-extensions-test
+    remotes:
+      origin: https://github.com/vitaliy-guliy/web-nodejs-sample.git
+  name: web-nodejs-sample

--- a/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/devworkspace-template-with-inlined-extensions-json.yaml
+++ b/extensions/eclipse-che-theia-remote-impl-k8s/tests/_data/devworkspace-template-with-inlined-extensions-json.yaml
@@ -1,0 +1,294 @@
+attributes:
+  .vscode/extensions.json: |
+    {
+      "recommendations": [
+        "vscode.typescript-language-features",
+        "ms-vscode.node-debug2",
+        "bmewburn.vscode-intelephense-client",
+        "atlassian.atlascode"
+      ]
+    }
+  dw.metadata.annotations:
+    che.eclipse.org/che-editor: https://gist.githubusercontent.com/vitaliy-guliy/bc6ff64a716a30bfc7492cec9314f3cf/raw/abcfeff8ccc9a1992fa9a6d4fe7a7a558dc7b7df/editor.meta.yaml
+    che.eclipse.org/devfile-source: |
+      scm:
+        repo: 'https://github.com/vitaliy-guliy/web-nodejs-sample.git'
+        revision: che-qe-extensions-test
+        fileName: devfile.yaml
+      factory:
+        params: >-
+          url=https://github.com/vitaliy-guliy/web-nodejs-sample/tree/che-qe-extensions-test&che-editor=https://gist.githubusercontent.com/vitaliy-guliy/bc6ff64a716a30bfc7492cec9314f3cf/raw/abcfeff8ccc9a1992fa9a6d4fe7a7a558dc7b7df/editor.meta.yaml
+    che.eclipse.org/last-updated-timestamp: "2022-07-12T11:25:04.110Z"
+commands:
+- apply:
+    component: remote-runtime-injector
+  attributes:
+    controller.devfile.io/imported-by: theia-ide-workspaced740715bb27b4967
+  id: init-container-command
+- exec:
+    commandLine: npm install
+    component: tools
+    group:
+      kind: build
+    label: Download dependencies
+    workingDir: ${PROJECTS_ROOT}/web-nodejs-sample/app
+  id: 1-dependencies
+- exec:
+    commandLine: nodemon app.js
+    component: tools
+    group:
+      kind: run
+    label: Run the web app
+    workingDir: ${PROJECTS_ROOT}/web-nodejs-sample/app
+  id: 2-run
+- exec:
+    commandLine: npm install; nodemon app.js
+    component: tools
+    group:
+      kind: run
+    label: Run the web app (and download dependencies)
+    workingDir: ${PROJECTS_ROOT}/web-nodejs-sample/app
+  id: 3-install-and-run
+- exec:
+    commandLine: nodemon --inspect app.js
+    component: tools
+    group:
+      isDefault: true
+      kind: debug
+    label: Run the web app (debugging enabled)
+    workingDir: ${PROJECTS_ROOT}/web-nodejs-sample/app
+  id: 4-debug
+- exec:
+    commandLine: 'node_server_pids=$(pgrep -fx ''.*nodemon (--inspect )?app.js'' |
+      tr "\\n" " ") && echo "Stopping node server with PIDs: ${node_server_pids}"
+      &&  kill -15 ${node_server_pids} &>/dev/null && echo ''Done.'''
+    component: tools
+    group:
+      kind: run
+    label: Stop the web app
+  id: 5-stopapp
+components:
+- attributes:
+    app.kubernetes.io/component: che-theia
+    app.kubernetes.io/part-of: che-theia.eclipse.org
+    che-theia.eclipse.org/vscode-extensions:
+    - https://open-vsx.org/api/atlassian/atlascode/2.8.6/file/atlassian.atlascode-2.8.6.vsix
+    controller.devfile.io/imported-by: theia-ide-workspaced740715bb27b4967
+  container:
+    cpuLimit: 1500m
+    cpuRequest: 100m
+    endpoints:
+    - attributes:
+        controller.devfile.io/endpoint-url: https://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/3100/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: main
+        urlRewriteSupported: true
+      exposure: public
+      name: theia
+      protocol: https
+      secure: false
+      targetPort: 3100
+    - attributes:
+        controller.devfile.io/endpoint-url: https://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/webviews/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: webview
+        unique: true
+        urlRewriteSupported: true
+      exposure: public
+      name: webviews
+      protocol: https
+      secure: false
+      targetPort: 3100
+    - attributes:
+        controller.devfile.io/endpoint-url: https://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/mini-browser/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: mini-browser
+        unique: true
+        urlRewriteSupported: true
+      exposure: public
+      name: mini-browser
+      protocol: https
+      secure: false
+      targetPort: 3100
+    - attributes:
+        controller.devfile.io/endpoint-url: https://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/3130/
+        discoverable: false
+        type: ide-dev
+        urlRewriteSupported: true
+      exposure: public
+      name: theia-dev
+      protocol: http
+      targetPort: 3130
+    - attributes:
+        controller.devfile.io/endpoint-url: https://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/13131/
+        discoverable: false
+        urlRewriteSupported: true
+      exposure: public
+      name: theia-redirect-1
+      protocol: http
+      targetPort: 13131
+    - attributes:
+        controller.devfile.io/endpoint-url: https://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/13132/
+        discoverable: false
+        urlRewriteSupported: true
+      exposure: public
+      name: theia-redirect-2
+      protocol: http
+      targetPort: 13132
+    - attributes:
+        controller.devfile.io/endpoint-url: https://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/13133/
+        discoverable: false
+        urlRewriteSupported: true
+      exposure: public
+      name: theia-redirect-3
+      protocol: http
+      targetPort: 13133
+    - attributes:
+        controller.devfile.io/endpoint-url: wss://192.168.49.2.nip.io/workspaced740715bb27b4967/theia-ide/3333/
+        cookiesAuthEnabled: true
+        discoverable: false
+        type: collocated-terminal
+        urlRewriteSupported: true
+      exposure: public
+      name: terminal
+      protocol: wss
+      secure: false
+      targetPort: 3333
+    env:
+    - name: THEIA_PLUGINS
+      value: local-dir:///plugins
+    - name: HOSTED_PLUGIN_HOSTNAME
+      value: 0.0.0.0
+    - name: HOSTED_PLUGIN_PORT
+      value: "3130"
+    - name: THEIA_HOST
+      value: 127.0.0.1
+    - name: CHE_DASHBOARD_URL
+      value: https://192.168.49.2.nip.io
+    - name: CHE_PLUGIN_REGISTRY_URL
+      value: https://192.168.49.2.nip.io/plugin-registry/v3
+    - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
+      value: http://plugin-registry.eclipse-che.svc:8080/v3
+    image: quay.io/vgulyy/che-theia:check-inlined-plugins
+    memoryLimit: 512M
+    mountSources: true
+    sourceMapping: /projects
+    volumeMounts:
+    - name: plugins
+      path: /plugins
+    - name: theia-local
+      path: /home/theia/.theia
+  name: theia-ide
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspaced740715bb27b4967
+  name: plugins
+  volume: {}
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspaced740715bb27b4967
+  name: theia-local
+  volume: {}
+- attributes:
+    app.kubernetes.io/component: machine-exec
+    app.kubernetes.io/part-of: che-theia.eclipse.org
+    controller.devfile.io/imported-by: theia-ide-workspaced740715bb27b4967
+  container:
+    command:
+    - /go/bin/che-machine-exec
+    - --url
+    - 127.0.0.1:3333
+    env:
+    - name: CHE_DASHBOARD_URL
+      value: https://192.168.49.2.nip.io
+    - name: CHE_PLUGIN_REGISTRY_URL
+      value: https://192.168.49.2.nip.io/plugin-registry/v3
+    - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
+      value: http://plugin-registry.eclipse-che.svc:8080/v3
+    image: quay.io/eclipse/che-machine-exec@sha256:45ac7cf14440ae4a6eceb6a9fba9ded845acf3981fd1c9b0761e994a1cdf0df7
+    sourceMapping: /projects
+  name: che-machine-exec
+- attributes:
+    app.kubernetes.io/component: remote-runtime-injector
+    app.kubernetes.io/part-of: che-theia.eclipse.org
+    controller.devfile.io/imported-by: theia-ide-workspaced740715bb27b4967
+  container:
+    env:
+    - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+      value: /remote-endpoint/plugin-remote-endpoint
+    - name: REMOTE_ENDPOINT_VOLUME_NAME
+      value: remote-endpoint
+    - name: CHE_DASHBOARD_URL
+      value: https://192.168.49.2.nip.io
+    - name: CHE_PLUGIN_REGISTRY_URL
+      value: https://192.168.49.2.nip.io/plugin-registry/v3
+    - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
+      value: http://plugin-registry.eclipse-che.svc:8080/v3
+    image: quay.io/eclipse/che-theia-endpoint-runtime-binary@sha256:e72767d42e745132870ee9a5087774447ecfddcb5d279b877a4bfbf41892b5fd
+    sourceMapping: /projects
+    volumeMounts:
+    - name: plugins
+      path: /plugins
+    - name: remote-endpoint
+      path: /remote-endpoint
+  name: remote-runtime-injector
+- attributes:
+    controller.devfile.io/imported-by: theia-ide-workspaced740715bb27b4967
+  name: remote-endpoint
+  volume:
+    ephemeral: true
+- attributes:
+    app.kubernetes.io/name: tools
+    che-theia.eclipse.org/vscode-extensions:
+    - https://open-vsx.org/api/vscode/typescript-language-features/1.49.3/file/vscode.typescript-language-features-1.49.3.vsix
+    - https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/releases/download/7.44-che-assets/vscode-intelephense-client-1.5.4.vsix
+    - https://open-vsx.org/api/redhat/vscode-yaml/0.14.0/file/redhat.vscode-yaml-0.14.0.vsix
+  container:
+    args:
+    - sh
+    - -c
+    - ${PLUGIN_REMOTE_ENDPOINT_EXECUTABLE}
+    endpoints:
+    - attributes:
+        controller.devfile.io/endpoint-url: http://workspaced740715bb27b4967-1.192.168.49.2.nip.io/
+      exposure: public
+      name: nodejs
+      protocol: http
+      targetPort: 3000
+    env:
+    - name: PLUGIN_REMOTE_ENDPOINT_EXECUTABLE
+      value: /remote-endpoint/plugin-remote-endpoint
+    - name: THEIA_PLUGINS
+      value: local-dir:///plugins/sidecars/tools
+    - name: CHE_DASHBOARD_URL
+      value: https://192.168.49.2.nip.io
+    - name: CHE_PLUGIN_REGISTRY_URL
+      value: https://192.168.49.2.nip.io/plugin-registry/v3
+    - name: CHE_PLUGIN_REGISTRY_INTERNAL_URL
+      value: http://plugin-registry.eclipse-che.svc:8080/v3
+    image: quay.io/devspaces/udi-rhel8:3.1
+    memoryLimit: 1G
+    mountSources: true
+    sourceMapping: /projects
+    volumeMounts:
+    - name: npm
+      path: /home/user/.npm
+    - name: remote-endpoint
+      path: /remote-endpoint
+    - name: plugins
+      path: /plugins
+  name: tools
+- name: npm
+  volume:
+    size: 1G
+events:
+  preStart:
+  - init-container-command
+projects:
+- git:
+    checkoutFrom:
+      revision: che-qe-extensions-test
+    remotes:
+      origin: https://github.com/vitaliy-guliy/web-nodejs-sample.git
+  name: web-nodejs-sample


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- If `.che/che-theia-plugins.yaml` file is inlined in the devfile, all the plugins will be marked as installed. Does the same when the devfile contains `.vscode/extensions.json`.
- For devworkspaces, switches to using `che-theia-plugin.yaml` instead of `meta.yaml`.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Screenshot from 2022-07-19 17-54-48](https://user-images.githubusercontent.com/1655894/179785074-0c307e53-7cd2-45d2-8180-3f7e573885a1.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21423

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
To test the behavior with inlined `che-theia-plugins.yaml` create workspace with a factory
`che-url#https://github.com/vitaliy-guliy/web-nodejs-sample/tree/inlined-che-theia-plugins-yaml?che-editor=https://gist.githubusercontent.com/vitaliy-guliy/bc6ff64a716a30bfc7492cec9314f3cf/raw/abcfeff8ccc9a1992fa9a6d4fe7a7a558dc7b7df/editor.meta.yaml`
 
To test the behavior with inlined `extensions.json` use
`che-url#https://github.com/vitaliy-guliy/web-nodejs-sample/tree/che-qe-extensions-test?che-editor=https://gist.githubusercontent.com/vitaliy-guliy/bc6ff64a716a30bfc7492cec9314f3cf/raw/abcfeff8ccc9a1992fa9a6d4fe7a7a558dc7b7df/editor.meta.yaml`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
