### PR TITLE
Filter the containers list in the Workspace panel

### DIFF
--- a/plugins/containers-plugin/src/containers-service.ts
+++ b/plugins/containers-plugin/src/containers-service.ts
@@ -77,34 +77,6 @@ export class ContainersService {
     }
   }
 
-
-  // async updateContainers(): Promise<void> {
-  //   const componentStatuses = await che.devfile.getComponentStatuses();
-
-  //   const devfile = await che.devfile.get();
-
-  //   const devfileComponentsWithContainers = (devfile.components || []).filter(c => c.container);
-  //   const containers = [];
-  //   // eslint-disable-next-line guard-for-in
-  //   for (const component of devfileComponentsWithContainers) {
-  //     const componentStatus = componentStatuses.find(c => c.name === component.name);
-  //     if (!componentStatus) {
-  //       continue;
-  //     }
-  //     const container: IContainer = {
-  //       name: component.name!,
-  //       status: 'RUNNING',
-  //       endpoints: componentStatus.endpoints,
-  //       isDev: componentStatus.isUser,
-  //       env: component.container!.env,
-  //       volumeMounts: component.container!.volumeMounts,
-  //       commands: this.getContainerCommands(component.name!, devfile),
-  //     };
-  //     containers.push(container);
-  //   }
-  //   this._containers = containers;
-  // }
-
   get containers(): Array<IContainer> {
     return this._containers;
   }

--- a/plugins/containers-plugin/tests/containers-service.spec.ts
+++ b/plugins/containers-plugin/tests/containers-service.spec.ts
@@ -26,7 +26,7 @@ describe('Test containers service', () => {
     containersService = new ContainersService();
   });
 
-  test('Check get containers', async () => {
+  test.skip('Check get containers', async () => {
     const devfileGetRawJson = await fs.readFile(path.join(__dirname, '_data', 'devfile-get.json'), 'utf8');
     const devfileGetComponentStatusesRawJson = await fs.readFile(
       path.join(__dirname, '_data', 'devfile-component-statuses.json'),

--- a/plugins/containers-plugin/tests/containers-service.spec.ts
+++ b/plugins/containers-plugin/tests/containers-service.spec.ts
@@ -26,7 +26,7 @@ describe('Test containers service', () => {
     containersService = new ContainersService();
   });
 
-  test.skip('Check get containers', async () => {
+  test('Check get containers', async () => {
     const devfileGetRawJson = await fs.readFile(path.join(__dirname, '_data', 'devfile-get.json'), 'utf8');
     const devfileGetComponentStatusesRawJson = await fs.readFile(
       path.join(__dirname, '_data', 'devfile-component-statuses.json'),


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
In the Workspace panel, hides the containers that are internals of the Che-Theia editor (with the `app.kubernetes.io/part-of: che-theia.eclipse.org` attribute).

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
closes https://github.com/eclipse/che/issues/21324 (https://issues.redhat.com/browse/CRW-3169)

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Run
https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/#https://github.com/azatsarynnyy/java-spring-petclinic/tree/theia-test
Make sure that there're no containers with the `app.kubernetes.io/part-of: che-theia.eclipse.org` attribute. E.g.: `machine-exec`, `telemetry-plugin`, etc.

**Note,** the Che-Theia build is failing ATM due to the OpenVSX outage https://github.com/eclipse/openvsx/issues/497
I was able to prepare the test image by disabling the built-in extensions downloading from the OpenVSX registry.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
