### PR TITLE
Download VS Code built-ins in no-parallel mode

### DIFF
--- a/dockerfiles/theia/src/patches/master/no-parallel.patch
+++ b/dockerfiles/theia/src/patches/master/no-parallel.patch
@@ -1,0 +1,22 @@
+diff --git a/dev-packages/cli/src/download-plugins.ts b/dev-packages/cli/src/download-plugins.ts
+index 7bc24a07185..1e2ce335fb9 100644
+--- a/dev-packages/cli/src/download-plugins.ts
++++ b/dev-packages/cli/src/download-plugins.ts
+@@ -104,7 +104,7 @@ export default async function downloadPlugins(options: DownloadPluginsOptions =
+                 ? await fs.readdir(extensionPackCachePath)
+                 : []
+         );
+-        console.warn('--- downloading plugins ---');
++        console.warn('--- downloading plugins (no-parallel mode) ---');
+         // Download the raw plugins defined by the `theiaPlugins` property.
+         // This will include both "normal" plugins as well as "extension packs".
+         const downloads = [];
+@@ -113,7 +113,7 @@ export default async function downloadPlugins(options: DownloadPluginsOptions =
+             if (cachedExtensionPacks.has(plugin) || typeof pluginUrl !== 'string') {
+                 continue;
+             }
+-            downloads.push(downloadPluginAsync(failures, plugin, pluginUrl, pluginsDir, packed));
++            downloads.push(await downloadPluginAsync(failures, plugin, pluginUrl, pluginsDir, packed));
+         }
+         await Promise.all(downloads);
+         console.warn('--- collecting extension-packs ---');


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Makes downloading the VS Code built-ins in `no-parallel` mode to avoid issues with OpenVSX rate limit which is about 15 req/sec.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-3493

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Look at the build output. Before starting downloading the built-ins, it should output:
--- downloading plugins **(no-parallel mode)** ---
and the extensions should be downloaded with no messages like `failed to download with: 429 Too Many Requests`.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)
- [ ] Optional Companion PR for updating the HappyPath tests is approved and ready to be merged


### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Happy Path Channel
<!-- Select the Happy Path Channel used for tests.
  `stable` will use the latest che version to run Che-Theia editor.
  `next`   will use the current development che version. May be unstable.

  if omitted, it will use stable
-->
HAPPY_PATH_CHANNEL=stable
